### PR TITLE
feat: adopt RefreshPartiallySucceeded/RefreshFailed from givenergy-modbus #125

### DIFF
--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import voluptuous as vol
 from givenergy_modbus.client.client import Client
+from givenergy_modbus.exceptions import RefreshPartiallySucceeded
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
 
@@ -94,10 +95,18 @@ class GivEnergyLocalConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-
         try:
             await client.connect()
             # detect() resolves the device model and topology before any reads
-            # so refresh_plant() picks the right register layout (single vs.
+            # so refresh() picks the right register layout (single vs.
             # three-phase) from the first request.
             await client.detect()
-            plant = await client.refresh_plant(full_refresh=False)
+            try:
+                plant = await client.refresh()
+            except RefreshPartiallySucceeded as exc:
+                # A connectivity probe only needs to identify the inverter
+                # (device 0x32), which is virtually always among the successful
+                # reads — a partial usually means a peripheral battery/meter
+                # dropped. A usable snapshot is enough here; RefreshFailed (no
+                # data at all) falls through to "cannot_connect" below.
+                plant = exc.plant
             return plant.inverter_serial_number, None
         except Exception:
             _LOGGER.exception("Connection test failed for %s:%s", host, port)

--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -107,7 +107,13 @@ class GivEnergyLocalConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-
                 # dropped. A usable snapshot is enough here; RefreshFailed (no
                 # data at all) falls through to "cannot_connect" below.
                 plant = exc.plant
-            return plant.inverter_serial_number, None
+            serial = plant.inverter_serial_number
+            if not serial:
+                # The partial dropped the inverter read itself — no usable
+                # unique ID, so treat it as a failed connection rather than
+                # creating an entry with an empty serial.
+                return "", "cannot_connect"
+            return serial, None
         except Exception:
             _LOGGER.exception("Connection test failed for %s:%s", host, port)
             return "", "cannot_connect"

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -114,6 +114,10 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                 else await self._active_update()
             )
 
+            # A fully clean poll — clear any stale partial-failure detail so the
+            # diagnostic sensor stops naming devices that have since recovered.
+            # (The cumulative partial_failures counter is left untouched.)
+            self.last_partial_failures = []
             self._mark_success(plant)
             return plant
         except RefreshPartiallySucceeded as exc:

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -5,7 +5,12 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 
 from givenergy_modbus.client.client import Client
-from givenergy_modbus.exceptions import PlantTopologyMismatch
+from givenergy_modbus.exceptions import (
+    PlantTopologyMismatch,
+    ReadFailure,
+    RefreshFailed,
+    RefreshPartiallySucceeded,
+)
 from givenergy_modbus.model.inverter import SinglePhaseInverter
 from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
 from givenergy_modbus.model.plant import Plant, PlantCapabilities
@@ -79,6 +84,15 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         self.last_successful_refresh: datetime | None = None
         self.consecutive_failures: int = 0
         self.total_failures: int = 0
+        # Cumulative count of polls that returned *some* data but had one or
+        # more register reads fail (RefreshPartiallySucceeded). Distinct from
+        # total_failures (which counts polls that yielded no usable data) so a
+        # flaky single device — e.g. dodgy RS485 wiring to one battery — shows
+        # up here without eroding the hard-failure metrics.
+        self.partial_failures: int = 0
+        # The ReadFailure records from the most recent partial poll, surfaced as
+        # a diagnostic sensor attribute so users can see *which* device dropped.
+        self.last_partial_failures: list[ReadFailure] = []
         self._last_inverter_time: datetime | None = None
         self._unchanged_ticks: int = 0
         self._active_tick: int = 0
@@ -100,38 +114,112 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                 else await self._active_update()
             )
 
-            self._last_inverter_time = plant.inverter.system_time
-            self.last_successful_refresh = dt_util.utcnow()
-            self.consecutive_failures = 0
+            self._mark_success(plant)
             return plant
+        except RefreshPartiallySucceeded as exc:
+            if reconnecting:
+                # No reliable per-device fallback on a (re)connect seed: a
+                # half-populated initial plant (the dropped device reads
+                # "unknown") is worse than a clean full retry. detect() already
+                # gated device presence, so a partial seed is most likely a
+                # transient hiccup on a present device. Route through the same
+                # tolerance gate as a timeout — serves last-known data on an
+                # in-process reconnect, or raises UpdateFailed (→
+                # ConfigEntryNotReady) on a cold start so HA retries setup.
+                self._record_failure()
+                return await self._serve_last_known_or_fail("Partial data on (re)connect seed", exc)
+            # Steady state: serve the partial. The dropped device's last-known
+            # register values ride along (frozen) while the rest stay fresh —
+            # this is the behaviour change #125 buys us (one offline battery no
+            # longer discards every other reading for the tick).
+            self._record_partial(exc)
+            self._mark_success(exc.plant)
+            return exc.plant
         except UpdateFailed:
-            self.consecutive_failures += 1
-            self.total_failures += 1
+            self._record_failure()
             raise
