### PR TITLE
fix(sensor): reconcile battery-energy sensors with renamed library fields

### DIFF
--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -331,12 +331,14 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         value_fn=lambda inv: inv.t_battery,
     ),
     GivEnergyInverterSensorDescription(
+        # key kept (unique_id suffix); the library field was renamed to
+        # e_battery_charge_today, routed per-model, in givenergy-modbus #76.
         key="e_battery_charge_day",
         name="Battery Charge Today",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda inv: inv.e_battery_charge_day,
+        value_fn=lambda inv: inv.e_battery_charge_today,
     ),
     GivEnergyInverterSensorDescription(
         key="e_battery_discharge_day",
@@ -344,7 +346,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda inv: inv.e_battery_discharge_day,
+        value_fn=lambda inv: inv.e_battery_discharge_today,
     ),
     GivEnergyInverterSensorDescription(
         key="e_battery_throughput",
@@ -532,41 +534,25 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda inv: inv.e_discharge_year,
     ),
-    # --- Alternate battery energy registers (present on some models only) ---
+    # --- Lifetime battery energy totals (routed per-model in givenergy-modbus
+    # #76; return None on models with no known total register — e.g. AC-coupled
+    # — so they're skipped there rather than shown blank). ---
     GivEnergyInverterSensorDescription(
-        key="e_battery_charge_alt",
-        name="Battery Alt Charge Total",
+        key="e_battery_charge_total",
+        name="Battery Charge Total",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda inv: inv.e_battery_charge_alt,
+        value_fn=lambda inv: inv.e_battery_charge_total,
         skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
-        key="e_battery_discharge_alt",
-        name="Battery Alt Discharge Total",
+        key="e_battery_discharge_total",
+        name="Battery Discharge Total",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda inv: inv.e_battery_discharge_alt,
-        skip_if_none=True,
-    ),
-    GivEnergyInverterSensorDescription(
-        key="e_battery_charge_day_alt",
-        name="Battery Alt Charge Today",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda inv: inv.e_battery_charge_day_alt,
-        skip_if_none=True,
-    ),
-    GivEnergyInverterSensorDescription(
-        key="e_battery_discharge_day_alt",
-        name="Battery Alt Discharge Today",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda inv: inv.e_battery_discharge_day_alt,
+        value_fn=lambda inv: inv.e_battery_discharge_total,
         skip_if_none=True,
     ),
     # --- Solar diverter ---
@@ -640,10 +626,10 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         native_unit_of_measurement=UnitOfTime.HOURS,
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        # Library key is work_time_total_hours (uint32, whole hours); this sensor
-        # reads the alias, so set 0 explicitly rather than deriving.
+        # Library field is work_time_total_hours (uint32, whole hours); the bare
+        # work_time_total alias is deprecated (#84) and slated for removal in 3.0.
         suggested_display_precision=0,
-        value_fn=lambda inv: inv.work_time_total,
+        value_fn=lambda inv: inv.work_time_total_hours,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     GivEnergyInverterSensorDescription(

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -536,9 +536,12 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
     ),
     # --- Lifetime battery energy totals (routed per-model in givenergy-modbus
     # #76; return None on models with no known total register — e.g. AC-coupled
-    # — so they're skipped there rather than shown blank). ---
+    # — so they're skipped there rather than shown blank). Keys retain the older
+    # `*_alt` suffix to preserve unique_ids for installs that already created
+    # these entities; only the value_fn (renamed library field) and display name
+    # change. ---
     GivEnergyInverterSensorDescription(
-        key="e_battery_charge_total",
+        key="e_battery_charge_alt",
         name="Battery Charge Total",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
@@ -547,7 +550,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
-        key="e_battery_discharge_total",
+        key="e_battery_discharge_alt",
         name="Battery Discharge Total",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
@@ -37,6 +38,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import GivEnergyUpdateCoordinator, InverterModel
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -536,12 +539,12 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
     ),
     # --- Lifetime battery energy totals (routed per-model in givenergy-modbus
     # #76; return None on models with no known total register — e.g. AC-coupled
