### PR TITLE
build: bump version to 1.0.2

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.0.0,<3.0.0"
+    "givenergy-modbus>=2.0.3,<3.0.0"
   ],
   "version": "1.0.2"
 }

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "givenergy-modbus>=2.0.0,<3.0.0"
   ],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -626,12 +626,6 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
     ),
     # --- Diagnostic ---
     GivEnergyInverterSensorDescription(
-        # The raw register at IR(47):IR(48) is already in hours of operation,
-        # despite the field name suggesting otherwise. Earlier code divided by
-        # 3600 assuming seconds, which produced values ~3600× too small (e.g.
-        # ~10h after several years of operation). Tracked upstream at
-        # givenergy-modbus#84 — once the library annotates the unit explicitly
-        # this comment can come out.
         key="work_time_total",
         name="Work Time Total",
         native_unit_of_measurement=UnitOfTime.HOURS,

--- a/uv.lock
+++ b/uv.lock
@@ -1276,16 +1276,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.0.0"
+version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic", version = "2.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14.2'" },
     { name = "pydantic", version = "2.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14.2'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/1a/06822214b3aca4254be029b4dfd0b794ada4f163b98e873132a6afd53958/givenergy_modbus-2.0.0.tar.gz", hash = "sha256:f6a40ec533b2eef42ef59c041e7c3f142d051957dba1be24ba180ccf7beddd73", size = 115580, upload-time = "2026-05-22T18:04:17.786Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/72/5449d00b42d4cbc32ebb7572e49a0cdce262187677485595db3bbf2a81cb/givenergy_modbus-2.0.3.tar.gz", hash = "sha256:2f979f8b8f947548b6be759ccb80951b40c3699f184edfec10e3fdfedfbe730d", size = 127654, upload-time = "2026-05-27T00:43:25.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/bc/719481664f77ca6b27bc8c0905313115d45a24344d011c8c9253aa4bb444/givenergy_modbus-2.0.0-py3-none-any.whl", hash = "sha256:6988e3cc896e5b886378a2b3c26c141588b0d8a8f83952d094c2e19b0f2f12bb", size = 72236, upload-time = "2026-05-22T18:04:16.36Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/78/ce5af6fc7efc19bec64fa8787e64178f5b52ccdbc1bfcfc0b4420137dc1e/givenergy_modbus-2.0.3-py3-none-any.whl", hash = "sha256:d953a163601a1528fae3978e80178c7ef8a33e064167172b9c3dcf3991267505", size = 75490, upload-time = "2026-05-27T00:43:24.226Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Patch release shipping the BMS diagnostics work from #56 and a sync to `givenergy-modbus` v2.0.3.

## Changes since v1.0.1

### Features

- **feat(sensor): expose additional BMS diagnostics on battery devices (#56)** — per-index BMS status (`status_1` … `status_7`) and warning (`warning_1`, `warning_2`) sensors rendered as fixed-width hex strings, exposes the alt-source `cap_design2` field as "Design Capacity Alt", adds a "BMS Diagnostics" card to the auto-generated dashboard. Dashboard schema bumped to v2 so existing installs are prompted via Repairs to regenerate.

### Library sync (`givenergy-modbus` 2.0.0 → 2.0.3)

- **Bounds enforcement (modbus#82, in 2.0.1)** — out-of-bounds register values now suppress to `None` instead of passing through. The IR(100)/IR(59) SOC corruption events that previously surfaced as raw out-of-range values (~5710, ~44820, etc.) will now show as `unknown` for one tick before recovering on the next poll. Cleaner UX, no more spurious "SOC > 100" automation triggers from this class of corruption.
- **Pattern A frame-level discard (modbus#78, in 2.0.1)** — corrupted IR(0,60) frames are now discarded at the framer level, before they reach the cache.
- **work_time_total documented and bounded upstream (modbus#84, in 2.0.1)** — confirms our existing hass-side `value_fn` passthrough is right. Drops the inline tracking comment in `sensor.py`.
- **PlantCapabilities.from_dict() compat (in 2.0.2)** — backward-compat fixes for serialised v2.0.0 payloads.
- **Framer DoS hardening (modbus#88, in 2.0.3)** — defence-in-depth against malformed-frame inputs.

No code changes needed for the library sync beyond the comment cleanup — the API surface is unchanged across 2.0.0 → 2.0.3.

## Test plan

- [x] All 83 tests pass on the BMS diagnostics work (#56)
- [x] All 83 tests pass against `givenergy-modbus` 2.0.3 after the bump
- [x] CI green on #56
- [ ] After release: confirm BMS sensors populate, dashboard Repairs prompt fires, and SOC sensors briefly show `unknown` instead of out-of-range values during the next corruption event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped integration version to 1.0.2 and raised the minimum required underlying library version.

* **Documentation**
  * Removed an outdated inline comment about a sensor register’s units to keep internal notes accurate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-hass/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->