### PR TITLE
feat(sensor): expose additional BMS diagnostics on battery devices

### DIFF
--- a/custom_components/givenergy_local/dashboard.py
+++ b/custom_components/givenergy_local/dashboard.py
@@ -238,6 +238,19 @@ def _battery_section(serial: str) -> str:
             ("cells_13_16_temperature", "Cells 13-16"),
         ],
     )
+    diagnostics = _bat_entity_rows(
+        serial,
+        [
+            ("bms_firmware_version", "BMS Firmware"),
+            ("usb_device", "USB Device"),
+            ("design_capacity_alt", "Design Capacity Alt"),
+            None,
+            *((f"bms_status_{i}", f"Status {i}") for i in range(1, 8)),
+            None,
+            ("bms_warning_1", "Warning 1"),
+            ("bms_warning_2", "Warning 2"),
+        ],
+    )
 
     return f"""\
       # ── {serial.upper()} ──
@@ -267,6 +280,11 @@ def _battery_section(serial: str) -> str:
             title: Cell Temperatures
             entities:
 {temps}
+
+          - type: entities
+            title: BMS Diagnostics
+            entities:
+{diagnostics}
 """
 
 

--- a/custom_components/givenergy_local/dashboard.py
+++ b/custom_components/givenergy_local/dashboard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 # Increment whenever the generated YAML layout changes in a meaningful way.
 # __init__.py compares this against the last-generated version stored in HA's
 # persistent Store and raises a Repairs issue when they diverge.
-DASHBOARD_VERSION = 1
+DASHBOARD_VERSION = 2
 
 
 def generate_dashboard(inv: str, bats: list[str], max_power_kw: int = 10) -> str:

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -61,6 +61,27 @@ def _battery_attr(name: str) -> Callable[[Battery], Any]:
     return lambda bat: getattr(bat, name)
 
 
+def _battery_hex(name: str, width: int) -> Callable[[Battery], Any]:
+    """Return a value_fn that renders the named attr as a fixed-width hex string.
+
+    The BMS status and warning registers carry bit-packed flags whose
+    individual bit meanings aren't documented upstream yet. Rendering as
+    `0xNN`/`0xNNNN` makes bit transitions visible at a glance in history
+    rather than forcing the user to mentally decode decimal integers.
+
+    Returns None for missing attributes so the sensor surfaces as
+    `unknown` instead of raising during model construction or formatting.
+    """
+
+    def fn(bat: Battery) -> Any:
+        val = getattr(bat, name, None)
+        if val is None:
+            return None
+        return f"0x{val:0{width}X}"
+
+    return fn
+
+
 @dataclass(frozen=True, kw_only=True)
 class GivEnergyCoordinatorSensorDescription(SensorEntityDescription):
     value_fn: Callable[[GivEnergyUpdateCoordinator], Any] = field(default=lambda _: None)