-        except TimeoutError:
-            # Keep the client alive — timeouts are transient and the TCP
-            # connection is likely still valid.
-            self.consecutive_failures += 1
-            self.total_failures += 1
-            if self.data is None or self.consecutive_failures >= self.timeout_tolerance:
-                await self._reset_client()
-                raise UpdateFailed(
-                    f"Timed out communicating with inverter "
-                    f"({self.consecutive_failures} consecutive failures)"
+        except RefreshFailed as err:
+            self._record_failure()
+            if self._is_timeout_failure(err):
+                # Every read timed out — treat like the bare-TimeoutError path
+                # below: transient, keep the client and serve last-known data
+                # until the tolerance window is exhausted.
+                return await self._serve_last_known_or_fail(
+                    "Timed out communicating with inverter", err
                 )
-            _LOGGER.warning(
-                "Timed out communicating with inverter (failure %d/%d); serving last known data",
-                self.consecutive_failures,
-                self.timeout_tolerance,
+            await self._reset_client()
+            raise UpdateFailed(f"Error communicating with inverter: {err}") from err
+        except TimeoutError as err:
+            # Defensive: a timeout not wrapped in RefreshFailed. Keep the client
+            # alive — timeouts are transient and the TCP connection is likely
+            # still valid.
+            self._record_failure()
+            return await self._serve_last_known_or_fail(
+                "Timed out communicating with inverter", err
             )
-            return self.data
         except Exception as err:
-            self.consecutive_failures += 1
-            self.total_failures += 1
+            self._record_failure()
             await self._reset_client()
             raise UpdateFailed(
                 f"Error communicating with inverter: {str(err) or type(err).__name__}"
             ) from err
+
+    # ------------------------------------------------------------------
+    # Failure / success bookkeeping
+    # ------------------------------------------------------------------
+
+    def _mark_success(self, plant: Plant) -> None:
+        """Record a tick that yielded usable data (full or partial success)."""
+        self._last_inverter_time = plant.inverter.system_time
+        self.last_successful_refresh = dt_util.utcnow()
+        self.consecutive_failures = 0
+
+    def _record_failure(self) -> None:
+        """Count a poll that yielded no usable data."""
+        self.consecutive_failures += 1
+        self.total_failures += 1
+
+    def _record_partial(self, exc: RefreshPartiallySucceeded) -> None:
+        """Count a degraded-but-usable poll and surface which reads dropped."""
+        self.partial_failures += 1
+        self.last_partial_failures = exc.failures
+        _LOGGER.warning(
+            "Partial refresh: %d register read(s) failed; serving last-known "
+            "values for those banks. Failures: %s",
+            len(exc.failures),
+            exc.failures,
+        )
+
+    def _is_timeout_failure(self, err: RefreshFailed) -> bool:
+        """True if every underlying cause of a RefreshFailed is a timeout.
+
+        Timeout-only failures are treated as transient (tolerance window);
+        anything else resets the client and fails immediately.
+        """
+        cause = err.cause
+        if isinstance(cause, BaseExceptionGroup):
+            _, rest = cause.split(TimeoutError)
+            return rest is None
+        return isinstance(cause, TimeoutError)
+
+    async def _serve_last_known_or_fail(self, message: str, err: BaseException) -> Plant:
+        """Serve last-known data within the tolerance window, else reset and fail.
+
+        Mirrors the long-standing timeout-tolerance behaviour: a transient blip
+        keeps the client and replays `self.data` up to `timeout_tolerance`
+        consecutive failures; past that (or with no data yet) the client is
+        reset and UpdateFailed raised.
+        """
+        if self.data is not None and self.consecutive_failures < self.timeout_tolerance:
+            _LOGGER.warning(
+                "%s (failure %d/%d); serving last known data",
+                message,
+                self.consecutive_failures,
+                self.timeout_tolerance,
+            )
+            return self.data
+        await self._reset_client()
+        raise UpdateFailed(f"{message} ({self.consecutive_failures} consecutive failures)") from err
 
     # ------------------------------------------------------------------
     # Update strategies
@@ -143,12 +231,17 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         Holding registers (config, charge slots, …) are re-read only every
         _full_refresh_every ticks; input registers (real-time data) are read
         every tick.
+
+        Raises RefreshPartiallySucceeded / RefreshFailed straight up to
+        _async_update_data, which owns the seed-vs-steady-state policy (it's the
+        only caller that knows whether this tick is a reconnect seed).
         """
         assert self._client is not None  # _async_update_data ensures this
         full_refresh = self._active_tick % self._full_refresh_every == 0
         self._active_tick += 1
-        await self._client.refresh_plant(full_refresh=full_refresh, retries=self.retries)
-        return self._client.plant
+        if full_refresh:
+            await self._client.load_config(retries=self.retries)
+        return await self._client.refresh(retries=self.retries)
 
     async def _passive_update(self, reconnecting: bool) -> Plant:
         """Seed the cache on (re)connect; on subsequent ticks read the cached plant.
@@ -158,8 +251,8 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         """
         assert self._client is not None  # _async_update_data ensures this
         if reconnecting:
-            await self._client.refresh_plant(full_refresh=True, retries=self.retries)
-            return self._client.plant
+            await self._client.load_config(retries=self.retries)
+            return await self._client.refresh(retries=self.retries)
 
         plant = self._client.plant
         self._check_cache_freshness(plant)

--- a/custom_components/givenergy_local/dashboard.py
+++ b/custom_components/givenergy_local/dashboard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 # Increment whenever the generated YAML layout changes in a meaningful way.
 # __init__.py compares this against the last-generated version stored in HA's
 # persistent Store and raises a Repairs issue when they diverge.
-DASHBOARD_VERSION = 2
+DASHBOARD_VERSION = 3
 
 
 def generate_dashboard(inv: str, bats: list[str], max_power_kw: int = 10) -> str:
@@ -363,6 +363,8 @@ def _diagnostics_view(inv: str, max_power_kw: int) -> str:
             name: Last Successful Refresh
           - entity: {_i(inv, "consecutive_refresh_failures")}
             name: Consecutive Failures
+          - entity: {_i(inv, "partial_refresh_failures")}
+            name: Partial Failures
           - entity: {_i(inv, "total_refresh_failures")}
             name: Total Failures
 

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.0a4,<3.0.0"
+    "givenergy-modbus>=2.1.0a5,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -93,9 +93,8 @@ def _battery_hex(name: str, width: int) -> Callable[[Battery], Any]:
 @dataclass(frozen=True, kw_only=True)
 class GivEnergyCoordinatorSensorDescription(SensorEntityDescription):
     value_fn: Callable[[GivEnergyUpdateCoordinator], Any] = field(default=lambda _: None)
-    attributes_fn: Callable[[GivEnergyUpdateCoordinator], dict[str, Any] | None] = field(
-        default=lambda _: None
-    )
+    # None (not a dummy lambda) so sensors without attributes skip the call entirely.
+    attributes_fn: Callable[[GivEnergyUpdateCoordinator], dict[str, Any] | None] | None = None
 
 
 INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
@@ -914,7 +913,9 @@ def _partial_failure_attributes(
         "last_failed_devices": sorted({f"0x{f.device_address:02x}" for f in failures}),
         "last_failure_count": len(failures),
         "last_failures": [
-            f"0x{f.device_address:02x} {f.request_type} @ {f.base_register}+{f.register_count}"
+            f"0x{f.device_address:02x} "
+            f"{getattr(f.request_type, 'value', f.request_type)} "
+            f"@ {f.base_register}+{f.register_count}"
             for f in failures
         ],
     }
@@ -1092,4 +1093,6 @@ class GivEnergyCoordinatorSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], 
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
+        if self.entity_description.attributes_fn is None:
+            return None
         return self.entity_description.attributes_fn(self.coordinator)

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -93,6 +93,9 @@ def _battery_hex(name: str, width: int) -> Callable[[Battery], Any]:
 @dataclass(frozen=True, kw_only=True)
 class GivEnergyCoordinatorSensorDescription(SensorEntityDescription):
     value_fn: Callable[[GivEnergyUpdateCoordinator], Any] = field(default=lambda _: None)
+    attributes_fn: Callable[[GivEnergyUpdateCoordinator], dict[str, Any] | None] = field(
+        default=lambda _: None
+    )
 
 
 INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
@@ -895,6 +898,28 @@ BATTERY_SENSORS: tuple[GivEnergyBatterySensorDescription, ...] = (
 )
 
 
+def _partial_failure_attributes(
+    coordinator: GivEnergyUpdateCoordinator,
+) -> dict[str, Any] | None:
+    """Summarise the most recent partial poll's failed reads for the UI.
+
+    Names the device(s) that dropped (e.g. "0x34" for a battery) plus the
+    per-bank detail, so a flaky device can be identified even though its
+    entities stay available with stale data.
+    """
+    failures = coordinator.last_partial_failures
+    if not failures:
+        return None
+    return {
+        "last_failed_devices": sorted({f"0x{f.device_address:02x}" for f in failures}),
+        "last_failure_count": len(failures),
+        "last_failures": [
+            f"0x{f.device_address:02x} {f.request_type} @ {f.base_register}+{f.register_count}"
+            for f in failures
+        ],
+    }
+
+
 COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
     GivEnergyCoordinatorSensorDescription(
         key="last_successful_refresh",
@@ -918,6 +943,17 @@ COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
         # long-term statistics still show correct cumulative deltas over time.
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda coord: coord.total_failures,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyCoordinatorSensorDescription(
+        key="partial_failures",
+        name="Partial Refresh Failures",
+        # Polls that returned data but had some register reads fail. The
+        # attributes name the device(s) that dropped — the only UI signal of a
+        # flaky device, since its entities stay available with frozen values.
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda coord: coord.partial_failures,
+        attributes_fn=_partial_failure_attributes,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
@@ -1053,3 +1089,7 @@ class GivEnergyCoordinatorSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], 
     @property
     def native_value(self) -> Any:
         return self.entity_description.value_fn(self.coordinator)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        return self.entity_description.attributes_fn(self.coordinator)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.0a4,<3.0.0",
+    "givenergy-modbus>=2.1.0a5,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,7 +173,8 @@ def mock_client(mock_plant) -> AsyncMock:
     client = AsyncMock()
     client.connected = True
     client.plant = mock_plant
-    client.refresh_plant = AsyncMock(return_value=mock_plant)
+    client.refresh = AsyncMock(return_value=mock_plant)
+    client.load_config = AsyncMock(return_value=mock_plant)
     client.connect = AsyncMock()
     client.detect = AsyncMock()
     client.close = AsyncMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,7 +170,21 @@ def mock_plant(mock_inverter, mock_battery) -> MagicMock:
 
 @pytest.fixture
 def mock_client(mock_plant) -> AsyncMock:
-    client = AsyncMock()
+    # spec_set deliberately omits the deprecated refresh_plant() so any lingering
+    # call to it fails fast (AttributeError) rather than silently auto-mocking —
+    # guards the #125 migration against regressions.
+    client = AsyncMock(
+        spec_set=[
+            "connected",
+            "plant",
+            "refresh",
+            "load_config",
+            "connect",
+            "detect",
+            "close",
+            "one_shot_command",
+        ]
+    )
     client.connected = True
     client.plant = mock_plant
     client.refresh = AsyncMock(return_value=mock_plant)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -71,6 +71,28 @@ async def test_partial_success_during_setup_returns_serial(hass, mock_client, mo
     assert result["title"] == "GivEnergy SA1234G123"
 
 
+async def test_partial_without_serial_during_setup_shows_cannot_connect(
+    hass, mock_client, mock_plant
+):
+    """If the partial dropped the inverter read itself (no serial), there's no
+    usable unique ID — treat it as cannot_connect rather than a blank entry."""
+    mock_plant.inverter_serial_number = ""
+    mock_client.refresh.side_effect = RefreshPartiallySucceeded(
+        "partial",
+        plant=mock_plant,
+        failures=[],
+        cause=ExceptionGroup("reads", [TimeoutError()]),
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], VALID_USER_INPUT)
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
 async def test_refresh_failed_during_setup_shows_cannot_connect(hass, mock_client):
     """A total failure (no data at all) during the connection test → cannot_connect."""
     mock_client.refresh.side_effect = RefreshFailed(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for the GivEnergy Local config flow."""
 
+from givenergy_modbus.exceptions import RefreshFailed, RefreshPartiallySucceeded
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 
@@ -50,6 +51,43 @@ async def test_cannot_connect_shows_error(hass, mock_client):
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+async def test_partial_success_during_setup_returns_serial(hass, mock_client, mock_plant):
+    """A partial poll during the connection test still identifies the inverter:
+    the serial (device 0x32) is virtually always among the reads that succeeded."""
+    mock_client.refresh.side_effect = RefreshPartiallySucceeded(
+        "partial",
+        plant=mock_plant,
+        failures=[],
+        cause=ExceptionGroup("reads", [TimeoutError()]),
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], VALID_USER_INPUT)
+    await hass.async_block_till_done()
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "GivEnergy SA1234G123"
+
+
+async def test_refresh_failed_during_setup_shows_cannot_connect(hass, mock_client):
+    """A total failure (no data at all) during the connection test → cannot_connect."""
+    mock_client.refresh.side_effect = RefreshFailed(
+        "link dead",
+        failures=[],
+        cause=ExceptionGroup("reads", [TimeoutError()]),
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], VALID_USER_INPUT)
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
 async def test_duplicate_entry_aborted(hass, mock_client, mock_config_entry):
     mock_config_entry.add_to_hass(hass)
 
