### PR TITLE
feat(controls): EMS export + flexi parity, RTC and active-power knobs

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.0a8,<3.0.0"
+    "givenergy-modbus>=2.1.0a11,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -84,6 +84,18 @@ NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
         set_value_cmd=lambda v: commands.set_battery_power_reserve(int(v)),
         entity_category=EntityCategory.CONFIG,
     ),
+    GivEnergyNumberEntityDescription(
+        key="active_power_rate",
+        name="Inverter Max Output Active Power",
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        mode=NumberMode.BOX,
+        value_fn=lambda inv: inv.active_power_rate,
+        set_value_cmd=lambda v: commands.set_active_power_rate(int(v)),
+        entity_category=EntityCategory.CONFIG,
+    ),
 )
 
 
@@ -105,9 +117,9 @@ def _target_setter(cmd: Callable[[int, int], list], idx: int) -> Callable[[float
 
 
 def _ems_number_descriptions() -> tuple[GivEnergyEmsNumberEntityDescription, ...]:
-    """Per-slot SoC target controls for EMS charge & discharge slots 1-3."""
+    """Per-slot SoC target controls for EMS charge, discharge & export slots 1-3."""
     descriptions: list[GivEnergyEmsNumberEntityDescription] = []
-    for kind in ("charge", "discharge"):
+    for kind in ("charge", "discharge", "export"):
         cmd = getattr(commands, f"set_ems_{kind}_target_soc")
         for idx in (1, 2, 3):
             descriptions.append(

--- a/custom_components/givenergy_local/switch.py
+++ b/custom_components/givenergy_local/switch.py
@@ -5,8 +5,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from givenergy_modbus.client import commands
+from givenergy_modbus.model.ems import Ems
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -38,6 +40,36 @@ SWITCH_DESCRIPTIONS: tuple[GivEnergySwitchEntityDescription, ...] = (
         turn_on_cmd=lambda: commands.set_enable_discharge(True),
         turn_off_cmd=lambda: commands.set_enable_discharge(False),
     ),
+    GivEnergySwitchEntityDescription(
+        key="enable_rtc",
+        name="Real Time Control",
+        is_on_fn=lambda inv: inv.enable_rtc,
+        turn_on_cmd=lambda: commands.set_enable_rtc(True),
+        turn_off_cmd=lambda: commands.set_enable_rtc(False),
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+
+# --- EMS plant-level switches (only created for EMS plants) ---
+
+
+@dataclass(frozen=True, kw_only=True)
+class GivEnergyEmsSwitchEntityDescription(SwitchEntityDescription):
+    is_on_fn: Callable[[Ems], bool | None] = field(default=lambda _: None)
+    turn_on_cmd: Callable[[], list] = field(default=list)
+    turn_off_cmd: Callable[[], list] = field(default=list)
+
+
+EMS_SWITCH_DESCRIPTIONS: tuple[GivEnergyEmsSwitchEntityDescription, ...] = (
+    GivEnergyEmsSwitchEntityDescription(
+        key="ems_plant_enable",
+        name="Flexi EMS Control",
+        is_on_fn=lambda ems: ems.plant_enabled,
+        turn_on_cmd=lambda: commands.set_ems_plant(True),
+        turn_off_cmd=lambda: commands.set_ems_plant(False),
+        entity_category=EntityCategory.CONFIG,
+    ),
 )
 
 
@@ -47,9 +79,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: GivEnergyUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
+    entities: list[SwitchEntity] = [
         GivEnergySwitchEntity(coordinator, description) for description in SWITCH_DESCRIPTIONS
-    )
+    ]
+    if coordinator.data.ems is not None:
+        entities.extend(
+            GivEnergyEmsSwitchEntity(coordinator, description)
+            for description in EMS_SWITCH_DESCRIPTIONS
+        )
+    async_add_entities(entities)
 
 
 class GivEnergySwitchEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], SwitchEntity):
@@ -72,6 +110,46 @@ class GivEnergySwitchEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], Switc
     @property
     def is_on(self) -> bool:
         return self.entity_description.is_on_fn(self.coordinator.data.inverter)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._send_command(self.entity_description.turn_on_cmd())
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._send_command(self.entity_description.turn_off_cmd())
+
+    async def _send_command(self, cmd: list) -> None:
+        client = self.coordinator._client
+        if client is None or not client.connected:
+            return
+        await client.one_shot_command(cmd)
+        await self.coordinator.async_request_refresh()
+
+
+class GivEnergyEmsSwitchEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], SwitchEntity):
+    """Plant-level EMS switch (e.g. the Flexi EMS Control master enable)."""
+
+    _attr_has_entity_name = True
+    entity_description: GivEnergyEmsSwitchEntityDescription
+
+    def __init__(
+        self,
+        coordinator: GivEnergyUpdateCoordinator,
+        description: GivEnergyEmsSwitchEntityDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        serial = coordinator.data.inverter_serial_number
+        self._attr_unique_id = f"{serial}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        ems = self.coordinator.data.ems
+        if ems is None:
+            return None
+        return self.entity_description.is_on_fn(ems)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         await self._send_command(self.entity_description.turn_on_cmd())

--- a/custom_components/givenergy_local/time.py
+++ b/custom_components/givenergy_local/time.py
@@ -133,9 +133,9 @@ def _endpoint_setter(cmd: Callable[[int, dt_time], list], idx: int) -> Callable[
 
 
 def _ems_time_descriptions() -> tuple[GivEnergyEmsTimeEntityDescription, ...]:
-    """Start/end time entities for EMS charge & discharge slots 1-3."""
+    """Start/end time entities for EMS charge, discharge & export slots 1-3."""
     descriptions: list[GivEnergyEmsTimeEntityDescription] = []
-    for kind in ("charge", "discharge"):
+    for kind in ("charge", "discharge", "export"):
         endpoints = (
             ("start", True, getattr(commands, f"set_ems_{kind}_slot_start")),
             ("end", False, getattr(commands, f"set_ems_{kind}_slot_end")),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.0a8,<3.0.0",
+    "givenergy-modbus>=2.1.0a11,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -23,12 +23,19 @@ def mock_ems() -> MagicMock:
     ems.discharge_slot_1 = TimeSlot.from_components(17, 0, 19, 0)
     ems.discharge_slot_2 = None
     ems.discharge_slot_3 = None
+    ems.export_slot_1 = TimeSlot.from_components(10, 0, 16, 0)
+    ems.export_slot_2 = None
+    ems.export_slot_3 = None
     ems.charge_target_1 = 80
     ems.charge_target_2 = 100
     ems.charge_target_3 = 100
     ems.discharge_target_1 = 20
     ems.discharge_target_2 = 4
     ems.discharge_target_3 = 4
+    ems.export_target_1 = 100
+    ems.export_target_2 = 4
+    ems.export_target_3 = 4
+    ems.plant_enabled = True
     return ems
 
 
@@ -52,13 +59,15 @@ def _entity_id(hass, platform: str, unique_id: str) -> str | None:
 
 
 async def test_ems_entities_created_for_ems_plant(hass, ems_setup):
-    """EMS plant exposes 12 slot time entities + 6 SoC-target number entities."""
+    """EMS plant exposes 18 slot-time + 9 SoC-target + 1 switch entities."""
     registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(registry, ems_setup.entry_id)
     ems_times = [e for e in entries if e.domain == "time" and "_ems_" in e.unique_id]
     ems_numbers = [e for e in entries if e.domain == "number" and "_ems_" in e.unique_id]
-    assert len(ems_times) == 12  # charge+discharge x slots 1-3 x start/end
-    assert len(ems_numbers) == 6  # charge+discharge x slots 1-3 target SoC
+    ems_switches = [e for e in entries if e.domain == "switch" and "_ems_" in e.unique_id]
+    assert len(ems_times) == 18  # charge+discharge+export x slots 1-3 x start/end
+    assert len(ems_numbers) == 9  # charge+discharge+export x slots 1-3 target SoC
+    assert len(ems_switches) == 1  # Flexi EMS Control
 
 
 async def test_no_ems_entities_for_non_ems_plant(hass, setup_integration):
@@ -87,6 +96,41 @@ async def test_ems_discharge_slot_initial_times(hass, ems_setup):
 async def test_ems_charge_target_initial_value(hass, ems_setup):
     state = hass.states.get(_entity_id(hass, "number", "SA1234G123_ems_charge_target_soc_1"))
     assert float(state.state) == 80
+
+
+async def test_ems_export_target_initial_value(hass, ems_setup):
+    state = hass.states.get(_entity_id(hass, "number", "SA1234G123_ems_export_target_soc_1"))
+    assert float(state.state) == 100
+
+
+async def test_set_ems_export_target_soc_writes_to_ems_controller(hass, mock_client, ems_setup):
+    entity_id = _entity_id(hass, "number", "SA1234G123_ems_export_target_soc_2")
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": entity_id, "value": 50}, blocking=True
+    )
+    mock_client.one_shot_command.assert_called_once()
+    (request,) = mock_client.one_shot_command.call_args[0][0]
+    # EMS export target SoC writes go to the EMS controller (0x11) with the value.
+    assert request.value == 50
+    assert request.device_address == 0x11
+
+
+async def test_ems_export_slot_initial_times(hass, ems_setup):
+    start = hass.states.get(_entity_id(hass, "time", "SA1234G123_ems_export_slot_1_start"))
+    end = hass.states.get(_entity_id(hass, "time", "SA1234G123_ems_export_slot_1_end"))
+    assert start.state == "10:00:00"
+    assert end.state == "16:00:00"
+
+
+async def test_flexi_ems_control_switch_reflects_plant_enabled(hass, ems_setup):
+    state = hass.states.get(_entity_id(hass, "switch", "SA1234G123_ems_plant_enable"))
+    assert state.state == "on"  # mock_ems.plant_enabled is True
+
+
+async def test_flexi_ems_control_switch_writes_command(hass, mock_client, ems_setup):
+    entity_id = _entity_id(hass, "switch", "SA1234G123_ems_plant_enable")
+    await hass.services.async_call("switch", "turn_off", {"entity_id": entity_id}, blocking=True)
+    mock_client.one_shot_command.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -36,3 +36,17 @@ async def test_set_battery_discharge_limit_sends_command(hass, mock_client, setu
         "number", "set_value", {"entity_id": entity_id, "value": 25}, blocking=True
     )
     mock_client.one_shot_command.assert_called_once()
+
+
+async def test_active_power_rate_present(hass, setup_integration):
+    # Entity is wired (the write path is covered below); this fixture's register
+    # set doesn't populate active_power_rate, so the decoded value may be unknown.
+    assert hass.states.get(_entity_id(hass, "SA1234G123_active_power_rate")) is not None
+
+
+async def test_set_active_power_rate_sends_command(hass, mock_client, setup_integration):
+    entity_id = _entity_id(hass, "SA1234G123_active_power_rate")
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": entity_id, "value": 90}, blocking=True
+    )
+    mock_client.one_shot_command.assert_called_once()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -32,3 +32,14 @@ async def test_turn_on_discharge_sends_command(hass, mock_client, setup_integrat
     entity_id = _entity_id(hass, "SA1234G123_enable_discharge")
     await hass.services.async_call("switch", "turn_on", {"entity_id": entity_id}, blocking=True)
     mock_client.one_shot_command.assert_called_once()
+
+
+async def test_enable_rtc_present_and_decodes(hass, setup_integration):
+    state = hass.states.get(_entity_id(hass, "SA1234G123_enable_rtc"))
+    assert state.state in ("on", "off")
+
+
+async def test_toggle_rtc_sends_command(hass, mock_client, setup_integration):
+    entity_id = _entity_id(hass, "SA1234G123_enable_rtc")
+    await hass.services.async_call("switch", "turn_off", {"entity_id": entity_id}, blocking=True)
+    mock_client.one_shot_command.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0a8,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0a11,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.0a8"
+version = "2.1.0a11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/8e/353667a1764927b8aed405833ee6af70005a4e42b034834ceaf1b3547870/givenergy_modbus-2.1.0a8.tar.gz", hash = "sha256:4b7e9a066cba507015c2efc9a5971c69478313d8e7cfdce3793a6186d0b6a77e", size = 262221, upload-time = "2026-05-30T14:30:01.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/0c/bc8e6e58c49258dd2a3b5e1b72d657468fa00586c537143c9caca648f882/givenergy_modbus-2.1.0a11.tar.gz", hash = "sha256:549c3b20cb25258ea45613d7ecd4ee71117961156f1da24980baaba0676ddeaa", size = 264275, upload-time = "2026-05-31T13:44:08.381Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/53/cf335bf6284fae2e7793c799b7a88b7db0bcb7781e6d33254909f960636e/givenergy_modbus-2.1.0a8-py3-none-any.whl", hash = "sha256:57ed8414ae7dae329ce2e5cd82f1c26cd7be112b8ca5abc6056d8708437021f2", size = 93329, upload-time = "2026-05-30T14:30:00.268Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ca/dcd35defe73bf0703b6686cb0d33ae805c93b27109a668c9d081ce9bdc90/givenergy_modbus-2.1.0a11-py3-none-any.whl", hash = "sha256:b761ddf7a3f33cba8063b1e6b04cc6d3ed96e86721ab422f9ca1ed90ed7b8623", size = 94755, upload-time = "2026-05-31T13:44:06.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## EMS / inverter control parity

Surfaces the GE-Cloud control knobs the integration was missing — limited to those where `givenergy_modbus` provides **both** a setter and a readable model field (real state, no write-only controls).

Bumps the `givenergy-modbus` floor **a8 → a11**, which brings the two pieces this needed: the EMS export slot setters (modbus #143) and the `Ems.plant_enabled` boolean read-back (modbus #145, added in response to the parity handoff).

### Added
- **Real Time Control** switch — `set_enable_rtc` / `inv.enable_rtc`
- **Inverter Max Output Active Power %** number — `set_active_power_rate` / `inv.active_power_rate`
- **EMS Export Slot 1–3** — start/end **times** (`set_ems_export_slot_*`) and **target SoC** (`set_ems_export_target_soc`), completing export parity with the charge/discharge slots; one-word extensions of the existing EMS time/number factories
- **Flexi EMS Control** switch — `set_ems_plant` / `ems.plant_enabled`; adds EMS-scoped switch support, gated on `coordinator.data.ems`

### Notes / not included
- **Battery Cutoff %** already exists (as "Battery Discharge Min Power Reserve" → `set_battery_power_reserve`).
- **Export power limit** deferred — the library only bounds it at the raw 0–65535 W; a sensible UI range needs GivTCP/Nick evidence.
- **`_ac` charge/discharge limit variants** and a **Set Date/Time** service deferred as follow-ups.
- The self-heating / winter-conditioning / EPS / export-priority knobs remain blocked on a hardware capture (modbus #144) — no library register yet.

Source: GE Cloud portal "EMS setup" (EMS + 2-inverter plant) on #52. 149 tests pass; mypy-neutral; full suite green against a11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