@@ -782,31 +803,63 @@ BATTERY_SENSORS: tuple[GivEnergyBatterySensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     # BMS status and warning flag bytes — no enum mapping exists upstream yet,
-    # but the raw values let users spot state changes in history and build
-    # template automations in the meantime.
+    # but rendering them as hex lets users spot bit transitions in history
+    # without having to mentally decode the decimal forms. Bitmap state
+    # values aren't valid `MEASUREMENT` data, so we deliberately omit the
+    # state_class to keep them out of long-term statistics.
     *(
         GivEnergyBatterySensorDescription(
             key=f"status_{i}",
             name=f"BMS Status {i}",
-            state_class=SensorStateClass.MEASUREMENT,
             entity_category=EntityCategory.DIAGNOSTIC,
-            value_fn=_battery_attr(f"status_{i}"),
+            value_fn=_battery_hex(f"status_{i}", width=2),
         )
         for i in range(1, 8)
     ),
     GivEnergyBatterySensorDescription(
         key="warning_1",
         name="BMS Warning 1",
-        state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda bat: bat.warning_1,
+        value_fn=_battery_hex("warning_1", width=2),
     ),
     GivEnergyBatterySensorDescription(
         key="warning_2",
         name="BMS Warning 2",
-        state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda bat: bat.warning_2,
+        value_fn=_battery_hex("warning_2", width=2),
+    ),
+    GivEnergyBatterySensorDescription(
+        key="bms_firmware_version",
+        name="BMS Firmware Version",
+        value_fn=lambda bat: bat.bms_firmware_version,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyBatterySensorDescription(
+        # Alternate copy of the design capacity, populated on some firmware
+        # variants. Exposed alongside `cap_design` so users can spot when
+        # the two diverge — that's the same alt-source phenomenon we saw
+        # on the inverter side (the battery_2_* fields). See modbus#76.
+        key="cap_design2",
+        # No parens in the display name — keeps the auto-generated entity_id
+        # predictable as `design_capacity_alt` (slugify drops parentheses but
+        # leaves stray underscores around them, which the dashboard template
+        # would then have to special-case).
+        name="Design Capacity Alt",
+        native_unit_of_measurement="Ah",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda bat: bat.cap_design2,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyBatterySensorDescription(
+        # Per-battery USB-device register. Semantics are partially unverified
+        # upstream — manufacturer docs only define 0 and 8 but values like 11
+        # have been observed on D0.449-A0.449. Rendered as hex so unrecognised
+        # values are still readable as bit patterns rather than mystery
+        # decimals.
+        key="usb_device_inserted",
+        name="USB Device",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_battery_hex("usb_device_inserted", width=4),
     ),
     # Per-cell voltages — 16 entities; unused cells in smaller packs read ~0.
     # `attr` default-arg captures the loop variable to avoid the closure trap.

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -77,7 +77,15 @@ def _battery_hex(name: str, width: int) -> Callable[[Battery], Any]:
         val = getattr(bat, name, None)
         if val is None:
             return None
-        return f"0x{val:0{width}X}"
+        # If upstream upgrades any of these fields to an Enum (the inverter's
+        # usb_device_inserted has already gone that way), pull the underlying
+        # numeric value before formatting.
+        if hasattr(val, "value"):
+            val = val.value
+        try:
+            return f"0x{int(val):0{width}X}"
+        except TypeError, ValueError:
+            return None
 
     return fn
 
@@ -847,7 +855,7 @@ BATTERY_SENSORS: tuple[GivEnergyBatterySensorDescription, ...] = (
         name="Design Capacity Alt",
         native_unit_of_measurement="Ah",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda bat: bat.cap_design2,
+        value_fn=lambda bat: getattr(bat, "cap_design2", None),
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     GivEnergyBatterySensorDescription(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,12 +122,21 @@ def mock_battery() -> MagicMock:
     bat.t_min = 21.3
     bat.cap_remaining = 8.5
     bat.cap_design = 9.5
+    bat.cap_calibrated = 9.4
+    bat.cap_design2 = 9.5
     bat.num_cycles = 42
     bat.bms_firmware_version = 3005
+    bat.usb_device_inserted = 8
     # BMS internals
     bat.num_cells = 16
     bat.v_cells_sum = 52.412
     bat.t_bms_mosfet = 28.4
+    # BMS status / warning bitmaps (rendered as hex by the sensor layer).
+    for i in range(1, 8):
+        setattr(bat, f"status_{i}", 0)
+    bat.status_3 = 0xA5  # one non-zero status to exercise the formatter
+    bat.warning_1 = 0
+    bat.warning_2 = 0
     for i in range(1, 17):
         setattr(bat, f"v_cell_{i:02d}", 3.275 + i * 0.001)  # ~3.276–3.291 V
     bat.t_cells_01_04 = 22.1

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -121,6 +121,34 @@ async def test_bms_internal_sensors_present(hass, setup_integration):
     assert hass.states.get(_entity_id(hass, "sensor", "BT1234A001_num_cells")).state == "16"
 
 
+async def test_bms_diagnostic_sensors_present(hass, setup_integration):
+    """The bms_firmware_version, cap_design2 and usb_device_inserted sensors are exposed."""
+    assert (
+        hass.states.get(_entity_id(hass, "sensor", "BT1234A001_bms_firmware_version")).state
+        == "3005"
+    )
+    cap_alt = hass.states.get(_entity_id(hass, "sensor", "BT1234A001_cap_design2"))
+    assert float(cap_alt.state) == 9.5
+    assert cap_alt.attributes["unit_of_measurement"] == "Ah"
+    # usb_device_inserted is rendered as 4-char hex (uint16 value).
+    assert (
+        hass.states.get(_entity_id(hass, "sensor", "BT1234A001_usb_device_inserted")).state
+        == "0x0008"
+    )
+
+
+async def test_bms_status_warning_rendered_as_hex(hass, setup_integration):
+    """BMS status / warning bytes surface as 2-char hex strings, not decimals."""
+    # status_3 is set to 0xA5 in the fixture; the rest are 0x00.
+    assert hass.states.get(_entity_id(hass, "sensor", "BT1234A001_status_3")).state == "0xA5"
+    assert hass.states.get(_entity_id(hass, "sensor", "BT1234A001_status_1")).state == "0x00"
+    assert hass.states.get(_entity_id(hass, "sensor", "BT1234A001_warning_1")).state == "0x00"
+    # Hex-formatted sensors deliberately omit state_class so HA doesn't
+    # try to roll them into long-term statistics.
+    state = hass.states.get(_entity_id(hass, "sensor", "BT1234A001_status_3"))
+    assert "state_class" not in state.attributes
+
+
 async def test_cell_voltages_attached_to_battery_device(hass, setup_integration):
     """Per-cell sensors live on the battery device, not the inverter device."""
     from homeassistant.helpers import device_registry as dr


### PR DESCRIPTION
## Summary

Closes the BMS-diagnostic gap on the battery device side:

- Three new sensors per battery: `bms_firmware_version`, `cap_design2` (alternate design capacity), `usb_device_inserted` (per-battery USB register).
- Existing `status_1`..`status_7` and `warning_1`/`warning_2` sensors switched from decimal integers to fixed-width hex strings (`0xNN`). They're bit-packed flags with no upstream enum mapping — hex makes individual bit transitions visible in history.
- Dashboard `_battery_section()` grows a new `BMS Diagnostics` entities card grouping all of these alongside the existing per-pack cards.

## Why hex on the status/warning bytes

The bit-level meanings of these bytes aren't decoded by the library yet (sensor.py has a comment to that effect). Rendering `165` vs `0xA5` makes the difference between visible "a bit flipped" and "some integer changed" when scrolling history. The state_class was also dropped on these since bitmap states aren't valid `MEASUREMENT` data and don't belong in long-term statistics — the previous `state_class=SensorStateClass.MEASUREMENT` was always misleading there.

## Test plan

- [x] `uv run pytest` — 83 tests pass (was 81; added 2 new ones covering the new sensors and the hex format)
- [x] `uv run ruff check` + `uv run ruff format` — clean
- [x] pre-commit hooks (mypy, bandit, etc.) — pass
- [x] Dashboard generator output spot-checked manually — new BMS Diagnostics card renders with correct entity_id references

## Notes for reviewers

- Three new sensors → three new HA entities per battery device. Net entity-count delta: `3 × num_batteries`.
- The hex-format change is a state-representation change. Users with automations watching the decimal form of `status_*` or `warning_*` will see breakage; given these were always documented as raw-byte diagnostics with no enum mapping, the migration cost is small. Worth flagging in the release notes when bumping.
- Dashboard card uses `None`-as-divider, matching the existing pattern in `pack_details`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a BMS Diagnostics card to battery sections showing firmware version, USB device, alternate design capacity, and status/warning indicators.

* **Improvements**
  * BMS status/warning and USB diagnostic values now render as fixed-width hexadecimal strings and are more robust when data is missing.

* **Bug Fixes**
  * Prevented sensor creation errors when certain BMS fields are absent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-hass/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->