### PR TITLE
feat: expose EMS plant-level charge/discharge slot scheduling entities (#74)

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.0a6,<3.0.0"
+    "givenergy-modbus>=2.1.0a8,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from givenergy_modbus.client import commands
+from givenergy_modbus.model.ems import Ems
 from homeassistant.components.number import NumberEntity, NumberEntityDescription, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
@@ -86,15 +87,66 @@ NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
 )
 
 
+# --- EMS plant-level per-slot SoC targets (only created for EMS plants) ---
+
+
+@dataclass(frozen=True, kw_only=True)
+class GivEnergyEmsNumberEntityDescription(NumberEntityDescription):
+    value_fn: Callable[[Ems], float | None] = field(default=lambda _: None)
+    set_value_cmd: Callable[[float], list] = field(default=lambda _: [])
+
+
+def _target_getter(attr: str) -> Callable[[Ems], float | None]:
+    return lambda ems: getattr(ems, attr)
+
+
+def _target_setter(cmd: Callable[[int, int], list], idx: int) -> Callable[[float], list]:
+    return lambda v: cmd(idx, int(v))
+
+
+def _ems_number_descriptions() -> tuple[GivEnergyEmsNumberEntityDescription, ...]:
+    """Per-slot SoC target controls for EMS charge & discharge slots 1-3."""
+    descriptions: list[GivEnergyEmsNumberEntityDescription] = []
+    for kind in ("charge", "discharge"):
+        cmd = getattr(commands, f"set_ems_{kind}_target_soc")
+        for idx in (1, 2, 3):
+            descriptions.append(
+                GivEnergyEmsNumberEntityDescription(
+                    key=f"ems_{kind}_target_soc_{idx}",
+                    name=f"EMS {kind.title()} Slot {idx} Target SOC",
+                    native_unit_of_measurement=PERCENTAGE,
+                    native_min_value=4,
+                    native_max_value=100,
+                    native_step=1,
+                    mode=NumberMode.BOX,
+                    value_fn=_target_getter(f"{kind}_target_{idx}"),
+                    set_value_cmd=_target_setter(cmd, idx),
+                    entity_category=EntityCategory.CONFIG,
+                )
+            )
+    return tuple(descriptions)
+
+
+EMS_NUMBER_DESCRIPTIONS: tuple[GivEnergyEmsNumberEntityDescription, ...] = (
+    _ems_number_descriptions()
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: GivEnergyUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
+    entities: list[NumberEntity] = [
         GivEnergyNumberEntity(coordinator, description) for description in NUMBER_DESCRIPTIONS
-    )
+    ]
+    if coordinator.data.ems is not None:
+        entities.extend(
+            GivEnergyEmsNumberEntity(coordinator, description)
+            for description in EMS_NUMBER_DESCRIPTIONS
+        )
+    async_add_entities(entities)
 
 
 class GivEnergyNumberEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], NumberEntity):
@@ -117,6 +169,40 @@ class GivEnergyNumberEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], Numbe
     @property
     def native_value(self) -> float | None:
         return self.entity_description.value_fn(self.coordinator.data.inverter)
+
+    async def async_set_native_value(self, value: float) -> None:
+        client = self.coordinator._client
+        if client is None or not client.connected:
+            return
+        await client.one_shot_command(self.entity_description.set_value_cmd(value))
+        await self.coordinator.async_request_refresh()
+
+
+class GivEnergyEmsNumberEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], NumberEntity):
+    """SoC target control for an EMS plant-level charge/discharge slot."""
+
+    _attr_has_entity_name = True
+    entity_description: GivEnergyEmsNumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: GivEnergyUpdateCoordinator,
+        description: GivEnergyEmsNumberEntityDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        serial = coordinator.data.inverter_serial_number
+        self._attr_unique_id = f"{serial}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        ems = self.coordinator.data.ems
+        if ems is None:
+            return None
+        return self.entity_description.value_fn(ems)
 
     async def async_set_native_value(self, value: float) -> None:
         client = self.coordinator._client

--- a/custom_components/givenergy_local/time.py
+++ b/custom_components/givenergy_local/time.py
@@ -6,6 +6,7 @@ from datetime import time as dt_time
 
 from givenergy_modbus.client import commands
 from givenergy_modbus.model import TimeSlot
+from givenergy_modbus.model.ems import Ems
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -111,15 +112,67 @@ TIME_DESCRIPTIONS: tuple[GivEnergyTimeEntityDescription, ...] = (
 )
 
 
