### PR TITLE
feat(controls): gate AC-coupled battery limits to AC inverters

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.0a11,<3.0.0"
+    "givenergy-modbus>=2.1.0b2,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -99,6 +99,41 @@ NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
 )
 
 
+# --- AC-coupled-only controls (only created for AC-coupled inverters) ---
+
+# The AC charge/discharge power limits (HR313/314) are distinct from the DC-side
+# limits above (HR111/112) and are only meaningful on AC-coupled inverters.
+# Gated via PlantCapabilities.is_ac_coupled (and not is_three_phase — three-phase AC
+# remaps the read-back to different registers than the command writes; see modbus#75).
+# The setter rejects values below 1, hence the 1–100 range.
+AC_COUPLED_NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
+    GivEnergyNumberEntityDescription(
+        key="battery_charge_limit_ac",
+        name="Battery AC Charge Limit",
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=1,
+        native_max_value=100,
+        native_step=1,
+        mode=NumberMode.BOX,
+        value_fn=lambda inv: inv.battery_charge_limit_ac,
+        set_value_cmd=lambda v: commands.set_battery_charge_limit_ac(int(v)),
+        entity_category=EntityCategory.CONFIG,
+    ),
+    GivEnergyNumberEntityDescription(
+        key="battery_discharge_limit_ac",
+        name="Battery AC Discharge Limit",
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=1,
+        native_max_value=100,
+        native_step=1,
+        mode=NumberMode.BOX,
+        value_fn=lambda inv: inv.battery_discharge_limit_ac,
+        set_value_cmd=lambda v: commands.set_battery_discharge_limit_ac(int(v)),
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+
 # --- EMS plant-level per-slot SoC targets (only created for EMS plants) ---
 
 
@@ -157,6 +192,12 @@ async def async_setup_entry(
         entities.extend(
             GivEnergyEmsNumberEntity(coordinator, description)
             for description in EMS_NUMBER_DESCRIPTIONS
+        )
+    caps = coordinator.data.capabilities
+    if caps is not None and caps.is_ac_coupled and not caps.is_three_phase:
+        entities.extend(
+            GivEnergyNumberEntity(coordinator, description)
+            for description in AC_COUPLED_NUMBER_DESCRIPTIONS
         )
     async_add_entities(entities)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.0a11,<3.0.0",
+    "givenergy-modbus>=2.1.0b2,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,5 +1,8 @@
 """Tests for the GivEnergy Local number platform."""
 
+import pytest
+from givenergy_modbus.model.inverter import Model
+from givenergy_modbus.model.plant import PlantCapabilities
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.givenergy_local.const import DOMAIN
@@ -10,6 +13,10 @@ def _entity_id(hass, unique_id: str) -> str:
     entity_id = registry.async_get_entity_id("number", DOMAIN, unique_id)
     assert entity_id is not None, f"No number entity for unique_id={unique_id!r}"
     return entity_id
+
+
+def _maybe_entity_id(hass, unique_id: str) -> str | None:
+    return er.async_get(hass).async_get_entity_id("number", DOMAIN, unique_id)
 
 
 async def test_charge_target_soc_initial_value(hass, setup_integration):
@@ -48,5 +55,50 @@ async def test_set_active_power_rate_sends_command(hass, mock_client, setup_inte
     entity_id = _entity_id(hass, "SA1234G123_active_power_rate")
     await hass.services.async_call(
         "number", "set_value", {"entity_id": entity_id, "value": 90}, blocking=True
+    )
+    mock_client.one_shot_command.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC-coupled limits — only created for AC-coupled inverters (Model.AC)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def ac_coupled_setup(hass, mock_client, mock_plant, mock_inverter, mock_config_entry):
+    """Set up the integration with a single-phase AC-coupled plant."""
+    mock_plant.capabilities = PlantCapabilities(
+        device_type=Model.AC,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    mock_inverter.battery_charge_limit_ac = 50
+    mock_inverter.battery_discharge_limit_ac = 60
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
+
+
+async def test_ac_limits_absent_on_hybrid_plant(hass, setup_integration):
+    """The default fixture has device_type=Model.HYBRID — AC limits must not be created."""
+    assert _maybe_entity_id(hass, "SA1234G123_battery_charge_limit_ac") is None
+    assert _maybe_entity_id(hass, "SA1234G123_battery_discharge_limit_ac") is None
+
+
+async def test_ac_limits_present_on_ac_coupled_plant(hass, ac_coupled_setup):
+    state = hass.states.get(_entity_id(hass, "SA1234G123_battery_charge_limit_ac"))
+    assert state is not None
+    assert float(state.state) == 50.0
+    assert state.attributes["min"] == 1
+    assert state.attributes["max"] == 100
+
+
+async def test_set_ac_charge_limit_sends_command(hass, mock_client, ac_coupled_setup):
+    entity_id = _entity_id(hass, "SA1234G123_battery_charge_limit_ac")
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": entity_id, "value": 40}, blocking=True
     )
     mock_client.one_shot_command.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0a11,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0b2,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.0a11"
+version = "2.1.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/0c/bc8e6e58c49258dd2a3b5e1b72d657468fa00586c537143c9caca648f882/givenergy_modbus-2.1.0a11.tar.gz", hash = "sha256:549c3b20cb25258ea45613d7ecd4ee71117961156f1da24980baaba0676ddeaa", size = 264275, upload-time = "2026-05-31T13:44:08.381Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/7d/c6b34078db124a7424ee43adb70e2b76596d15cda20f5234b2f4ed993faa/givenergy_modbus-2.1.0b2.tar.gz", hash = "sha256:4f1531247e72179e374f016d2be267127a6a1435fba676a7504c40117afaad67", size = 273266, upload-time = "2026-05-31T19:19:35.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/ca/dcd35defe73bf0703b6686cb0d33ae805c93b27109a668c9d081ce9bdc90/givenergy_modbus-2.1.0a11-py3-none-any.whl", hash = "sha256:b761ddf7a3f33cba8063b1e6b04cc6d3ed96e86721ab422f9ca1ed90ed7b8623", size = 94755, upload-time = "2026-05-31T13:44:06.997Z" },
+    { url = "https://files.pythonhosted.org/packages/47/7c/b818c9a447ea87486acdb068450fee0aa45d70ccbf11dc78fdf4c2d8b065/givenergy_modbus-2.1.0b2-py3-none-any.whl", hash = "sha256:9033e11db57965936fcdbfd725bf813cd27bd382d9f3a54a0c1db31442ea3038", size = 98779, upload-time = "2026-05-31T19:19:33.952Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Exposes the AC-coupled battery charge/discharge power limits (HR313/314) as
`number` entities — gated to single-phase AC-coupled inverters.

## Why gated

These are distinct from the DC-side limits (HR111/112) and only meaningful on
AC-coupled inverters. Rather than hardcoding the model set here, the gate is
built on two topology properties added to givenergy-modbus in b2 (#152):
`PlantCapabilities.is_ac_coupled` and `is_three_phase`. The composite
`is_ac_coupled and not is_three_phase` covers single-phase AC while excluding
three-phase AC, whose read-back registers differ from what the current command
writes (tracked in modbus#75 — when that lands, the gate can relax to just
`is_ac_coupled`). Hybrid inverters — the common case — are unaffected.

## Also

- Range fixed to 1–100% (the setter rejects values below 1).
- Pin bumped to `givenergy-modbus>=2.1.0b2`.

## Caveat

No AC-coupled plant available for live validation. The capabilities gate
contains the risk (hybrid users unaffected); AC-coupled users can
self-validate. Tests cover both paths — absent on the hybrid default fixture,
present + sends the command on a `PlantCapabilities(device_type=Model.AC)`
fixture.

Resolves the AC-limit item in #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)