### PR TITLE
feat(controls): add set_system_datetime service to sync the inverter clock

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_PASSIVE,
@@ -38,6 +39,7 @@ from .const import (
     SERVICE_GENERATE_DASHBOARD,
     SERVICE_REBOOT_INVERTER,
     SERVICE_REDETECT_PLANT,
+    SERVICE_SET_SYSTEM_DATETIME,
 )
 from .coordinator import GivEnergyUpdateCoordinator
 from .dashboard import DASHBOARD_VERSION
@@ -314,6 +316,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
             await c._client.one_shot_command(commands.set_calibrate_battery_soc())
 
+        async def handle_set_system_datetime(call: ServiceCall) -> None:
+            c = _coordinator_for_device(hass, call.data["device_id"])
+            if c is None or c._client is None or not c._client.connected:
+                raise HomeAssistantError(
+                    f"GivEnergy inverter for device {call.data['device_id']!r} "
+                    "is not currently connected"
+                )
+            # Sync the inverter's clock to Home Assistant's current local time.
+            await c._client.one_shot_command(commands.set_system_date_time(dt_util.now()))
+
         async def handle_generate_dashboard(call: ServiceCall) -> None:
             from .dashboard import generate_dashboard
 
@@ -417,6 +429,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             DOMAIN,
             SERVICE_CALIBRATE_BATTERY_SOC,
             handle_calibrate_battery_soc,
+            SERVICE_DEVICE_SCHEMA,
+        )
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_SYSTEM_DATETIME,
+            handle_set_system_datetime,
             SERVICE_DEVICE_SCHEMA,
         )
         hass.services.async_register(
@@ -537,6 +555,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not hass.data.get(DOMAIN):
         hass.services.async_remove(DOMAIN, SERVICE_REBOOT_INVERTER)
         hass.services.async_remove(DOMAIN, SERVICE_CALIBRATE_BATTERY_SOC)
+        hass.services.async_remove(DOMAIN, SERVICE_SET_SYSTEM_DATETIME)
         hass.services.async_remove(DOMAIN, SERVICE_GENERATE_DASHBOARD)
         hass.services.async_remove(DOMAIN, SERVICE_CAPTURE_FRAMES)
         hass.services.async_remove(DOMAIN, SERVICE_REDETECT_PLANT)

--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -20,6 +20,7 @@ SERVICE_GENERATE_DASHBOARD = "generate_dashboard"
 SERVICE_CAPTURE_FRAMES = "capture_frames"
 SERVICE_REDETECT_PLANT = "redetect_plant"
 SERVICE_EXPOSE_RECOMMENDED_ENTITIES = "expose_recommended_entities"
+SERVICE_SET_SYSTEM_DATETIME = "set_system_datetime"
 
 # Curated headline entities for the expose_recommended_entities service.
 # Each value is an entity-description `key` (the suffix portion of unique_id).

--- a/custom_components/givenergy_local/services.yaml
+++ b/custom_components/givenergy_local/services.yaml
@@ -27,6 +27,21 @@ calibrate_battery_soc:
         device:
           integration: givenergy_local
 
+set_system_datetime:
+  name: Set inverter date & time
+  description: >
+    Sets the GivEnergy inverter's internal clock to Home Assistant's current
+    local time. Useful if the inverter's clock has drifted — it affects
+    charge/discharge slot scheduling.
+  fields:
+    device_id:
+      name: Device
+      description: The GivEnergy inverter whose clock to set.
+      required: true
+      selector:
+        device:
+          integration: givenergy_local
+
 capture_frames:
   name: Capture debug frames
   description: >

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,6 +24,7 @@ from custom_components.givenergy_local.const import (
     EXPOSE_RECOMMENDED_ENTITY_KEYS,
     SERVICE_EXPOSE_RECOMMENDED_ENTITIES,
     SERVICE_REDETECT_PLANT,
+    SERVICE_SET_SYSTEM_DATETIME,
 )
 
 
@@ -194,6 +195,21 @@ async def test_redetect_plant_service_clears_cache_and_reloads(
     store_factory.assert_called_with(hass, setup_integration.entry_id)
     fake_store.async_remove.assert_awaited_once()
     reload_mock.assert_called_with(setup_integration.entry_id)
+
+
+async def test_set_system_datetime_service_sends_command(hass, mock_client, setup_integration):
+    """The set_system_datetime service writes the inverter clock for the device."""
+    device_reg = dr.async_get(hass)
+    inverter_device = next(
+        d for d in device_reg.devices.values() if setup_integration.entry_id in d.config_entries
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_SYSTEM_DATETIME,
+        {"device_id": inverter_device.id},
+        blocking=True,
+    )
+    mock_client.one_shot_command.assert_called_once()
 
 
 async def test_topology_mismatch_persists_actual_and_raises_repairs_issue(


### PR DESCRIPTION
Part of #85.

Adds a `set_system_datetime` service that syncs the GivEnergy inverter's clock to Home Assistant's current local time (`set_system_date_time`). Targeted by `device_id`, mirroring the existing reboot / calibrate services.

The inverter clock drives charge/discharge slot scheduling, so a drifted clock misfires schedules — this gives a one-click resync.

- `const.py`: `SERVICE_SET_SYSTEM_DATETIME`
- `__init__.py`: handler (same connected-guard as the others) + register + unload-remove
- `services.yaml`: service definition (device selector)
- test: the service call sends the command for the device

150 tests pass; mypy-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
