### PR TITLE
Release 1.1.0

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.0.4,<3.0.0"
+    "givenergy-modbus>=2.0.4,<2.1"
   ],
-  "version": "1.0.2"
+  "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.0.4,<3.0.0",
+    "givenergy-modbus>=2.0.4,<2.1",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.0.4,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.0.4,<2.1" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Version bump to 1.1.0 collecting the following changes since v1.0.2:

- **feat** (#62): Persist `PlantCapabilities` across restarts — warm-start detection, advisory Repairs issue + reload on topology change, `redetect_plant` service (#48)
- **feat** (#66): `expose_recommended_entities` service — one-shot voice/LLM assistant exposure for 17 headline entities; voice assistant docs (#65)
- **docs** (#67): GivTCP → givenergy_local migration guide and helper script
- **docs**: Passive mode reframing; parallel-running and GivTCP coexistence notes
- **build** (#61): Bump `requires-python` floor to `>=3.14.2`
- **chore** (#59): Retire v1.0 branch; bump givenergy-modbus floor to 2.0.4
- **chore** (#60): Version-format validation in auto-bumper workflow
- **chore**: Cap `givenergy-modbus` at `<2.1` — 2.1 is expected to include breaking API changes (command dispatch refactor); compatibility will be a separate minor release

## Test plan

- [ ] CI passes on this branch
- [ ] HACS validation passes
- [ ] Merge → tag `v1.1.0` → release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Integration version updated to 1.1.0
  * Dependency constraints refined for improved stability and compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-hass/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->