### PR TITLE
chore: retire v1.0, bump givenergy-modbus to 2.0.4

### DIFF
--- a/.github/workflows/bump-givenergy-modbus.yml
+++ b/.github/workflows/bump-givenergy-modbus.yml
@@ -34,8 +34,7 @@ jobs:
           # branch (and/or new modbus major) is introduced.
           major="${NEW%%.*}"
           case "$major" in
-            1) base=main ;;
-            2) base=v1.0 ;;
+            2) base=main ;;
             *)
               echo "::error::no target branch configured for givenergy-modbus major $major (version $NEW)"
               exit 1

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.0.3,<3.0.0"
+    "givenergy-modbus>=2.0.4,<3.0.0"
   ],
   "version": "1.0.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14"
 dependencies = [
-    "givenergy-modbus>=2.0.0,<3.0.0",
+    "givenergy-modbus>=2.0.4,<3.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1263,7 +1263,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.0.0,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.0.4,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1276,16 +1276,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.0.3"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic", version = "2.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14.2'" },
     { name = "pydantic", version = "2.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14.2'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/72/5449d00b42d4cbc32ebb7572e49a0cdce262187677485595db3bbf2a81cb/givenergy_modbus-2.0.3.tar.gz", hash = "sha256:2f979f8b8f947548b6be759ccb80951b40c3699f184edfec10e3fdfedfbe730d", size = 127654, upload-time = "2026-05-27T00:43:25.654Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/d9/983b871110ca37825e3ac6c739f0b27f0d75826a9b910cc2ac8705720896/givenergy_modbus-2.0.4.tar.gz", hash = "sha256:1cf16b4cbe3d64c688177369c6d9b04efae3d3fc25a8254c23fdd8994f1f5f1e", size = 129116, upload-time = "2026-05-27T19:56:33.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/78/ce5af6fc7efc19bec64fa8787e64178f5b52ccdbc1bfcfc0b4420137dc1e/givenergy_modbus-2.0.3-py3-none-any.whl", hash = "sha256:d953a163601a1528fae3978e80178c7ef8a33e064167172b9c3dcf3991267505", size = 75490, upload-time = "2026-05-27T00:43:24.226Z" },
+    { url = "https://files.pythonhosted.org/packages/12/89/6b9d5a78ea92a0c1b9c55a00059f950d0727328a3fe3038928f75e0f3693/givenergy_modbus-2.0.4-py3-none-any.whl", hash = "sha256:1946fc236f02d4545c44695a4e66789f273965707769d3119d71cb06a982d427", size = 76616, upload-time = "2026-05-27T19:56:32.62Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Tidy-up after the v1.0 staging branch fell out of sync with main:

- Bumps `givenergy-modbus` floor to **2.0.4** across `pyproject.toml`, `manifest.json`, and `uv.lock`. Also closes the existing drift where `pyproject.toml` was still at `>=2.0.0` while `manifest.json` had moved to `>=2.0.3`.
- Updates the auto-bumper workflow (`.github/workflows/bump-givenergy-modbus.yml`) to route modbus major-2 releases to `main`. The previous case statement sent them to `v1.0`, which has been falling behind feature work on `main` — that's why PRs #54/#55/#58 all landed on a stale tree.

Once this lands I'll delete `origin/v1.0` and the three stale `bump/givenergy-modbus-*` remote branches.

No code changes, no behavioural changes — just metadata + workflow routing. All 83 existing tests still pass locally; ruff check is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated givenergy-modbus dependency requirement to minimum version 2.0.4 across the application.
  * Adjusted automated dependency management workflow configuration for version 2 releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-hass/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->