### PR TITLE
feat(controls): expose export priority and EPS for AC-coupled inverters

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.0b2,<3.0.0"
+    "givenergy-modbus>=2.1.0b3,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/select.py
+++ b/custom_components/givenergy_local/select.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from givenergy_modbus.client import commands
-from givenergy_modbus.model.battery import BatteryPauseMode
+from givenergy_modbus.model.battery import BatteryPauseMode, ExportPriority
 from givenergy_modbus.model.inverter import BatteryPowerMode
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -74,15 +74,56 @@ SELECT_DESCRIPTIONS: tuple[GivEnergySelectEntityDescription, ...] = (
 )
 
 
+# --- AC-coupled-only select controls ---
+
+# Export priority (HR311): only meaningful on AC-coupled inverters; three-phase AC
+# excluded pending per-model register work (modbus#75).
+_EXPORT_PRIORITY_LABELS: dict[ExportPriority, str] = {
+    ExportPriority.BATTERY_FIRST: "Battery First",
+    ExportPriority.GRID_FIRST: "Grid First",
+    ExportPriority.LOAD_FIRST: "Load First",
+}
+_EXPORT_PRIORITY_BY_LABEL: dict[str, ExportPriority] = {
+    v: k for k, v in _EXPORT_PRIORITY_LABELS.items()
+}
+
+
+def _export_priority_current_option(inv: InverterModel) -> str | None:
+    if inv.export_priority is None:
+        return None
+    return _EXPORT_PRIORITY_LABELS.get(ExportPriority(inv.export_priority))
+
+
+AC_COUPLED_SELECT_DESCRIPTIONS: tuple[GivEnergySelectEntityDescription, ...] = (
+    GivEnergySelectEntityDescription(
+        key="export_priority",
+        name="Export Priority",
+        options=list(_EXPORT_PRIORITY_BY_LABEL.keys()),
+        current_option_fn=_export_priority_current_option,
+        select_option_cmd=lambda option: commands.set_export_priority(
+            _EXPORT_PRIORITY_BY_LABEL[option]
+        ),
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: GivEnergyUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
+    entities: list[SelectEntity] = [
         GivEnergySelectEntity(coordinator, description) for description in SELECT_DESCRIPTIONS
-    )
+    ]
+    caps = coordinator.data.capabilities
+    if caps is not None and caps.is_ac_coupled and not caps.is_three_phase:
+        entities.extend(
+            GivEnergySelectEntity(coordinator, description)
+            for description in AC_COUPLED_SELECT_DESCRIPTIONS
+        )
+    async_add_entities(entities)
 
 
 class GivEnergySelectEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], SelectEntity):

--- a/custom_components/givenergy_local/switch.py
+++ b/custom_components/givenergy_local/switch.py
@@ -51,6 +51,22 @@ SWITCH_DESCRIPTIONS: tuple[GivEnergySwitchEntityDescription, ...] = (
 )
 
 
