### PR TITLE
fix(sensor): treat work_time_total as hours, not seconds

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -206,7 +206,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     raise HomeAssistantError("No connected GivEnergy inverter found")
 
             for coordinator in coordinators:
-                if coordinator.data is None:
+                if coordinator.data is None or coordinator._client is None:
                     continue
                 inv = coordinator.data.inverter.serial_number.lower()
                 frames: list[str] = []

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -597,12 +597,18 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
     ),
     # --- Diagnostic ---
     GivEnergyInverterSensorDescription(
+        # The raw register at IR(47):IR(48) is already in hours of operation,
+        # despite the field name suggesting otherwise. Earlier code divided by
+        # 3600 assuming seconds, which produced values ~3600× too small (e.g.
+        # ~10h after several years of operation). Tracked upstream at
+        # givenergy-modbus#84 — once the library annotates the unit explicitly
+        # this comment can come out.
         key="work_time_total",
         name="Work Time Total",
         native_unit_of_measurement=UnitOfTime.HOURS,
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda inv: round(inv.work_time_total / 3600, 1),
+        value_fn=lambda inv: inv.work_time_total,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     GivEnergyInverterSensorDescription(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def mock_inverter() -> MagicMock:
     inv.model = MagicMock()
     inv.model.name = "HYBRID"
     inv.firmware_version = "D0.19-A0.21"
-    inv.work_time_total = 36_000_000  # 10,000 hours in seconds
+    inv.work_time_total = 36055  # hours of operation (raw register unit)
     inv.p_pv.return_value = 2500
     inv.p_pv1 = 1500
     inv.p_pv2 = 1000

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -44,10 +44,11 @@ async def test_grid_power_sensor_negative_is_import(hass, setup_integration):
     assert float(state.state) == -800
 
 
-async def test_work_time_converted_to_hours(hass, setup_integration):
+async def test_work_time_total_reported_in_hours(hass, setup_integration):
     state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_work_time_total"))
-    # 36_000_000 seconds / 3600 = 10000.0 hours
-    assert float(state.state) == 10000.0
+    # Raw register is already in hours — no conversion applied (see sensor.py).
+    assert float(state.state) == 36055
+    assert state.attributes["unit_of_measurement"] == "h"
 
 
 async def test_inverter_device_info(hass, setup_integration):


### PR DESCRIPTION
## Summary

- Drop the `/3600` divisor on `Work Time Total` — the raw `IR(47):IR(48)` register is already in hours, not seconds. The previous code reported ~10h on a plant that's been running for several years.
- Update the test mock from `36_000_000` (a value only meaningful under the wrong seconds assumption) to `36055`, matching what the wire actually emits.
- Drive-by mypy fix in `__init__.py` to guard against `coordinator._client is None` in the `capture_frames` service handler — pre-existing on `main`, was blocking the pre-commit hook on this branch.

## Evidence

Wire data from a 67h TCP capture against the dongle showed the counter ticking once per ~3603 wall-clock seconds — i.e. one increment per hour, not per second. Read as hours, the current value (~36055) corresponds to ~4.1 years of operation, which matches the install lifetime on the test plant.

Tracked upstream at [givenergy-modbus#84](https://github.com/dewet22/givenergy-modbus/issues/84) — the library currently exposes `work_time_total` as a raw `uint32` with no unit annotation, which is what led to the wrong assumption here. Once the library annotates the unit explicitly the inline comment in `sensor.py` can come out.

## Test plan

- [x] `uv run pytest` — all 81 tests pass, including the updated `test_work_time_total_reported_in_hours`
- [x] `uv run ruff check` + `uv run ruff format` — clean
- [x] mypy via pre-commit — clean
- [ ] Manual sanity check against a real inverter after deploy — value should now read as multi-thousand hours rather than ~10h

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed work_time_total sensor to correctly report inverter operating hours
  * Improved error handling to prevent issues when client connection is unavailable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-hass/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->