### PR TITLE
fix(deps): bump givenergy-modbus to 2.1.0a11

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.0a8,<3.0.0"
+    "givenergy-modbus>=2.1.0a11,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.0a8,<3.0.0",
+    "givenergy-modbus>=2.1.0a11,<3.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0a8,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0a11,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.0a8"
+version = "2.1.0a11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/8e/353667a1764927b8aed405833ee6af70005a4e42b034834ceaf1b3547870/givenergy_modbus-2.1.0a8.tar.gz", hash = "sha256:4b7e9a066cba507015c2efc9a5971c69478313d8e7cfdce3793a6186d0b6a77e", size = 262221, upload-time = "2026-05-30T14:30:01.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/0c/bc8e6e58c49258dd2a3b5e1b72d657468fa00586c537143c9caca648f882/givenergy_modbus-2.1.0a11.tar.gz", hash = "sha256:549c3b20cb25258ea45613d7ecd4ee71117961156f1da24980baaba0676ddeaa", size = 264275, upload-time = "2026-05-31T13:44:08.381Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/53/cf335bf6284fae2e7793c799b7a88b7db0bcb7781e6d33254909f960636e/givenergy_modbus-2.1.0a8-py3-none-any.whl", hash = "sha256:57ed8414ae7dae329ce2e5cd82f1c26cd7be112b8ca5abc6056d8708437021f2", size = 93329, upload-time = "2026-05-30T14:30:00.268Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ca/dcd35defe73bf0703b6686cb0d33ae805c93b27109a668c9d081ce9bdc90/givenergy_modbus-2.1.0a11-py3-none-any.whl", hash = "sha256:b761ddf7a3f33cba8063b1e6b04cc6d3ed96e86721ab422f9ca1ed90ed7b8623", size = 94755, upload-time = "2026-05-31T13:44:06.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated bump triggered by [givenergy-modbus@2.1.0a11](https://github.com/dewet22/givenergy-modbus/releases/tag/v2.1.0a11).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated givenergy-modbus library dependency to version 2.1.0a11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->