### PR TITLE
fix(coordinator): throttle the partial-refresh warning

### DIFF
--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -35,6 +35,12 @@ _LOGGER = logging.getLogger(__name__)
 # so polling them every tick is wasteful.
 _FULL_REFRESH_INTERVAL = 300  # seconds (~5 minutes)
 
+# During a sustained run of partial polls, re-emit the partial warning at this
+# cadence (in polls) instead of every cycle. The first partial of a run always
+# warns; the in-between ones drop to DEBUG so a flaky/contended plant doesn't
+# flood the log. The cumulative partial_failures counter/sensor is unaffected.
+_PARTIAL_LOG_EVERY = 20
+
 
 class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
     """Wraps a long-lived Modbus Client, polling the inverter on a fixed interval.
@@ -93,6 +99,9 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         # The ReadFailure records from the most recent partial poll, surfaced as
         # a diagnostic sensor attribute so users can see *which* device dropped.
         self.last_partial_failures: list[ReadFailure] = []
+        # Length of the current unbroken run of partial polls, used only to
+        # throttle the partial log (see _record_partial). Reset by a clean poll.
+        self._consecutive_partials: int = 0
         self._last_inverter_time: datetime | None = None
         self._unchanged_ticks: int = 0
         self._active_tick: int = 0
@@ -115,9 +124,11 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
             )
 
             # A fully clean poll — clear any stale partial-failure detail so the
-            # diagnostic sensor stops naming devices that have since recovered.
+            # diagnostic sensor stops naming devices that have since recovered,
+            # and end the partial run so the next one warns afresh.
             # (The cumulative partial_failures counter is left untouched.)
             self.last_partial_failures = []
+            self._consecutive_partials = 0
             self._mark_success(plant)
             return plant
         except RefreshPartiallySucceeded as exc:
@@ -184,15 +195,38 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         self.total_failures += 1
 
     def _record_partial(self, exc: RefreshPartiallySucceeded) -> None:
-        """Count a degraded-but-usable poll and surface which reads dropped."""
+        """Count a degraded-but-usable poll and surface which reads dropped.
+
+        Partials are expected on flaky/contended plants (device-level dongle
+        garbage, multi-client contention), so the per-poll log is throttled:
+        the first partial of a run warns, a sustained run re-warns every
+        ``_PARTIAL_LOG_EVERY`` polls, and the rest drop to DEBUG. The cumulative
+        ``partial_failures`` counter and the diagnostic sensor are unaffected.
+        """
         self.partial_failures += 1
         self.last_partial_failures = exc.failures
-        _LOGGER.warning(
-            "Partial refresh: %d register read(s) failed; serving last-known "
-            "values for those banks. Failures: %s",
-            len(exc.failures),
-            exc.failures,
-        )
+        self._consecutive_partials += 1
+        if self._consecutive_partials == 1:
+            _LOGGER.warning(
+                "Partial refresh: %d register read(s) failed; serving last-known "
+                "values for those banks (further partials this run at debug). "
+                "Failures: %s",
+                len(exc.failures),
+                exc.failures,
+            )
+        elif self._consecutive_partials % _PARTIAL_LOG_EVERY == 0:
+            _LOGGER.warning(
+                "Partial refresh still occurring (%d consecutive polls); serving "
+                "last-known values. Failures: %s",
+                self._consecutive_partials,
+                exc.failures,
+            )
+        else:
+            _LOGGER.debug(
+                "Partial refresh: %d register read(s) failed; serving last-known. Failures: %s",
+                len(exc.failures),
+                exc.failures,
+            )
 
     def _is_timeout_failure(self, err: RefreshFailed) -> bool:
         """True if every underlying cause of a RefreshFailed is a timeout.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -15,7 +15,10 @@ from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from custom_components.givenergy_local.coordinator import GivEnergyUpdateCoordinator
+from custom_components.givenergy_local.coordinator import (
+    _PARTIAL_LOG_EVERY,
+    GivEnergyUpdateCoordinator,
+)
 
 
 def _caps(**overrides) -> PlantCapabilities:
@@ -337,6 +340,55 @@ async def test_partial_success_increments_partial_failures_cumulatively(hass, mo
     assert coordinator.partial_failures == 3
     assert coordinator.consecutive_failures == 0
     assert coordinator.total_failures == 0
+
+
+async def test_partial_log_throttled_and_resets(hass, mock_plant, caplog):
+    """First partial of a run warns; subsequent ones drop to debug; a clean poll
+    ends the run so the next partial warns afresh. (partial_failures unaffected.)"""
+    caplog.set_level(logging.DEBUG, logger="custom_components.givenergy_local.coordinator")
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+
+    def partial_warnings() -> list:
+        return [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "Partial refresh" in r.getMessage()
+        ]
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        mock_cls.return_value = client
+        coordinator._client = client
+
+        client.refresh = AsyncMock(side_effect=_partial(mock_plant))
+        for _ in range(3):
+            await coordinator._async_update_data()
+        assert len(partial_warnings()) == 1  # only the first of the run warned
+        assert coordinator.partial_failures == 3  # counter still bumps every poll
+
+        client.refresh = AsyncMock(return_value=mock_plant)
+        await coordinator._async_update_data()  # clean poll ends the run
+        assert coordinator._consecutive_partials == 0
+
+        client.refresh = AsyncMock(side_effect=_partial(mock_plant))
+        await coordinator._async_update_data()
+        assert len(partial_warnings()) == 2  # next run warns afresh
+
+
+async def test_partial_log_periodic_rewarn(hass, mock_plant, caplog):
+    """A sustained partial run re-warns every _PARTIAL_LOG_EVERY polls."""
+    caplog.set_level(logging.DEBUG, logger="custom_components.givenergy_local.coordinator")
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+    exc = _partial(mock_plant)
+
+    for _ in range(_PARTIAL_LOG_EVERY):
+        coordinator._record_partial(exc)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 2  # poll 1 (first) + poll _PARTIAL_LOG_EVERY (periodic)
+    assert coordinator.partial_failures == _PARTIAL_LOG_EVERY
 
 
 async def test_clean_poll_clears_stale_partial_detail(hass, mock_plant):


### PR DESCRIPTION
Fixes #84.

#125's partial-poll handling serves last-known values per-bank when a read times out (good), but logged a WARNING on **every** poll cycle that had a partial — flooding the log on flaky/contended plants (Nick's logs on #52, repeating each cycle).

Now:
- **First partial of a run** → WARNING (notes that further partials this run are at DEBUG)
- **Sustained run** → re-WARN every `_PARTIAL_LOG_EVERY` (20) polls
- **In between** → DEBUG
- **Clean poll** resets the run, so the next partial warns afresh

The cumulative `partial_failures` counter and the device-naming diagnostic sensor are unchanged — only the log cadence. Two tests cover the debounce-and-reset and the periodic re-warn. 151 tests pass; mypy-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced logging efficiency for partial refresh operations. Warning logs are now intelligently throttled during sustained partial refresh sequences to reduce log verbosity while preserving comprehensive issue tracking. The system maintains periodic alert reminders to ensure visibility of ongoing problems and automatically resets throttling upon successful polling to restore full alerting responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->