### PR TITLE
build: bump version to 1.0.1

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "givenergy-modbus>=2.0.0,<3.0.0"
   ],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
Patch release shipping the `work_time_total` unit fix that landed in #51.

## Changes since v1.0.0

- **fix(sensor): treat work_time_total as hours, not seconds (#51)** — the raw IR(47):IR(48) register is already in hours, so the previous `/3600` divisor produced values ~3600× too small (e.g. ~10h on an inverter running continuously for years). Wire evidence from a 67h TCP capture confirmed the counter ticks once per hour, not once per second.
- **fix(capture_frames): guard against None _client in service handler (#51)** — drive-by mypy fix for the `capture_frames` service path that was blocking the pre-commit hook.

## Cross-references

- [givenergy-modbus#84](https://github.com/dewet22/givenergy-modbus/issues/84) — library-side documentation of `work_time_total` as hours-since-first-power-on, landing in 2.0.1.
- [givenergy-modbus#82](https://github.com/dewet22/givenergy-modbus/issues/82) — bounds enforcement on `Def` that will mask the IR(100)/IR(59) SOC corruption events on the next library bump. No integration changes needed for that one — it lands automatically when 2.0.1 ships.
- [givenergy-modbus#85](https://github.com/dewet22/givenergy-modbus/issues/85) — pending None-guards on `p_pv()` / `e_pv_day()`. Doesn't affect this release.

## Test plan

- [x] All 81 tests pass on the merged fix
- [x] CI green on #51
- [ ] After release: confirm the sensor on a real inverter reports multi-thousand-hour values (was ~10h pre-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.0.1 for the GivEnergy Local integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-hass/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->