+# --- EMS plant-level slots (only created for EMS plants) ---
+
+
+@dataclass(frozen=True, kw_only=True)
+class GivEnergyEmsTimeEntityDescription(TimeEntityDescription):
+    slot_fn: Callable[[Ems], TimeSlot | None] = field(default=lambda _: None)
+    is_start: bool = True
+    # EMS setters bake in the slot index and write just the relevant endpoint;
+    # unlike the inverter setters they need no slot_map.
+    setter_fn: Callable[[dt_time], list] = field(default=lambda _: [])
+
+
+def _slot_getter(attr: str) -> Callable[[Ems], TimeSlot | None]:
+    return lambda ems: getattr(ems, attr)
+
+
+def _endpoint_setter(cmd: Callable[[int, dt_time], list], idx: int) -> Callable[[dt_time], list]:
+    return lambda value: cmd(idx, value)
+
+
+def _ems_time_descriptions() -> tuple[GivEnergyEmsTimeEntityDescription, ...]:
+    """Start/end time entities for EMS charge & discharge slots 1-3."""
+    descriptions: list[GivEnergyEmsTimeEntityDescription] = []
+    for kind in ("charge", "discharge"):
+        endpoints = (
+            ("start", True, getattr(commands, f"set_ems_{kind}_slot_start")),
+            ("end", False, getattr(commands, f"set_ems_{kind}_slot_end")),
+        )
+        for idx in (1, 2, 3):
+            for endpoint, is_start, cmd in endpoints:
+                descriptions.append(
+                    GivEnergyEmsTimeEntityDescription(
+                        key=f"ems_{kind}_slot_{idx}_{endpoint}",
+                        name=f"EMS {kind.title()} Slot {idx} {endpoint.title()}",
+                        slot_fn=_slot_getter(f"{kind}_slot_{idx}"),
+                        is_start=is_start,
+                        setter_fn=_endpoint_setter(cmd, idx),
+                        entity_category=EntityCategory.CONFIG,
+                    )
+                )
+    return tuple(descriptions)
+
+
+EMS_TIME_DESCRIPTIONS: tuple[GivEnergyEmsTimeEntityDescription, ...] = _ems_time_descriptions()
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: GivEnergyUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
+    entities: list[TimeEntity] = [
         GivEnergyTimeEntity(coordinator, description) for description in TIME_DESCRIPTIONS
-    )
+    ]
+    if coordinator.data.ems is not None:
+        entities.extend(
+            GivEnergyEmsTimeEntity(coordinator, description)
+            for description in EMS_TIME_DESCRIPTIONS
+        )
+    async_add_entities(entities)
 
 
 class GivEnergyTimeEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], TimeEntity):
@@ -154,4 +207,41 @@ class GivEnergyTimeEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], TimeEnt
         if self.entity_description.slot_fn(inverter) is None:
             return
         await client.one_shot_command(self.entity_description.setter_fn(value, inverter))
