### PR TITLE
ci: auto-bump givenergy-modbus on release

### DIFF
--- a/.github/workflows/bump-givenergy-modbus.yml
+++ b/.github/workflows/bump-givenergy-modbus.yml
@@ -1,0 +1,96 @@
+name: Bump givenergy-modbus
+
+# Triggered by a repository_dispatch event from dewet22/givenergy-modbus's
+# release workflow. Also exposed as workflow_dispatch for manual runs.
+on:
+  repository_dispatch:
+    types: [givenergy-modbus-release]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to bump givenergy-modbus to (e.g. 1.2.0)"
+        required: true
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Determine target version
+        id: ver
+        env:
+          DISPATCH_VERSION: ${{ github.event.client_payload.version }}
+          MANUAL_VERSION: ${{ inputs.version }}
+        run: |
+          NEW="${DISPATCH_VERSION:-$MANUAL_VERSION}"
+          if [ -z "$NEW" ]; then
+            echo "::error::no version supplied via client_payload.version or workflow inputs"
+            exit 1
+          fi
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+
+      - name: Bump pin in pyproject.toml and manifest.json
+        env:
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          python3 - <<'PY'
+          import os, re, pathlib, glob
+          new = os.environ["NEW"]
+          # Match "givenergy-modbus>=<version>" capturing the version as a
+          # separate group that stops at the next comma or closing quote;
+          # this handles pre-release suffixes (e.g. "1.2.0a1") in the
+          # existing pin without leaving the suffix glued to the new version.
+          pattern = re.compile(r'("givenergy-modbus>=)[^",]+(.*?")')
+
+          targets = ["pyproject.toml", *glob.glob("custom_components/*/manifest.json")]
+          for path in targets:
+              p = pathlib.Path(path)
+              if not p.exists():
+                  continue
+              text = p.read_text()
+              updated, n = pattern.subn(rf'\g<1>{new}\g<2>', text)
+              if n == 0:
+                  print(f"warning: no givenergy-modbus pin found in {path}")
+                  continue
+              p.write_text(updated)
+              print(f"bumped {n} pin(s) in {path}")
+          PY
+
+      - name: Refresh uv.lock
+        run: uv lock --upgrade-package givenergy-modbus
+
+      - name: Commit, push, open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          if git diff --quiet; then
+            echo "nothing to bump (pin already at ${NEW}?)"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          branch="bump/givenergy-modbus-${NEW}"
+          git checkout -B "$branch"
+          git add -A
+          git commit -m "fix(deps): bump givenergy-modbus to ${NEW}"
+          git push -f origin "$branch"
+
+          existing=$(gh pr list --head "$branch" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "PR #${existing} already open for ${branch}; updated branch in place"
+          else
+            gh pr create \
+              --title "fix(deps): bump givenergy-modbus to ${NEW}" \
+              --body "Automated bump triggered by [givenergy-modbus@${NEW}](https://github.com/dewet22/givenergy-modbus/releases/tag/v${NEW})." \
+              --base main \
+              --head "$branch"
+          fi


### PR DESCRIPTION
## Summary

Wires up automated bumping of `givenergy-modbus` on upstream releases. Adds one file:

**`.github/workflows/bump-givenergy-modbus.yml`** — listens for a `repository_dispatch` event of type `givenergy-modbus-release` fired by [`dewet22/givenergy-modbus`'s release workflow](https://github.com/dewet22/givenergy-modbus/blob/main/.github/workflows/release.yml). Bumps the `>=` pin in **both** `pyproject.toml` and `custom_components/*/manifest.json` (the HA requirements list, not covered by dependabot since it's a JSON manifest), refreshes `uv.lock`, opens a PR.

Also exposed as `workflow_dispatch` for manual runs.

## Why both files

Dependabot already handles `pyproject.toml` on a weekly cadence, but it doesn't touch `manifest.json` (JSON is not a pip-format manifest). This workflow makes the bump immediate and keeps both pin locations in sync.

## How the wiring lands

This PR is half the picture. The other half is a corresponding step in `givenergy-modbus`'s release workflow that fires the dispatch event. That requires a fine-grained PAT with `Contents: write` scope on this repo (and `givenergy-cli`) stored as `DOWNSTREAM_DISPATCH_TOKEN` in `givenergy-modbus`. Once both PRs merge and the secret is set, every `givenergy-modbus` release will produce an immediate bump PR here.

## Test plan

- [x] Workflow YAML lints cleanly
- [ ] After merge: trigger via `gh workflow run bump-givenergy-modbus.yml -f version=1.2.0` to verify it opens the expected bump PR with both `pyproject.toml` and `manifest.json` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)