@@ -82,7 +120,8 @@ async def test_reconfigure_updates_settings_without_retesting_connection(
     hass, mock_client, setup_integration
 ):
     """Changing only scan_interval/passive should skip the explicit connection test."""
-    mock_client.refresh_plant.reset_mock()  # ignore the initial setup refresh
+    mock_client.refresh.reset_mock()  # ignore the initial setup refresh
+    mock_client.load_config.reset_mock()
 
     result = await setup_integration.start_reconfigure_flow(hass)
     new_input = {**VALID_USER_INPUT, CONF_SCAN_INTERVAL: 60, CONF_PASSIVE: True}
@@ -94,14 +133,10 @@ async def test_reconfigure_updates_settings_without_retesting_connection(
     assert setup_integration.data[CONF_SCAN_INTERVAL] == 60
     assert setup_integration.data[CONF_PASSIVE] is True
 
-    # The post-reload coordinator calls refresh_plant(full_refresh=True).
-    # _test_connection (used only when host/port changes) calls
-    # refresh_plant(full_refresh=False) — the latter should not appear if
-    # the host didn't change.
-    test_connection_calls = [
-        c for c in mock_client.refresh_plant.call_args_list if c.kwargs.get("full_refresh") is False
-    ]
-    assert test_connection_calls == []
+    # _test_connection (host/port change only) issues a bare refresh() with no
+    # preceding load_config(); the post-reload coordinator always pairs the two
+    # on its first (full) tick. Equal counts ⇒ _test_connection did not run.
+    assert mock_client.refresh.call_count == mock_client.load_config.call_count
 
 
 async def test_reconfigure_with_host_change_succeeds_for_same_inverter(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -339,6 +339,27 @@ async def test_partial_success_increments_partial_failures_cumulatively(hass, mo
     assert coordinator.total_failures == 0
 
 
+async def test_clean_poll_clears_stale_partial_detail(hass, mock_plant):
+    """After a partial, a later clean poll clears last_partial_failures so the
+    diagnostic stops naming a recovered device — but the cumulative counter stays."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.refresh = AsyncMock(side_effect=[_partial(mock_plant), mock_plant])
+        mock_cls.return_value = client
+        coordinator._client = client
+
+        await coordinator._async_update_data()  # partial — detail populated
+        assert coordinator.last_partial_failures
+        await coordinator._async_update_data()  # clean — detail cleared
+
+    assert coordinator.last_partial_failures == []
+    assert coordinator.partial_failures == 1  # counter is cumulative, retained
+
+
 async def test_partial_on_cold_seed_raises_update_failed(hass, mock_plant):
     """A partial on a cold (re)connect seed (no prior data) must NOT be served —
     it fails so HA retries setup (→ ConfigEntryNotReady) rather than locking in a
@@ -653,7 +674,7 @@ async def test_active_mode_nth_tick_is_full_refresh(hass, mock_plant):
         mock_cls.return_value = client
         coordinator._client = client
 
-        for _ in range(11):  # ticks 0–10
+        for _ in range(11):  # ticks 0-10
             await coordinator._async_update_data()
 
     # load_config on ticks 0 and 10; refresh on all 11.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5,7 +5,12 @@ from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from givenergy_modbus.exceptions import PlantTopologyMismatch
+from givenergy_modbus.exceptions import (
+    PlantTopologyMismatch,
+    ReadFailure,
+    RefreshFailed,
+    RefreshPartiallySucceeded,
+)
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -25,10 +30,42 @@ def _caps(**overrides) -> PlantCapabilities:
     return PlantCapabilities(**{**defaults, **overrides})
 
 
+def _read_failure(addr: int = 0x34) -> ReadFailure:
+    """A single failed register read, e.g. one offline battery's input bank."""
+    return ReadFailure(
+        device_address=addr,
+        request_type="ReadInputRegisters",
+        base_register=60,
+        register_count=60,
+    )
+
+
+def _partial(plant, failures=None) -> RefreshPartiallySucceeded:
+    """A partial-poll exception carrying `plant` and the failed reads."""
+    failures = failures if failures is not None else [_read_failure()]
+    return RefreshPartiallySucceeded(
+        "partial poll",
+        plant=plant,
+        failures=failures,
+        cause=ExceptionGroup("reads", [TimeoutError()]),
+    )
+
+
+def _refresh_failed(*causes: BaseException) -> RefreshFailed:
+    """A total-poll failure whose ExceptionGroup carries the given causes."""
+    return RefreshFailed(
+        "link effectively dead",
+        failures=[_read_failure()],
+        cause=ExceptionGroup("reads", list(causes)),
+    )
+
+
 async def test_first_refresh_connects_and_fetches(hass, mock_client, setup_integration):
     mock_client.connect.assert_called_once()
     mock_client.detect.assert_called_once()
-    mock_client.refresh_plant.assert_called_once_with(full_refresh=True, retries=1)
+    # Tick 0 is a full refresh → load_config() then refresh(), both threading retries.
+    mock_client.load_config.assert_called_once_with(retries=1)
+    mock_client.refresh.assert_called_once_with(retries=1)
 
 
 async def test_reconnects_when_disconnected(hass, mock_client, mock_config_entry):
@@ -73,7 +110,7 @@ async def test_timeout_raises_update_failed(hass):
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
         client.connected = True
-        client.refresh_plant.side_effect = TimeoutError()
+        client.refresh.side_effect = TimeoutError()
         mock_cls.return_value = client
         coordinator._client = client
 
@@ -89,7 +126,7 @@ async def test_timeout_within_tolerance_preserves_client(hass, mock_plant):
         client = AsyncMock()
         client.connected = True
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(side_effect=TimeoutError())
+        client.refresh = AsyncMock(side_effect=TimeoutError())
         mock_cls.return_value = client
         coordinator._client = client
         coordinator.data = mock_plant  # seed stale data so tolerance path is reached
@@ -109,7 +146,7 @@ async def test_timeout_reaching_tolerance_resets_client(hass, mock_plant):
         client = AsyncMock()
         client.connected = True
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(side_effect=TimeoutError())
+        client.refresh = AsyncMock(side_effect=TimeoutError())
         mock_cls.return_value = client
         coordinator._client = client
         coordinator.data = mock_plant  # seed stale data
@@ -133,7 +170,7 @@ async def test_timeout_increments_consecutive_failures(hass):
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
         client.connected = True
-        client.refresh_plant.side_effect = TimeoutError()
+        client.refresh.side_effect = TimeoutError()
         mock_cls.return_value = client
         coordinator._client = client
 
@@ -149,7 +186,7 @@ async def test_successful_refresh_resets_failure_count(hass, mock_plant):
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
         client.connected = True
-        client.refresh_plant.side_effect = [
+        client.refresh.side_effect = [
             TimeoutError(),
             TimeoutError(),
             mock_plant,
@@ -180,7 +217,7 @@ async def test_total_failures_increments_on_every_failure_type(hass, mock_plant)
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
         client.connected = True
-        client.refresh_plant.side_effect = [
+        client.refresh.side_effect = [
             TimeoutError(),  # → counted (TimeoutError path)
             ConnectionResetError("peer reset"),  # → counted (generic Exception path)
             mock_plant,  # → success, no count
@@ -213,7 +250,7 @@ async def test_reset_and_reconnect_emit_integration_level_logs(hass, mock_plant,
         client = AsyncMock()
         client.connected = True
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(side_effect=TimeoutError())
+        client.refresh = AsyncMock(side_effect=TimeoutError())
         mock_cls.return_value = client
         coordinator._client = client
         coordinator.data = mock_plant
@@ -225,7 +262,7 @@ async def test_reset_and_reconnect_emit_integration_level_logs(hass, mock_plant,
 
             # Next tick: client is None → _connect() runs and succeeds
             client.connected = True
-            client.refresh_plant = AsyncMock(return_value=mock_plant)
+            client.refresh = AsyncMock(return_value=mock_plant)
             await coordinator._async_update_data()
 
     messages = [r.getMessage() for r in caplog.records]
@@ -240,7 +277,7 @@ async def test_non_timeout_error_closes_client(hass):
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
         client.connected = True
-        client.refresh_plant.side_effect = ConnectionResetError("peer reset")
+        client.refresh.side_effect = ConnectionResetError("peer reset")
         mock_cls.return_value = client
         coordinator._client = client
 
@@ -251,6 +288,197 @@ async def test_non_timeout_error_closes_client(hass):
         assert coordinator._client is None
 
 
+# ---------------------------------------------------------------------------
+# Partial / total refresh outcomes (#125)
+# ---------------------------------------------------------------------------
+
+
+async def test_partial_in_steady_state_serves_partial_and_counts(hass, mock_plant):
+    """A steady-state partial poll serves exc.plant, counts as a success, and bumps
+    only the partial_failures counter — keeping the good entities live."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+    failures = [_read_failure(0x34)]
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.refresh = AsyncMock(side_effect=_partial(mock_plant, failures))
+        mock_cls.return_value = client
+        coordinator._client = client  # already connected → not a seed
+
+        result = await coordinator._async_update_data()
+
+        assert result is mock_plant
+        assert coordinator.partial_failures == 1
+        assert coordinator.consecutive_failures == 0
+        assert coordinator.total_failures == 0
+        assert coordinator.last_successful_refresh is not None
+        assert coordinator.last_partial_failures == failures
+        client.close.assert_not_called()
+        assert coordinator._client is client
+
+
+async def test_partial_success_increments_partial_failures_cumulatively(hass, mock_plant):
+    """Repeated steady-state partials accumulate on partial_failures."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.refresh = AsyncMock(side_effect=_partial(mock_plant))
+        mock_cls.return_value = client
+        coordinator._client = client
+
+        for _ in range(3):
+            await coordinator._async_update_data()
+
+    assert coordinator.partial_failures == 3
+    assert coordinator.consecutive_failures == 0
+    assert coordinator.total_failures == 0
+
+
+async def test_partial_on_cold_seed_raises_update_failed(hass, mock_plant):
+    """A partial on a cold (re)connect seed (no prior data) must NOT be served —
+    it fails so HA retries setup (→ ConfigEntryNotReady) rather than locking in a
+    half-populated initial plant."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.refresh = AsyncMock(side_effect=_partial(mock_plant))
+        mock_cls.return_value = client
+        # _client is None → reconnecting=True, and coordinator.data is None (cold).
+
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    # Counted as a hard failure, not a partial; client reset for a clean retry.
+    assert coordinator.partial_failures == 0
+    assert coordinator.total_failures == 1
+    assert coordinator.consecutive_failures == 1
+    assert coordinator._client is None
+
+
+async def test_partial_on_inprocess_reconnect_seed_serves_last_known(hass, mock_plant):
+    """A partial on an in-process reconnect seed serves the pre-disconnect data
+    (within the tolerance window) rather than the partial plant."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, timeout_tolerance=3)
+    prior_data = mock_plant
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = False  # forces a reconnect (seed)
+        client.plant = mock_plant
+        client.refresh = AsyncMock(side_effect=_partial(mock_plant))
+        mock_cls.return_value = client
+        coordinator.data = prior_data  # pre-disconnect snapshot available
+
+        result = await coordinator._async_update_data()
+
+    assert result is prior_data  # served last-known, not exc.plant
+    assert coordinator.partial_failures == 0
+    assert coordinator.total_failures == 1
+    assert coordinator._client is client  # kept — transient
+
+
+async def test_refresh_failed_timeout_cause_within_tolerance_serves_stale(hass, mock_plant):
+    """A total RefreshFailed whose causes are all timeouts is treated as transient:
+    serve last-known data within the tolerance window."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, timeout_tolerance=3)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.refresh = AsyncMock(side_effect=_refresh_failed(TimeoutError(), TimeoutError()))
+        mock_cls.return_value = client
+        coordinator._client = client
+        coordinator.data = mock_plant
+
+        result = await coordinator._async_update_data()
+
+    assert result is mock_plant
+    assert coordinator._client is client
+    client.close.assert_not_called()
+    assert coordinator.total_failures == 1
+
+
+async def test_refresh_failed_timeout_cause_reaching_tolerance_resets(hass, mock_plant):
+    """Timeout-driven RefreshFailed escalates to UpdateFailed + reset at the threshold."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, timeout_tolerance=2)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.refresh = AsyncMock(side_effect=_refresh_failed(TimeoutError()))
+        mock_cls.return_value = client
+        coordinator._client = client
+        coordinator.data = mock_plant
+
+        result = await coordinator._async_update_data()  # 1/2 — serves stale
+        assert result is mock_plant
+        client.close.assert_not_called()
+
+        with pytest.raises(UpdateFailed, match="Timed out"):
+            await coordinator._async_update_data()  # 2/2 — resets
+
+        client.close.assert_called_once()
+        assert coordinator._client is None
+
+
+async def test_refresh_failed_bare_timeout_cause_serves_stale(hass, mock_plant):
+    """Defensive: a RefreshFailed whose cause is a bare TimeoutError (not wrapped in
+    an ExceptionGroup) is still recognised as a timeout and served within tolerance."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, timeout_tolerance=3)
+    bare = RefreshFailed("link dead", failures=[_read_failure()], cause=TimeoutError())
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.refresh = AsyncMock(side_effect=bare)
+        mock_cls.return_value = client
+        coordinator._client = client
+        coordinator.data = mock_plant
+
+        result = await coordinator._async_update_data()
+
+    assert result is mock_plant
+    assert coordinator._client is client
+
+
+async def test_refresh_failed_nontimeout_cause_resets_immediately(hass, mock_plant):
+    """A RefreshFailed with any non-timeout cause resets the client and fails at once,
+    even when last-known data is available."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, timeout_tolerance=3)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.refresh = AsyncMock(side_effect=_refresh_failed(ConnectionResetError("peer reset")))
+        mock_cls.return_value = client
+        coordinator._client = client
+        coordinator.data = mock_plant  # present, but must not be served
+
+        with pytest.raises(UpdateFailed, match="Error communicating"):
+            await coordinator._async_update_data()
+
+        client.close.assert_called_once()
+        assert coordinator._client is None
+        assert coordinator.total_failures == 1
+
+
+# ---------------------------------------------------------------------------
+# Active / passive refresh cadence
+# ---------------------------------------------------------------------------
+
+
 async def test_passive_mode_initial_connect_does_full_refresh(hass, mock_plant):
     """Even in passive mode the first connect must seed the cache with a full refresh."""
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True)
@@ -259,12 +487,14 @@ async def test_passive_mode_initial_connect_does_full_refresh(hass, mock_plant):
         client = AsyncMock()
         client.connected = True
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        client.load_config = AsyncMock(return_value=mock_plant)
         mock_cls.return_value = client
 
         await coordinator._async_update_data()
 
-    client.refresh_plant.assert_called_once_with(full_refresh=True, retries=1)
+    client.load_config.assert_called_once_with(retries=1)
+    client.refresh.assert_called_once_with(retries=1)
 
 
 async def test_passive_mode_skips_refresh_on_subsequent_ticks(hass, mock_plant):
@@ -275,7 +505,8 @@ async def test_passive_mode_skips_refresh_on_subsequent_ticks(hass, mock_plant):
         client = AsyncMock()
         client.connected = True
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        client.load_config = AsyncMock(return_value=mock_plant)
         mock_cls.return_value = client
         coordinator._client = client  # already connected
 
@@ -286,8 +517,9 @@ async def test_passive_mode_skips_refresh_on_subsequent_ticks(hass, mock_plant):
             mock_plant.inverter.system_time = base + timedelta(seconds=tick * 30)
             await coordinator._async_update_data()
 
-    # refresh_plant must never be called — client was already connected
-    client.refresh_plant.assert_not_called()
+    # No wire traffic — the client was already connected.
+    client.refresh.assert_not_called()
+    client.load_config.assert_not_called()
 
 
 async def test_passive_mode_reconnect_does_full_refresh(hass, mock_plant):
@@ -298,16 +530,18 @@ async def test_passive_mode_reconnect_does_full_refresh(hass, mock_plant):
         client = AsyncMock()
         client.connected = False  # simulate a dropped connection
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        client.load_config = AsyncMock(return_value=mock_plant)
         mock_cls.return_value = client
 
         await coordinator._async_update_data()
 
-    client.refresh_plant.assert_called_once_with(full_refresh=True, retries=1)
+    client.load_config.assert_called_once_with(retries=1)
+    client.refresh.assert_called_once_with(retries=1)
 
 
-async def test_retries_forwarded_to_refresh_plant_active(hass, mock_plant):
-    """Active-mode ticks must thread the configured retries count to refresh_plant()."""
+async def test_retries_forwarded_to_refresh_active(hass, mock_plant):
+    """Active-mode ticks must thread the configured retries count to the primitives."""
     coordinator = GivEnergyUpdateCoordinator(
         hass, "192.168.1.1", 8899, 30, passive=False, retries=2
     )
@@ -316,16 +550,18 @@ async def test_retries_forwarded_to_refresh_plant_active(hass, mock_plant):
         client = AsyncMock()
         client.connected = True
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        client.load_config = AsyncMock(return_value=mock_plant)
         mock_cls.return_value = client
         coordinator._client = client
 
         await coordinator._async_update_data()
 
-    client.refresh_plant.assert_called_once_with(full_refresh=True, retries=2)
+    client.load_config.assert_called_once_with(retries=2)
+    client.refresh.assert_called_once_with(retries=2)
 
 
-async def test_retries_forwarded_to_refresh_plant_passive_reconnect(hass, mock_plant):
+async def test_retries_forwarded_to_refresh_passive_reconnect(hass, mock_plant):
     """Passive-mode reconnect (the only path that hits the wire) must also forward retries."""
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True, retries=3)
 
@@ -333,51 +569,56 @@ async def test_retries_forwarded_to_refresh_plant_passive_reconnect(hass, mock_p
         client = AsyncMock()
         client.connected = False  # forces reconnect
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        client.load_config = AsyncMock(return_value=mock_plant)
         mock_cls.return_value = client
 
         await coordinator._async_update_data()
 
-    client.refresh_plant.assert_called_once_with(full_refresh=True, retries=3)
+    client.load_config.assert_called_once_with(retries=3)
+    client.refresh.assert_called_once_with(retries=3)
 
 
 async def test_active_mode_always_refreshes(hass, mock_plant):
-    """In active (default) mode every tick issues a refresh_plant request."""
+    """In active (default) mode every tick issues a refresh() request."""
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=False)
 
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
         client.connected = True
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        client.load_config = AsyncMock(return_value=mock_plant)
         mock_cls.return_value = client
         coordinator._client = client
 
         for _ in range(3):
             await coordinator._async_update_data()
 
-    assert client.refresh_plant.call_count == 3
+    assert client.refresh.call_count == 3
 
 
 async def test_active_mode_first_tick_is_full_refresh(hass, mock_plant):
-    """Tick 0 must always be a full refresh regardless of interval."""
+    """Tick 0 must always be a full refresh (load_config + refresh) regardless of interval."""
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=False)
 
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
         client.connected = True
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        client.load_config = AsyncMock(return_value=mock_plant)
         mock_cls.return_value = client
         coordinator._client = client
 
         await coordinator._async_update_data()
 
-    client.refresh_plant.assert_called_once_with(full_refresh=True, retries=1)
+    client.load_config.assert_called_once_with(retries=1)
+    client.refresh.assert_called_once_with(retries=1)
 
 
 async def test_active_mode_intermediate_ticks_are_partial(hass, mock_plant):
-    """Ticks 1 … (n-1) must use full_refresh=False."""
+    """Ticks 1 … (n-1) must skip load_config (input registers only)."""
     # scan_interval=30 → _full_refresh_every = round(300/30) = 10
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=False)
 
@@ -385,21 +626,21 @@ async def test_active_mode_intermediate_ticks_are_partial(hass, mock_plant):
         client = AsyncMock()
         client.connected = True
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        client.load_config = AsyncMock(return_value=mock_plant)
         mock_cls.return_value = client
         coordinator._client = client
 
         for _ in range(3):  # ticks 0, 1, 2
             await coordinator._async_update_data()
 
-    calls = client.refresh_plant.call_args_list
-    assert calls[0].kwargs["full_refresh"] is True  # tick 0 — full
-    assert calls[1].kwargs["full_refresh"] is False  # tick 1 — partial
-    assert calls[2].kwargs["full_refresh"] is False  # tick 2 — partial
+    # load_config only on tick 0; refresh on every tick.
+    assert client.load_config.call_count == 1
+    assert client.refresh.call_count == 3
 
 
 async def test_active_mode_nth_tick_is_full_refresh(hass, mock_plant):
-    """Every _full_refresh_every ticks a full refresh must be issued again."""
+    """Every _full_refresh_every ticks a full refresh (load_config) must be issued again."""
     # scan_interval=30 → _full_refresh_every = 10; tick 10 is the next full refresh
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=False)
 
@@ -407,18 +648,17 @@ async def test_active_mode_nth_tick_is_full_refresh(hass, mock_plant):
         client = AsyncMock()
         client.connected = True
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        client.load_config = AsyncMock(return_value=mock_plant)
         mock_cls.return_value = client
         coordinator._client = client
 
         for _ in range(11):  # ticks 0–10
             await coordinator._async_update_data()
 
-    calls = client.refresh_plant.call_args_list
-    assert calls[0].kwargs["full_refresh"] is True  # tick 0
-    assert calls[10].kwargs["full_refresh"] is True  # tick 10
-    for i in range(1, 10):
-        assert calls[i].kwargs["full_refresh"] is False
+    # load_config on ticks 0 and 10; refresh on all 11.
+    assert client.load_config.call_count == 2
+    assert client.refresh.call_count == 11
 
 
 async def test_active_mode_reconnect_resets_refresh_cycle(hass, mock_plant):
@@ -429,22 +669,23 @@ async def test_active_mode_reconnect_resets_refresh_cycle(hass, mock_plant):
         client = AsyncMock()
         client.connected = True
         client.plant = mock_plant
-        client.refresh_plant = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        client.load_config = AsyncMock(return_value=mock_plant)
         mock_cls.return_value = client
         coordinator._client = client
 
-        # Advance a few ticks so _active_tick > 0
+        # Advance a few ticks so _active_tick > 0 (load_config fired once, on tick 0)
         for _ in range(3):
             await coordinator._async_update_data()
+        assert client.load_config.call_count == 1
 
         # Simulate a reconnect by resetting the client
         coordinator._client = None
 
         await coordinator._async_update_data()
 
-    # The post-reconnect call should be a full refresh (tick 0 of new cycle)
-    last_call = client.refresh_plant.call_args_list[-1]
-    assert last_call.kwargs["full_refresh"] is True
+    # The post-reconnect call is tick 0 of a new cycle → load_config fires again.
+    assert client.load_config.call_count == 2
 
 
 async def test_passive_stale_cache_raises_after_two_unchanged_ticks(hass, mock_plant):
@@ -518,6 +759,8 @@ async def test_passive_reconnect_resets_stale_detection(hass, mock_plant):
         client = AsyncMock()
         client.connected = True
         client.plant = mock_plant
+        client.refresh = AsyncMock(return_value=mock_plant)
+        client.load_config = AsyncMock(return_value=mock_plant)
         mock_cls.return_value = client
         # _client is None → reconnecting=True → _last_inverter_time is reset before the check
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -217,7 +217,7 @@ async def test_diagnostic_sensors_available_during_coordinator_failure(
     await hass.async_block_till_done()
 
     # Make subsequent refreshes time out
-    mock_client.refresh_plant.side_effect = TimeoutError()
+    mock_client.refresh.side_effect = TimeoutError()
     from custom_components.givenergy_local.const import DOMAIN as _DOMAIN
 
     coordinator = hass.data[_DOMAIN][mock_config_entry.entry_id]
@@ -232,3 +232,45 @@ async def test_diagnostic_sensors_available_during_coordinator_failure(
 
     assert hass.states.get(failures_id).state == "1"
     assert hass.states.get(refresh_id).state != "unavailable"
+
+
+async def test_partial_failures_starts_at_zero(hass, setup_integration):
+    state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_partial_failures"))
+    assert state.state == "0"
+
+
+async def test_partial_failures_increments_and_attributes_name_device(
+    hass, mock_client, mock_plant, mock_config_entry
+):
+    """After a partial poll, the sensor increments and its attributes name the
+    device(s) that dropped — the only UI signal of a flaky device, since its
+    entities stay available with stale data."""
+    from givenergy_modbus.exceptions import ReadFailure, RefreshPartiallySucceeded
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # A steady-state partial: battery 0x34's input bank dropped.
+    mock_client.refresh.side_effect = RefreshPartiallySucceeded(
+        "partial",
+        plant=mock_plant,
+        failures=[
+            ReadFailure(
+                device_address=0x34,
+                request_type="ReadInputRegisters",
+                base_register=60,
+                register_count=60,
+            )
+        ],
+        cause=ExceptionGroup("reads", [TimeoutError()]),
+    )
+
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_partial_failures"))
+    assert state.state == "1"
+    assert "0x34" in state.attributes["last_failed_devices"]
+    assert state.attributes["last_failure_count"] == 1

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0a4,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0a5,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.0a4"
+version = "2.1.0a5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/95/d3b8a7f89f1870f1ff643256184ff3999ccc4dc49901d57113f5c4046cf3/givenergy_modbus-2.1.0a4.tar.gz", hash = "sha256:80dfcaea0339342576e5f6513a02949b6f875eae7f18d528e51b67ba460d2d16", size = 189632, upload-time = "2026-05-28T23:28:33.897Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d3/8477f0527a5ac1eb71435722d12b78653920425e3a77a165bbc369022971/givenergy_modbus-2.1.0a5.tar.gz", hash = "sha256:eda6fe9375dd052501f159dce9e9e314c3f874e80c65156f00ed957891d9b34f", size = 255616, upload-time = "2026-05-29T20:31:39.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/07/8f8e5bb5de820553024acb3fc0fc18aaf6cb3d224db9b401b5931475ca13/givenergy_modbus-2.1.0a4-py3-none-any.whl", hash = "sha256:6cf2264c70b8a0de8e664c100443a595534a308bc47272aedb04501f9253a3ba", size = 85034, upload-time = "2026-05-28T23:28:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b9/bfdc4799f16c5b5c13a8b4d2545c9b345bf538a7e514e44470c1f5ed265f/givenergy_modbus-2.1.0a5-py3-none-any.whl", hash = "sha256:1d3a745c7ecba053a196786c9e99406bc55c04e7877c31afee71bb61718f17f1", size = 90666, upload-time = "2026-05-29T20:31:38.457Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does

Adopts the new poll contract from [givenergy-modbus#125](https://github.com/dewet22/givenergy-modbus/pull/125). Previously the first register read to time out aborted the whole poll, so one offline battery discarded every reading that *did* come back. Now `refresh()`/`load_config()` raise `RefreshPartiallySucceeded` (carrying the data that arrived) or `RefreshFailed` (nothing came back), and this integration handles them so a single flaky device no longer takes the rest of the plant down with it.

This also retires the last consumer of the deprecated `refresh_plant()` (removed in modbus 3.0).

## Behaviour

**Coordinator**
- **Steady-state partial** → serve `exc.plant`. The dropped device's entities freeze at their last-known register values (the library's cache retains them) and stay *available*, rather than the whole device going unavailable for the tick. A new cumulative `partial_failures` counter records it.
- **(Re)connect-seed partial** → treated as a failure, not served. There's no per-device fallback on a seed, so I'd rather fail and retry cleanly than lock in a half-populated initial plant. Cold start → `ConfigEntryNotReady` (HA retries setup); in-process reconnect → the existing tolerance window serves the pre-disconnect snapshot. `detect()` having already gated device presence is what makes a seed partial most likely transient.
- **`RefreshFailed`** → I kept the existing timeout-tolerance window when every underlying cause is a timeout (transient blip, serve last-known up to the threshold); any non-timeout cause resets the client and fails immediately. This deliberately diverges from the simpler `RefreshFailed → UpdateFailed` in the modbus PR's migration note, to preserve resilience this integration already had.

**Diagnostics** — a new *Partial Refresh Failures* sensor (always-available, like the other coordinator diagnostics). Because a flaky device stays *available* with stale values, the entity-availability channel stays silent — so the sensor's attributes name the dropping device(s) (`0x34`, bank, request type) from the structured `ReadFailure` records. Added to the auto-generated Integration Health card; dashboard schema bumped to v3 (existing installs get the usual Repairs prompt to regenerate).

**config_flow** — `_test_connection` accepts a partial, since it only needs to identify the inverter (device `0x32`), which virtually always survives a peripheral drop. `RefreshFailed` still maps to `cannot_connect`.

## Testing

- Full suite green (108 tests); coordinator and config_flow at 100% line coverage, including the partial/total/seed paths and the timeout-vs-non-timeout `RefreshFailed` split.
- The partial behaviour is exercised with mocked exceptions rather than a real flaky bus — I haven't yet run the hardware sanity-check (pull one battery's RS485 and watch the entities stay live while the counter ticks). Something I'll do when I next have the kit in front of me.

## Follow-up

The interim tradeoff is that a long partial shows a frozen value with no intrinsic "stale" marker — the counter and logs are the only signal. Decisively offlining a single silent device needs per-bank freshness timestamps, tracked in [givenergy-modbus#65](https://github.com/dewet22/givenergy-modbus/issues/65); the `ReadFailure.device_address` surfaced here maps straight onto that once it lands.

## Dependency

Requires `givenergy-modbus>=2.1.0a5` (the release that ships #125); pin bumped in `pyproject.toml` and `manifest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic sensor for tracking partial device polling failures, with detailed failure summaries displayed as sensor attributes.

* **Bug Fixes**
  * Improved resilience during device polling by distinguishing between complete failures and partial successes, allowing the integration to continue operating with partially-read device data when appropriate.
  * Enhanced reconnection behavior to properly recover partial snapshots instead of discarding incomplete readings.

* **Chores**
  * Updated dependency to latest compatible version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-hass/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->