### PR TITLE
fix(setup): register the bundled card at component scope, not per entry

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.storage import Store
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -162,28 +163,45 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _async_register_frontend_card(hass: HomeAssistant) -> None:
-    """Serve and auto-load the bundled cell-heatmap card (once per instance).
+    """Serve and auto-load the bundled cell-heatmap card.
 
     The card module ships inside this integration's ``www/`` dir; we expose it
     at a stable URL and register it as an extra frontend module so the generated
     dashboard's ``custom:ge-cell-heatmap`` resolves on any dashboard without a
-    manual HACS/resource install. Guarded so repeat config entries don't
-    re-register the static path (which raises on a duplicate).
+    manual HACS/resource install.
+
+    Called once from :func:`async_setup` (component scope), so the static-path
+    registration happens a single time for the integration regardless of how
+    many inverters/EMS config entries exist — no per-entry race on the shared URL.
     """
-    data = hass.data.setdefault(DOMAIN, {})
-    if data.get("_frontend_registered"):
-        return
     if hass.http is None:
         # http isn't initialised (e.g. the test harness has no web server). In
         # production it's a bootstrap dependency and always present, so this only
         # skips where there is nothing to serve from anyway.
         return
-    card_path = Path(__file__).parent / "www" / _CARD_FILENAME
-    await hass.http.async_register_static_paths(
-        [StaticPathConfig(_CARD_URL, str(card_path), False)]
-    )
-    add_extra_js_url(hass, f"{_CARD_URL}?v={_CARD_VERSION}")
-    data["_frontend_registered"] = True
+    try:
+        card_path = Path(__file__).parent / "www" / _CARD_FILENAME
+        await hass.http.async_register_static_paths(
+            [StaticPathConfig(_CARD_URL, str(card_path), False)]
+        )
+        add_extra_js_url(hass, f"{_CARD_URL}?v={_CARD_VERSION}")
+    except Exception as exc:  # noqa: BLE001
+        # The bundled card is cosmetic (a dashboard heatmap). Registering it once
+        # at component scope means a failure here is genuinely unexpected, but it
+        # must still never take down the integration — log and carry on.
+        _LOGGER.warning("Could not register the bundled cell-heatmap card: %s", exc)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Integration-wide setup, run once before any config entry.
+
+    The bundled frontend card is an integration-level singleton (one JS module,
+    one custom element), so it's registered here rather than per config entry —
+    which previously raced on the shared static path when several entries set up
+    concurrently.
+    """
+    await _async_register_frontend_card(hass)
+    return True
 
 
 # External HACS cards the generated dashboard depends on (the bundled
@@ -216,8 +234,6 @@ async def _missing_dashboard_cards(hass: HomeAssistant) -> list[str]:
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    await _async_register_frontend_card(hass)
-
     # Persisted topology lets the coordinator skip the cold-detect sweep on
     # most reconnects/restarts. Client.detect(prior=...) accepts the cached
     # topology as a hint and only re-probes slots the prior asserts non-empty;

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -80,16 +80,26 @@ async def test_frontend_card_served_and_autoloaded():
     add_js.assert_called_once_with(hass, f"{_CARD_URL}?v={_CARD_VERSION}")
 
 
-async def test_frontend_card_registered_at_component_scope_only():
-    """Registration lives in async_setup (once per integration), not in
-    async_setup_entry — so multi-inverter/EMS installs can't race on the shared
-    static path (regression for hass#52)."""
-    import inspect
+async def test_frontend_card_registered_once_across_multiple_entries(hass, mock_client):
+    """With several config entries (multi-inverter / EMS), the card still registers
+    exactly once — it lives at component scope (async_setup), not per entry, so the
+    entries can't race on the shared static path (regression for hass#52). Under the
+    old per-entry registration this fires once per entry."""
+    entries = [
+        MockConfigEntry(
+            domain=DOMAIN,
+            data={"host": f"192.168.1.{n}", "port": 8899, "scan_interval": 30},
+            unique_id=f"entry-{n}",
+        )
+        for n in (10, 11, 12)
+    ]
+    with patch("custom_components.givenergy_local._async_register_frontend_card") as mock_register:
+        for entry in entries:
+            entry.add_to_hass(hass)
+            assert await hass.config_entries.async_setup(entry.entry_id) is True
+        await hass.async_block_till_done()
 
