### PR TITLE
fix: guard inverter status sensor against None (#52)

### DIFF
--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -105,7 +105,10 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         device_class=SensorDeviceClass.ENUM,
         options=[s.name.lower() for s in Status],
         translation_key="inverter_status",
-        value_fn=lambda inv: inv.status.name.lower(),
+        # inv.status can be None while the library serves an empty model during
+        # partial / pre-first-poll windows (givenergy-modbus's .inverter accessor
+        # returns an empty model rather than raising); guard like the other enums.
+        value_fn=lambda inv: inv.status.name.lower() if inv.status is not None else None,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     GivEnergyInverterSensorDescription(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -27,6 +27,7 @@ def test_enum_value_fns_tolerate_none_attribute():
         "battery_type",
         "battery_calibration_stage",
         "usb_device_inserted",
+        "battery_maintenance_mode",
     ):
         setattr(empty, key, None)
         assert _inverter_desc(key).value_fn(empty) is None, f"{key} value_fn crashed on None"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,5 +1,7 @@
 """Tests for the GivEnergy Local sensor platform."""
 
+from unittest.mock import MagicMock
+
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.givenergy_local.const import DOMAIN
@@ -8,6 +10,33 @@ from custom_components.givenergy_local.sensor import (
     COORDINATOR_SENSORS,
     INVERTER_SENSORS,
 )
+
+
+def _inverter_desc(key: str):
+    return next(d for d in INVERTER_SENSORS if d.key == key)
+
+
+def test_enum_value_fns_tolerate_none_attribute():
+    """value_fns reading `.name` off an enum attribute must return None, not crash,
+    when the attribute is None — the library serves an empty model (all attrs None)
+    during partial / pre-first-poll windows (issue #52)."""
+    empty = MagicMock()
+    for key in (
+        "status",
+        "meter_type",
+        "battery_type",
+        "battery_calibration_stage",
+        "usb_device_inserted",
+    ):
+        setattr(empty, key, None)
+        assert _inverter_desc(key).value_fn(empty) is None, f"{key} value_fn crashed on None"
+
+
+def test_status_value_fn_renders_when_present():
+    """Sanity: the guarded status value_fn still renders a real status."""
+    inv = MagicMock()
+    inv.status.name = "NORMAL"
+    assert _inverter_desc("status").value_fn(inv) == "normal"
 
 
 def _entity_id(hass, platform: str, unique_id: str) -> str:


### PR DESCRIPTION
## What

The inverter **Status** sensor crashed with `AttributeError: 'NoneType' object has no attribute 'name'`:

```
File ".../givenergy_local/sensor.py", line 108, in <lambda>
    value_fn=lambda inv: inv.status.name.lower(),
AttributeError: 'NoneType' object has no attribute 'name'
```

As of the addressing fix, `givenergy-modbus`'s `.inverter` accessor returns an **empty model** (all attributes `None`) rather than raising during partial / pre-first-poll windows. So `inv.status` can legitimately be `None`, and `inv.status.name.lower()` blows up — breaking the entity's state write.

Reported from live EMS hardware in #52 (the rest of which — EMS reads — works; this crash is independent of EMS).

## Fix

Guard `status` like the other enum value_fns already do (`meter_type`, `battery_type`, `battery_calibration_stage`, `usb_device_inserted`):

```python
value_fn=lambda inv: inv.status.name.lower() if inv.status is not None else None,
```

An audit confirmed `status` was the **only** unguarded attribute-chained value_fn.

## Tests

Added `test_enum_value_fns_tolerate_none_attribute` (every enum value_fn returns `None`, not a crash, when its attribute is `None`) plus a sanity check that the guarded `status` value_fn still renders a real status. Full suite green (116).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the inverter Status sensor to gracefully handle cases where status data is unavailable during initial startup or partial polling cycles, preventing unexpected sensor failures.

* **Tests**
  * Added comprehensive test coverage to ensure all inverter sensors safely handle missing or incomplete data without crashing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-hass/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->