-    # — so they're skipped there rather than shown blank). Keys retain the older
-    # `*_alt` suffix to preserve unique_ids for installs that already created
-    # these entities; only the value_fn (renamed library field) and display name
-    # change. ---
+    # — so they're skipped there rather than shown blank). These replace the
+    # provisional `e_battery_*_alt` sensors, which were an anomaly: their keys
+    # change, so any pre-existing "Battery Alt …" entities orphan and the user
+    # removes them. Acceptable churn at this pre-release stage. ---
     GivEnergyInverterSensorDescription(
-        key="e_battery_charge_alt",
+        key="e_battery_charge_total",
         name="Battery Charge Total",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
@@ -550,7 +553,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
-        key="e_battery_discharge_alt",
+        key="e_battery_discharge_total",
         name="Battery Discharge Total",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
@@ -959,6 +962,30 @@ COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
 )
 
 
+def _include_inverter_sensor(
+    description: GivEnergyInverterSensorDescription, inverter: InverterModel
+) -> bool:
+    """Whether to create an inverter sensor at setup.
+
+    `skip_if_none` descriptions have their `value_fn` evaluated eagerly here, so a
+    single bad descriptor — e.g. a library field renamed out from under us — must
+    not be allowed to raise and abort the *entire* sensor platform (which is how a
+    field rename in givenergy-modbus once dropped every sensor). Guard the call:
+    skip the offending sensor with a warning, but keep the rest.
+    """
+    if not description.skip_if_none:
+        return True
+    try:
+        return description.value_fn(inverter) is not None
+    except Exception:  # noqa: BLE001 - one bad descriptor must not sink the platform
+        _LOGGER.warning(
+            "Skipping sensor %s: its value_fn raised at setup (library field drift?)",
+            description.key,
+            exc_info=True,
+        )
+        return False
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -970,7 +997,7 @@ async def async_setup_entry(
     entities: list[SensorEntity] = [
         GivEnergyInverterSensor(coordinator, description)
         for description in INVERTER_SENSORS
-        if not description.skip_if_none or description.value_fn(inverter) is not None
+        if _include_inverter_sensor(description, inverter)
     ]
 
     for battery_index, battery in enumerate(coordinator.data.batteries):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def mock_inverter() -> MagicMock:
     inv.model = MagicMock()
     inv.model.name = "HYBRID"
     inv.firmware_version = "D0.19-A0.21"
-    inv.work_time_total = 36055  # hours of operation (raw register unit)
+    inv.work_time_total_hours = 36055  # hours of operation (raw register unit)
     inv.p_pv.return_value = 2500
     inv.p_pv1 = 1500
     inv.p_pv2 = 1000
@@ -54,8 +54,12 @@ def mock_inverter() -> MagicMock:
     inv.v_battery = 52.4
     inv.i_battery = 9.54
     inv.t_battery = 22.5
-    inv.e_battery_charge_day = 8.2
-    inv.e_battery_discharge_day = 3.1
+    # Canonical battery-energy field names (givenergy-modbus #76). Mirror the
+    # real model so the mock can't fabricate fields the sensors then break on.
+    inv.e_battery_charge_today = 8.2
+    inv.e_battery_discharge_today = 3.1
+    inv.e_battery_charge_total = 980.5
+    inv.e_battery_discharge_total = 845.1
     inv.e_battery_throughput = 1250.3
     inv.p_grid_out = -800
     inv.e_grid_out_day = 2.1

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -40,6 +40,30 @@ def test_status_value_fn_renders_when_present():
     assert _inverter_desc("status").value_fn(inv) == "normal"
 
 
+def test_inverter_value_fns_resolve_against_real_model():
+    """Every INVERTER_SENSORS value_fn must resolve against a REAL inverter model,
+    not just the MagicMock fixture (which fabricates any attribute and so masks
+    field drift vs givenergy-modbus). Regression for the rc8 breakage where the
+    library renamed battery-energy fields (#76) and the skip_if_none setup filter
+    raised AttributeError, taking down the whole sensor platform.
+
+    Mirrors the eager filter in sensor.async_setup_entry, then exercises every
+    value_fn (the native_value path) — both must run without raising on a
+    cold, all-None model.
+    """
+    from givenergy_modbus.model.inverter import SinglePhaseInverter
+
+    inv = SinglePhaseInverter()  # all fields None, like a pre-first-poll model
+
+    # The setup-time filter evaluates skip_if_none value_fns eagerly; a field the
+    # library no longer exposes would raise AttributeError here.
+    [d for d in INVERTER_SENSORS if not d.skip_if_none or d.value_fn(inv) is not None]
+
+    # And the native_value path for every sensor must resolve too.
+    for d in INVERTER_SENSORS:
+        d.value_fn(inv)
+
+
 def _entity_id(hass, platform: str, unique_id: str) -> str:
     registry = er.async_get(hass)
     entity_id = registry.async_get_entity_id(platform, DOMAIN, unique_id)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,6 +9,8 @@ from custom_components.givenergy_local.sensor import (
     BATTERY_SENSORS,
     COORDINATOR_SENSORS,
     INVERTER_SENSORS,
+    GivEnergyInverterSensorDescription,
+    _include_inverter_sensor,
 )
 
 
@@ -62,6 +64,31 @@ def test_inverter_value_fns_resolve_against_real_model():
     # And the native_value path for every sensor must resolve too.
     for d in INVERTER_SENSORS:
         d.value_fn(inv)
+
+
+def test_setup_filter_skips_bad_descriptor_instead_of_crashing():
+    """A skip_if_none descriptor whose value_fn raises must be skipped (logged),
+    not propagate — so one bad descriptor can't take down the whole platform the
+    way the renamed-field bug did. A healthy descriptor is still included."""
+
+    def _boom(_inv):
+        raise AttributeError("field renamed out from under us")
+
+    bad = GivEnergyInverterSensorDescription(
+        key="bad", name="Bad", value_fn=_boom, skip_if_none=True
+    )
+    good = GivEnergyInverterSensorDescription(
+        key="good", name="Good", value_fn=lambda _inv: 1.0, skip_if_none=True
+    )
+    plain = GivEnergyInverterSensorDescription(
+        key="plain", name="Plain", value_fn=_boom, skip_if_none=False
+    )
+
+    inv = MagicMock()
+    assert _include_inverter_sensor(bad, inv) is False  # skipped, no raise
+    assert _include_inverter_sensor(good, inv) is True
+    # non-skip descriptors aren't evaluated at setup, so they're always included
+    assert _include_inverter_sensor(plain, inv) is True
 
 
 def _entity_id(hass, platform: str, unique_id: str) -> str:


### PR DESCRIPTION
## Problem

On a real inverter with the current `givenergy-modbus >=2.1.0b3` pin, the
**entire sensor platform fails to load** — no PV/battery/grid/load/temperature
sensors at all.

## Cause

givenergy-modbus #76 (first in b1) renamed the battery-energy fields
(`e_battery_charge_day` → `e_battery_charge_today`) and removed the interim
`e_battery_*_alt` fields in favour of routed `e_battery_charge_total` /
`e_battery_discharge_total`. `sensor.py` still referenced the old names. The
`skip_if_none` filter in `async_setup_entry` evaluates `value_fn(inverter)`
eagerly, so the first dead `*_alt` field raised `AttributeError` and aborted the
whole sensor list comprehension.

rc7 (pinned `a11`, pre-#76) was unaffected; **rc8's bump to b3 introduced it**
(rc8 has since been pulled). The `MagicMock` inverter fixture fabricates any
attribute, which is why tests, CI, and review never caught the drift.

## Fix

- Daily sensors → canonical `e_battery_charge_today` / `e_battery_discharge_today`
  (**keys unchanged** — existing entities preserved).
- Four dead `*_alt` descriptions → two canonical totals,
  `e_battery_charge_total` / `e_battery_discharge_total` (`skip_if_none`; return
  `None` and skip on models with no total register, e.g. AC-coupled).
- Uptime sensor → `work_time_total_hours` (the bare alias is deprecated, #84).

## Hardening

- conftest mock inverter now uses the canonical field names.
- New regression test builds a **real** `SinglePhaseInverter` and exercises the
  setup filter + every `value_fn` — the drift guard the `MagicMock` can't give.

## Notes

- Removing the `*_alt` sensors changes their entity keys (`alt` → `total`); any
  pre-existing "Battery Alt …" entities orphan (cosmetic, were provisional).
- AC-coupled plants (e.g. the #52 reporter's) get their sensor platform back, but
  the charge/discharge **totals** still read `None` there until the library adds
  AC total-register routing — a separate modbus follow-up tied to the pending
  register probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Battery Charge Total and Battery Discharge Total sensors for lifetime energy tracking across inverter operation.

* **Bug Fixes**
  * Corrected daily battery charge and discharge sensor field mappings for accurate readings.
  * Fixed Work Time Total sensor backing field reference.

* **Improvements**
  * Enhanced sensor reliability with improved handling of unavailable data across different inverter models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->