### PR TITLE
build: bump requires-python floor to 3.14 to match givenergy-modbus v2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "givenergy-local"
 # duplicate the real version here and let it drift.
 version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 dependencies = [
     "givenergy-modbus>=2.0.0a6,<3.0.0",
 ]


### PR DESCRIPTION
## Summary

- Bumps `requires-python` on the v1.0 branch from `>=3.13` to `>=3.14` to match the floor adopted by [givenergy-modbus 2.0.0](https://github.com/dewet22/givenergy-modbus/issues/67)
- Unblocks the downstream `Bump givenergy-modbus` workflow, which currently fails resolving 2.0.0rc1 with a Python-version split

## Why

givenergy-modbus 2.0.0rc1 dropped Python 3.13 (matching where HA Core itself has moved). Without matching the floor here, `uv lock --upgrade-package givenergy-modbus` fails:

```
Because the requested Python version (>=3.13) does not satisfy Python>=3.14
and givenergy-modbus==2.0.0rc1 depends on Python>=3.14, we can conclude that
givenergy-modbus==2.0.0rc1 cannot be used.
```

Run that hit this: [dewet22/givenergy-hass/actions/runs/26130081146](https://github.com/dewet22/givenergy-hass/actions/runs/26130081146).

The `givenergy-modbus>=2.0.0a6,<3.0.0` dep pin on this branch already accepts prereleases — only the Python floor was missing.

## Test plan

- [ ] Re-run the bump workflow manually with `workflow_dispatch -f version=2.0.0rc1` once this PR is merged; expect a clean lockfile refresh and a follow-up bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)