### PR TITLE
feat: render sensors at native register precision

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.0a5,<3.0.0"
+    "givenergy-modbus>=2.1.0a6,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -194,6 +194,8 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        # Computed (p_pv1 + p_pv2) so not register-backed; watts -> 0 decimals.
+        suggested_display_precision=0,
         value_fn=lambda inv: inv.p_pv(),
     ),
     GivEnergyInverterSensorDescription(
@@ -254,6 +256,8 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        # Computed (e_pv1_day + e_pv2_day, each deci-scaled kWh) -> 1 decimal.
+        suggested_display_precision=1,
         value_fn=lambda inv: inv.e_pv_day(),
     ),
     GivEnergyInverterSensorDescription(
@@ -633,6 +637,9 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         native_unit_of_measurement=UnitOfTime.HOURS,
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        # Library key is work_time_total_hours (uint32, whole hours); this sensor
+        # reads the alias, so set 0 explicitly rather than deriving.
+        suggested_display_precision=0,
         value_fn=lambda inv: inv.work_time_total,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
@@ -998,6 +1005,25 @@ _MODEL_NAMES: dict[Model, str] = {
 }
 
 
+def _derive_display_precision(description: SensorEntityDescription, model: Any) -> int | None:
+    """Native display precision for a sensor, from the library's register scaling.
+
+    Returns None (leave HA's default) when:
+    - the description already pins a precision — an explicit value always wins;
+    - the sensor has no ``state_class`` — display precision only applies to
+      numeric measurement/total sensors, never to the enum / hex-string /
+      version diagnostics, several of which are register-backed integers that
+      hass deliberately renders as non-numeric strings;
+    - the library has no precision for the attribute (non-numeric register, or a
+      computed value not backed by a single register).
+    """
+    if description.suggested_display_precision is not None:
+        return None
+    if description.state_class is None:
+        return None
+    return model.precision_of(description.key)
+
+
 class GivEnergyInverterSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity):
     _attr_has_entity_name = True
     entity_description: GivEnergyInverterSensorDescription
@@ -1009,6 +1035,9 @@ class GivEnergyInverterSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], Sen
     ) -> None:
         super().__init__(coordinator)
         self.entity_description = description