-    from custom_components.givenergy_local import async_setup_entry
-
-    assert "_async_register_frontend_card" not in inspect.getsource(async_setup_entry)
-    assert "_async_register_frontend_card" in inspect.getsource(async_setup)
+    mock_register.assert_called_once()
 
 
 async def test_frontend_card_skipped_when_http_unavailable():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,8 +14,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.givenergy_local import (
     _CARD_URL,
     _CARD_VERSION,
-    _async_register_frontend_card,
     _missing_dashboard_cards,
+    async_setup,
 )
 from custom_components.givenergy_local.const import (
     CONF_RETRIES,
@@ -65,20 +65,31 @@ async def test_missing_dashboard_cards_swallows_registry_errors():
     assert await _missing_dashboard_cards(hass) == []
 
 
-async def test_frontend_card_served_and_autoloaded_once():
-    """The bundled heatmap card is served + auto-loaded, exactly once."""
+async def test_frontend_card_served_and_autoloaded():
+    """The bundled heatmap card is served + auto-loaded at component setup."""
     hass = MagicMock()
     hass.data = {}
     hass.http.async_register_static_paths = AsyncMock()
 
     with patch("custom_components.givenergy_local.add_extra_js_url") as add_js:
-        await _async_register_frontend_card(hass)
-        await _async_register_frontend_card(hass)  # idempotent: must no-op
+        assert await async_setup(hass, {}) is True
 
     hass.http.async_register_static_paths.assert_awaited_once()
     (paths,) = hass.http.async_register_static_paths.call_args[0]
     assert paths[0].url_path == _CARD_URL
     add_js.assert_called_once_with(hass, f"{_CARD_URL}?v={_CARD_VERSION}")
+
+
+async def test_frontend_card_registered_at_component_scope_only():
+    """Registration lives in async_setup (once per integration), not in
+    async_setup_entry — so multi-inverter/EMS installs can't race on the shared
+    static path (regression for hass#52)."""
+    import inspect
+
+    from custom_components.givenergy_local import async_setup_entry
+
+    assert "_async_register_frontend_card" not in inspect.getsource(async_setup_entry)
+    assert "_async_register_frontend_card" in inspect.getsource(async_setup)
 
 
 async def test_frontend_card_skipped_when_http_unavailable():
@@ -88,7 +99,19 @@ async def test_frontend_card_skipped_when_http_unavailable():
     hass.http = None
 
     with patch("custom_components.givenergy_local.add_extra_js_url") as add_js:
-        await _async_register_frontend_card(hass)
+        assert await async_setup(hass, {}) is True
+
+    add_js.assert_not_called()
+
+
+async def test_frontend_card_failure_does_not_break_setup():
+    """A registration error must be swallowed so component setup still succeeds."""
+    hass = MagicMock()
+    hass.data = {}
+    hass.http.async_register_static_paths = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch("custom_components.givenergy_local.add_extra_js_url") as add_js:
+        assert await async_setup(hass, {}) is True  # must not raise
 
     add_js.assert_not_called()
 


### PR DESCRIPTION
## Problem

On HA restart, users with multiple config entries (e.g. several inverters plus
an EMS) saw a random subset of entries fail to set up with:

    RuntimeError: Added route will never be executed, method GET is already registered

recovering only on a manual reload. Reported on #52.

## Cause

`_async_register_frontend_card` ran from `async_setup_entry` (once per entry)
and registered a shared static path for the bundled heatmap card. The
`_frontend_registered` guard was set *after* the `await`, so concurrent entry
setups all passed the guard before any claimed it, and the second onwards hit
the duplicate-route error — which aborts that entry's setup.

## Fix

The card is an integration-wide singleton (one JS file, one `ge-cell-heatmap`
custom element), so it belongs at component scope. Register it once from a new
`async_setup()` instead of per config entry:

- removes the race by construction — `async_setup` runs a single time, before
  any entry, so there's no concurrency on the shared URL and no guard flag
- a genuine registration failure is logged and swallowed, never breaking setup

## Tests

- card is served + auto-loaded from `async_setup`
- registration lives in `async_setup`, not `async_setup_entry` (guards the
  regression structurally)
- http-unavailable and registration-failure paths both leave setup succeeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)