+# --- AC-coupled-only switches (only created for AC-coupled inverters) ---
+
+# EPS (HR317): only meaningful on AC-coupled inverters; three-phase AC excluded
+# pending per-model register work (modbus#75).
+AC_COUPLED_SWITCH_DESCRIPTIONS: tuple[GivEnergySwitchEntityDescription, ...] = (
+    GivEnergySwitchEntityDescription(
+        key="enable_eps",
+        name="Emergency Power Supply (EPS)",
+        is_on_fn=lambda inv: inv.enable_eps,
+        turn_on_cmd=lambda: commands.set_enable_eps(True),
+        turn_off_cmd=lambda: commands.set_enable_eps(False),
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+
 # --- EMS plant-level switches (only created for EMS plants) ---
 
 
@@ -82,6 +98,12 @@ async def async_setup_entry(
     entities: list[SwitchEntity] = [
         GivEnergySwitchEntity(coordinator, description) for description in SWITCH_DESCRIPTIONS
     ]
+    caps = coordinator.data.capabilities
+    if caps is not None and caps.is_ac_coupled and not caps.is_three_phase:
+        entities.extend(
+            GivEnergySwitchEntity(coordinator, description)
+            for description in AC_COUPLED_SWITCH_DESCRIPTIONS
+        )
     if coordinator.data.ems is not None:
         entities.extend(
             GivEnergyEmsSwitchEntity(coordinator, description)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.0b2,<3.0.0",
+    "givenergy-modbus>=2.1.0b3,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,5 +1,9 @@
 """Tests for the GivEnergy Local select platform."""
 
+import pytest
+from givenergy_modbus.model.battery import ExportPriority
+from givenergy_modbus.model.inverter import Model
+from givenergy_modbus.model.plant import PlantCapabilities
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.givenergy_local.const import DOMAIN
@@ -10,6 +14,10 @@ def _entity_id(hass, unique_id: str) -> str:
     entity_id = registry.async_get_entity_id("select", DOMAIN, unique_id)
     assert entity_id is not None, f"No select entity for unique_id={unique_id!r}"
     return entity_id
+
+
+def _maybe_entity_id(hass, unique_id: str) -> str | None:
+    return er.async_get(hass).async_get_entity_id("select", DOMAIN, unique_id)
 
 
 async def test_battery_power_mode_initial_option(hass, setup_integration):
@@ -65,6 +73,51 @@ async def test_select_pause_both_sends_command(hass, mock_client, setup_integrat
         "select",
         "select_option",
         {"entity_id": entity_id, "option": "Pause Both"},
+        blocking=True,
+    )
+    mock_client.one_shot_command.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC-coupled controls — only created for AC-coupled inverters (Model.AC)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def ac_coupled_setup(hass, mock_client, mock_plant, mock_inverter, mock_config_entry):
+    """Set up the integration with a single-phase AC-coupled plant."""
+    mock_plant.capabilities = PlantCapabilities(
+        device_type=Model.AC,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    mock_inverter.export_priority = ExportPriority.BATTERY_FIRST
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
+
+
+async def test_export_priority_absent_on_hybrid_plant(hass, setup_integration):
+    """The default fixture has device_type=Model.HYBRID — export priority must not be created."""
+    assert _maybe_entity_id(hass, "SA1234G123_export_priority") is None
+
+
+async def test_export_priority_present_on_ac_coupled_plant(hass, ac_coupled_setup):
+    state = hass.states.get(_entity_id(hass, "SA1234G123_export_priority"))
+    assert state is not None
+    assert state.state == "Battery First"
+    assert set(state.attributes["options"]) == {"Battery First", "Grid First", "Load First"}
+
+
+async def test_select_export_priority_sends_command(hass, mock_client, ac_coupled_setup):
+    entity_id = _entity_id(hass, "SA1234G123_export_priority")
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": entity_id, "option": "Grid First"},
         blocking=True,
     )
     mock_client.one_shot_command.assert_called_once()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,5 +1,8 @@
 """Tests for the GivEnergy Local switch platform."""
 
+import pytest
+from givenergy_modbus.model.inverter import Model
+from givenergy_modbus.model.plant import PlantCapabilities
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.givenergy_local.const import DOMAIN
@@ -10,6 +13,10 @@ def _entity_id(hass, unique_id: str) -> str:
     entity_id = registry.async_get_entity_id("switch", DOMAIN, unique_id)
     assert entity_id is not None, f"No switch entity for unique_id={unique_id!r}"
     return entity_id
+
+
+def _maybe_entity_id(hass, unique_id: str) -> str | None:
+    return er.async_get(hass).async_get_entity_id("switch", DOMAIN, unique_id)
 
 
 async def test_enable_charge_initial_state(hass, setup_integration):
@@ -42,4 +49,43 @@ async def test_enable_rtc_present_and_decodes(hass, setup_integration):
 async def test_toggle_rtc_sends_command(hass, mock_client, setup_integration):
     entity_id = _entity_id(hass, "SA1234G123_enable_rtc")
     await hass.services.async_call("switch", "turn_off", {"entity_id": entity_id}, blocking=True)
+    mock_client.one_shot_command.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC-coupled controls — only created for AC-coupled inverters (Model.AC)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def ac_coupled_setup(hass, mock_client, mock_plant, mock_inverter, mock_config_entry):
+    """Set up the integration with a single-phase AC-coupled plant."""
+    mock_plant.capabilities = PlantCapabilities(
+        device_type=Model.AC,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    mock_inverter.enable_eps = False
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
+
+
+async def test_enable_eps_absent_on_hybrid_plant(hass, setup_integration):
+    """The default fixture has device_type=Model.HYBRID — EPS must not be created."""
+    assert _maybe_entity_id(hass, "SA1234G123_enable_eps") is None
+
+
+async def test_enable_eps_present_on_ac_coupled_plant(hass, ac_coupled_setup):
+    state = hass.states.get(_entity_id(hass, "SA1234G123_enable_eps"))
+    assert state is not None
+    assert state.state == "off"
+
+
+async def test_turn_on_eps_sends_command(hass, mock_client, ac_coupled_setup):
+    entity_id = _entity_id(hass, "SA1234G123_enable_eps")
+    await hass.services.async_call("switch", "turn_on", {"entity_id": entity_id}, blocking=True)
     mock_client.one_shot_command.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0b2,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0b3,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.0b2"
+version = "2.1.0b3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/7d/c6b34078db124a7424ee43adb70e2b76596d15cda20f5234b2f4ed993faa/givenergy_modbus-2.1.0b2.tar.gz", hash = "sha256:4f1531247e72179e374f016d2be267127a6a1435fba676a7504c40117afaad67", size = 273266, upload-time = "2026-05-31T19:19:35.424Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/27/188c51063267d3283c9c9b76bf3735510141c4e46da16d15c436080b02df/givenergy_modbus-2.1.0b3.tar.gz", hash = "sha256:cd26914c34e7d35b93614d486699f2998b9437e58b55b0897b8583501cd539ad", size = 274582, upload-time = "2026-06-01T15:00:49.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/7c/b818c9a447ea87486acdb068450fee0aa45d70ccbf11dc78fdf4c2d8b065/givenergy_modbus-2.1.0b2-py3-none-any.whl", hash = "sha256:9033e11db57965936fcdbfd725bf813cd27bd382d9f3a54a0c1db31442ea3038", size = 98779, upload-time = "2026-05-31T19:19:33.952Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c9/2b8e9f25c3a5772831e8ea532ee4c873d51f674af90632a67952d4e66131/givenergy_modbus-2.1.0b3-py3-none-any.whl", hash = "sha256:3eb8470005c13626a075cb9d18a9abd229a4f20ce70ebd86ab94e6e3230707dd", size = 99735, upload-time = "2026-06-01T15:00:47.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Two new controls for AC-coupled inverters, both observed being written by
the GivEnergy portal during deliberate testing on real hardware (issue #52):

- `export_priority` — select entity with three options: Battery First, Grid
  First, Load First (HR311 via `set_export_priority`)
- `enable_eps` — switch entity for Emergency Power Supply mode (HR317 via
  `set_enable_eps`)

Both require givenergy-modbus >=2.1.0b3, which adds the commands, the
`ExportPriority` enum, and includes HR(300-359) in the `load_config` poll
block so these fields are read automatically.

## Gating

Same gate as the AC charge/discharge limits: `caps.is_ac_coupled and not
caps.is_three_phase`. Three-phase AC is excluded for now — pending per-model
register work in modbus#75, at which point the gate can relax to just
`is_ac_coupled`.

## Caveat

Not yet validated on live hardware — that's the next step once a reporter
with an AC-coupled plant picks up the pre-release. Tests cover both paths:
absent on the hybrid default fixture, present and command-sending on a
`PlantCapabilities(device_type=Model.AC)` fixture.

Bumps `givenergy-modbus` pin to `>=2.1.0b3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)