+        precision = _derive_display_precision(description, coordinator.data.inverter)
+        if precision is not None:
+            self._attr_suggested_display_precision = precision
         serial = coordinator.data.inverter_serial_number
         self._attr_unique_id = f"{serial}_{description.key}"
         self._attr_device_info = DeviceInfo(
@@ -1041,6 +1070,9 @@ class GivEnergyBatterySensor(CoordinatorEntity[GivEnergyUpdateCoordinator], Sens
         self.entity_description = description
         self._battery_index = battery_index
         battery = coordinator.data.batteries[battery_index]
+        precision = _derive_display_precision(description, battery)
+        if precision is not None:
+            self._attr_suggested_display_precision = precision
         serial = battery.serial_number
         self._attr_unique_id = f"{serial}_{description.key}"
         self._attr_device_info = DeviceInfo(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.0a5,<3.0.0",
+    "givenergy-modbus>=2.1.0a6,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from givenergy_modbus.model import TimeSlot
+from givenergy_modbus.model.battery import Battery
 from givenergy_modbus.model.inverter import (
     SINGLE_PHASE_SLOTS,
     BatteryPowerMode,
     BatteryType,
     MeterType,
     Model,
+    SinglePhaseInverter,
 )
 from givenergy_modbus.model.plant import PlantCapabilities
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -26,6 +28,9 @@ def auto_enable_custom_integrations(enable_custom_integrations):
 @pytest.fixture
 def mock_inverter() -> MagicMock:
     inv = MagicMock()
+    # Delegate precision_of to the real model classmethod so the display-precision
+    # derivation is exercised against the library's actual register scaling.
+    inv.precision_of = SinglePhaseInverter.precision_of
     inv.status = MagicMock()
     inv.status.name = "NORMAL"
     inv.fault_code = "00000000"
@@ -117,6 +122,7 @@ def mock_inverter() -> MagicMock:
 @pytest.fixture
 def mock_battery() -> MagicMock:
     bat = MagicMock()
+    bat.precision_of = Battery.precision_of
     bat.serial_number = "BT1234A001"
     bat.soc = 85
     bat.v_out = 52.4

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -17,6 +17,13 @@ def _entity_id(hass, platform: str, unique_id: str) -> str:
     return entity_id
 
 
+def _suggested_precision(hass, unique_id: str) -> int | None:
+    """The sensor's suggested display precision, as stored in the entity registry."""
+    registry = er.async_get(hass)
+    entry = registry.async_get(_entity_id(hass, "sensor", unique_id))
+    return entry.options.get("sensor", {}).get("suggested_display_precision")
+
+
 async def test_expected_sensor_count(hass, setup_integration):
     registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(registry, setup_integration.entry_id)
@@ -274,3 +281,29 @@ async def test_partial_failures_increments_and_attributes_name_device(
     assert state.state == "1"
     assert "0x34" in state.attributes["last_failed_devices"]
     assert state.attributes["last_failure_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Native display precision (derived from the library's register scaling)
+# ---------------------------------------------------------------------------
+
+
+async def test_native_precision_derived_for_register_backed_sensors(hass, setup_integration):
+    """Register-backed numeric sensors get the decimals implied by their scaling."""
+    assert _suggested_precision(hass, "BT1234A001_v_cell_01") == 3  # milli
+    assert _suggested_precision(hass, "BT1234A001_t_bms_mosfet") == 1  # deci
+    assert _suggested_precision(hass, "BT1234A001_cap_design2") == 2  # uint32 -> centi
+    assert _suggested_precision(hass, "BT1234A001_soc") == 0  # uint16
+
+
+async def test_string_rendered_sensor_has_no_precision(hass, setup_integration):
+    """usb_device_inserted is a uint16 register rendered as a hex string; it must
+    NOT get a display precision (no state_class) or HA would mis-format it."""
+    assert _suggested_precision(hass, "BT1234A001_usb_device_inserted") is None
+
+
+async def test_computed_sensors_use_explicit_precision(hass, setup_integration):
+    """Computed (non-register-backed) sensors pin precision in their descriptor."""
+    assert _suggested_precision(hass, "SA1234G123_e_pv_day") == 1
+    assert _suggested_precision(hass, "SA1234G123_battery_capacity_kwh") == 2
+    assert _suggested_precision(hass, "SA1234G123_p_pv") == 0

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0a5,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0a6,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.0a5"
+version = "2.1.0a6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/d3/8477f0527a5ac1eb71435722d12b78653920425e3a77a165bbc369022971/givenergy_modbus-2.1.0a5.tar.gz", hash = "sha256:eda6fe9375dd052501f159dce9e9e314c3f874e80c65156f00ed957891d9b34f", size = 255616, upload-time = "2026-05-29T20:31:39.883Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/76/7c4f7f5c5a429c816ea03e278a90f5f34d0d2eb3252b69d86c385d3d2614/givenergy_modbus-2.1.0a6.tar.gz", hash = "sha256:0dec171a843b72949e2ded2f20c7bfa68f84957d7d162f318bd873c1e1cad339", size = 257619, upload-time = "2026-05-30T00:15:02.776Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/b9/bfdc4799f16c5b5c13a8b4d2545c9b345bf538a7e514e44470c1f5ed265f/givenergy_modbus-2.1.0a5-py3-none-any.whl", hash = "sha256:1d3a745c7ecba053a196786c9e99406bc55c04e7877c31afee71bb61718f17f1", size = 90666, upload-time = "2026-05-29T20:31:38.457Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/3b8914a9677974a00514dd596ff55114c71b0711c716f9524a495cb6ae25/givenergy_modbus-2.1.0a6-py3-none-any.whl", hash = "sha256:c94ebf58e54ee6daba88c3353fe6dbbc8348dbf36651278abbbcd8e6b7b5e09f", size = 92026, upload-time = "2026-05-30T00:15:01.39Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does

Sensors now display at their **native register resolution** instead of stripping trailing zeros. Battery voltage (a centivolt register) shows `52.10 V` rather than `52.1`/`52`; temperatures show 1 dp, cell voltages 3 dp, and so on. Users can still override any entity's precision in the HA UI.

This consumes [givenergy-modbus#129](https://github.com/dewet22/givenergy-modbus/pull/129)'s `Model.precision_of(attribute)` — precision lives with the register scaling in the library (it's model-specific: e.g. `i_battery` is centivolts on single-phase, decivolts on three-phase), so hass just asks the live model.

## How

- `_derive_display_precision(description, model)` sets `suggested_display_precision` in the inverter/battery sensor `__init__` from `model.precision_of(description.key)`. It returns `None` (leaving HA's default) when:
  - the descriptor already pins a precision — **an explicit value always wins**;
  - the sensor has **no `state_class`** — display precision only applies to numeric measurement/total sensors. This deliberately skips the enum / hex-string / version diagnostics, several of which are register-backed integers (`uint16`) that hass renders as hex strings (`usb_device_inserted` → `"0x0008"`, the BMS `status_*`/`warning_*` bytes). Handing those a numeric precision would break HA's formatting.
- Explicit `suggested_display_precision` on the three computed-numeric descriptors that aren't backed by a single register: `p_pv` (0, W), `e_pv_day` (1, kWh), `work_time_total` (0, h). `battery_capacity_kwh` already pinned 2.
- Pin bumped to `givenergy-modbus>=2.1.0a6` (ships `precision_of`).

## Tests

`conftest` points the mock models' `precision_of` at the real library classmethods, so the derivation runs against actual register scaling rather than a stub. New coverage: register-backed sensors get the right decimals (cell voltage → 3 / milli, BMS temp → 1 / deci, alt capacity → 2 / centi, SoC → 0 / uint16); the hex-rendered `usb_device_inserted` gets none; the computed sensors use their explicit values. Full suite green (114), ruff + mypy clean (no new errors vs baseline).

## Validation

I'll confirm on a live instance once this lands and a 1.1 pre-release is cut — battery voltage should render `52.10`. (The reading itself is genuinely 0.01 V; the register is centivolts.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensor display precision handling for numeric sensors based on register scaling
  * Pinned explicit display precision for PV Power, PV Energy Today, and Work Time Total sensors

* **Dependencies**
  * Updated givenergy-modbus requirement to `>=2.1.0a6`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-hass/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->