+        await self.coordinator.async_request_refresh()
+
+
+class GivEnergyEmsTimeEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], TimeEntity):
+    """Start/end time control for an EMS plant-level charge/discharge slot."""
+
+    _attr_has_entity_name = True
+    entity_description: GivEnergyEmsTimeEntityDescription
+
+    def __init__(
+        self,
+        coordinator: GivEnergyUpdateCoordinator,
+        description: GivEnergyEmsTimeEntityDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        serial = coordinator.data.inverter_serial_number
+        self._attr_unique_id = f"{serial}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+        )
+
+    @property
+    def native_value(self) -> dt_time | None:
+        ems = self.coordinator.data.ems
+        if ems is None:
+            return None
+        slot = self.entity_description.slot_fn(ems)
+        if slot is None:
+            return None
+        return slot.start if self.entity_description.is_start else slot.end
+
+    async def async_set_value(self, value: dt_time) -> None:
+        client = self.coordinator._client
+        if client is None or not client.connected:
+            return
+        await client.one_shot_command(self.entity_description.setter_fn(value))
         await self.coordinator.async_request_refresh()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.0a6,<3.0.0",
+    "givenergy-modbus>=2.1.0a8,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,6 +162,9 @@ def mock_plant(mock_inverter, mock_battery) -> MagicMock:
     plant.inverter = mock_inverter
     plant.batteries = [mock_battery]
     plant.number_batteries = 1
+    # No EMS by default; the EMS-specific tests override this with a mock Ems so
+    # the EMS scheduling entities are only created for EMS plants.
+    plant.ems = None
     # A real PlantCapabilities — the integration's save-on-success path calls
     # .to_dict() through CapabilitiesCache, which would choke on a MagicMock.
     plant.capabilities = PlantCapabilities(

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -1,0 +1,116 @@
+"""Tests for the EMS plant-level scheduling entities (issue #74).
+
+These are only created when the plant is an EMS (coordinator.data.ems is not
+None); the shared fixtures default ems to None, so here we override it with a
+mock Ems before setting up the integration.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from givenergy_modbus.model import TimeSlot
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.givenergy_local.const import DOMAIN
+
+
+@pytest.fixture
+def mock_ems() -> MagicMock:
+    ems = MagicMock()
+    ems.charge_slot_1 = TimeSlot.from_components(2, 0, 5, 0)
+    ems.charge_slot_2 = None
+    ems.charge_slot_3 = None
+    ems.discharge_slot_1 = TimeSlot.from_components(17, 0, 19, 0)
+    ems.discharge_slot_2 = None
+    ems.discharge_slot_3 = None
+    ems.charge_target_1 = 80
+    ems.charge_target_2 = 100
+    ems.charge_target_3 = 100
+    ems.discharge_target_1 = 20
+    ems.discharge_target_2 = 4
+    ems.discharge_target_3 = 4
+    return ems
+
+
+@pytest.fixture
+async def ems_setup(hass, mock_client, mock_plant, mock_ems, mock_config_entry):
+    """Set up the integration with the plant presenting as an EMS."""
+    mock_plant.ems = mock_ems
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
+
+
+def _entity_id(hass, platform: str, unique_id: str) -> str | None:
+    return er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
+
+
+# ---------------------------------------------------------------------------
+# Creation gating
+# ---------------------------------------------------------------------------
+
+
+async def test_ems_entities_created_for_ems_plant(hass, ems_setup):
+    """EMS plant exposes 12 slot time entities + 6 SoC-target number entities."""
+    registry = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(registry, ems_setup.entry_id)
+    ems_times = [e for e in entries if e.domain == "time" and "_ems_" in e.unique_id]
+    ems_numbers = [e for e in entries if e.domain == "number" and "_ems_" in e.unique_id]
+    assert len(ems_times) == 12  # charge+discharge x slots 1-3 x start/end
+    assert len(ems_numbers) == 6  # charge+discharge x slots 1-3 target SoC
+
+
+async def test_no_ems_entities_for_non_ems_plant(hass, setup_integration):
+    """A plant without an EMS (the default) must not get EMS entities."""
+    assert _entity_id(hass, "time", "SA1234G123_ems_charge_slot_1_start") is None
+    assert _entity_id(hass, "number", "SA1234G123_ems_charge_target_soc_1") is None
+
+
+# ---------------------------------------------------------------------------
+# Initial values (read from coordinator.data.ems)
+# ---------------------------------------------------------------------------
+
+
+async def test_ems_charge_slot_initial_times(hass, ems_setup):
+    start = hass.states.get(_entity_id(hass, "time", "SA1234G123_ems_charge_slot_1_start"))
+    end = hass.states.get(_entity_id(hass, "time", "SA1234G123_ems_charge_slot_1_end"))
+    assert start.state == "02:00:00"
+    assert end.state == "05:00:00"
+
+
+async def test_ems_discharge_slot_initial_times(hass, ems_setup):
+    start = hass.states.get(_entity_id(hass, "time", "SA1234G123_ems_discharge_slot_1_start"))
+    assert start.state == "17:00:00"
+
+
+async def test_ems_charge_target_initial_value(hass, ems_setup):
+    state = hass.states.get(_entity_id(hass, "number", "SA1234G123_ems_charge_target_soc_1"))
+    assert float(state.state) == 80
+
+
+# ---------------------------------------------------------------------------
+# Writes (build the right set_ems_* command)
+# ---------------------------------------------------------------------------
+
+
+async def test_set_ems_charge_slot_start_writes_endpoint(hass, mock_client, ems_setup):
+    entity_id = _entity_id(hass, "time", "SA1234G123_ems_charge_slot_1_start")
+    await hass.services.async_call(
+        "time", "set_value", {"entity_id": entity_id, "time": "01:00:00"}, blocking=True
+    )
+    mock_client.one_shot_command.assert_called_once()
+    (request,) = mock_client.one_shot_command.call_args[0][0]
+    # EMS charge slot 1 start = HR 2053, 01:00 -> 100, on the EMS controller 0x11.
+    assert (request.register, request.value, request.device_address) == (2053, 100, 0x11)
+
+
+async def test_set_ems_charge_target_soc_writes_register(hass, mock_client, ems_setup):
+    entity_id = _entity_id(hass, "number", "SA1234G123_ems_charge_target_soc_1")
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": entity_id, "value": 75}, blocking=True
+    )
+    mock_client.one_shot_command.assert_called_once()
+    (request,) = mock_client.one_shot_command.call_args[0][0]
+    # EMS charge slot 1 target SoC = HR 2055.
+    assert (request.register, request.value, request.device_address) == (2055, 75, 0x11)

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0a6,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0a8,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.0a6"
+version = "2.1.0a8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/76/7c4f7f5c5a429c816ea03e278a90f5f34d0d2eb3252b69d86c385d3d2614/givenergy_modbus-2.1.0a6.tar.gz", hash = "sha256:0dec171a843b72949e2ded2f20c7bfa68f84957d7d162f318bd873c1e1cad339", size = 257619, upload-time = "2026-05-30T00:15:02.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/8e/353667a1764927b8aed405833ee6af70005a4e42b034834ceaf1b3547870/givenergy_modbus-2.1.0a8.tar.gz", hash = "sha256:4b7e9a066cba507015c2efc9a5971c69478313d8e7cfdce3793a6186d0b6a77e", size = 262221, upload-time = "2026-05-30T14:30:01.899Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/fc/3b8914a9677974a00514dd596ff55114c71b0711c716f9524a495cb6ae25/givenergy_modbus-2.1.0a6-py3-none-any.whl", hash = "sha256:c94ebf58e54ee6daba88c3353fe6dbbc8348dbf36651278abbbcd8e6b7b5e09f", size = 92026, upload-time = "2026-05-30T00:15:01.39Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/53/cf335bf6284fae2e7793c799b7a88b7db0bcb7781e6d33254909f960636e/givenergy_modbus-2.1.0a8-py3-none-any.whl", hash = "sha256:57ed8414ae7dae329ce2e5cd82f1c26cd7be112b8ca5abc6056d8708437021f2", size = 93329, upload-time = "2026-05-30T14:30:00.268Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #74.

## What

For **EMS plants**, exposes the plant-level charge/discharge scheduling controls — the entities a scheduler like Predbat needs to be pointed at for an EMS (see #52). Built against the new `givenergy-modbus 2.1.0a8` `set_ems_*` commands, which write to the EMS controller at device `0x11`.

- **Time entities** (`time.py`) — EMS charge + discharge **slots 1–3**, start and end (12 total), reading `coordinator.data.ems.{charge,discharge}_slot_N` and writing via `commands.set_ems_charge/discharge_slot_start/_end(idx, value)` (a8's per-endpoint setters — no `slot_map` needed).
- **Number entities** (`number.py`) — per-slot **SoC targets** for charge + discharge slots 1–3 (6 total, 4–100%), via `commands.set_ems_charge/discharge_target_soc(idx, int(v))`.

## How

- Created **only when the plant is an EMS** (`coordinator.data.ems is not None`); attached to the existing device (the EMS controller serial). Entity keys are `ems_…`-prefixed so they don't collide with the inverter slot entities.
- New `GivEnergyEmsTimeEntity` / `GivEnergyEmsNumberEntity` read from `coordinator.data.ems` (vs `.inverter`); descriptions generated via small typed factory helpers.
- Pin bumped to `givenergy-modbus>=2.1.0a8`.

## Scope notes

- **Export slots deferred** — the library has no `set_ems_export_slot_*` setter yet (only export *target SoC* and *power limit*), so export scheduling is a clean follow-up.
- **Inverter slot entities left as-is** on EMS plants for now (they're still created against the unified facade); de-duplicating those is a separate cleanup, per discussion.

## Tests

`tests/test_ems.py` (7): EMS entities created only for EMS plants (and *not* for non-EMS), initial values read from the EMS model, and set-value builds the correct register write (charge slot 1 start → HR 2053, target → HR 2055, both at `0x11`). `conftest` defaults `ems` to None so existing tests are unaffected.

Full suite green (123); ruff clean; mypy adds no new errors vs baseline.

## Validation

Not yet confirmed on live EMS hardware — that's the next step: cut a hass alpha, and @njhcarroll kindly test the writes land on his EMS (#52). The modbus write path is correct-by-construction (addresses cross-checked against the read map) but unconfirmed on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)