### PR TITLE
fix(coordinator): load on a usable cold-seed partial instead of bricking

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -271,10 +271,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Seed the cache on cold start (no prior loaded). Warm-hit doesn't need a
     # write — the prior we just loaded is what's on the wire. Mismatch is
     # already covered by _on_topology_changed having saved exc.actual.
+    #
+    # Only persist a CLEAN seed: if the seed poll was partial (last_partial_failures
+    # non-empty), the integration still loads (coordinator serves the partial), but
+    # we don't commit a possibly-degraded topology to disk — flaky kit could
+    # otherwise vanish permanently on the next warm start. A permanently-partial
+    # plant re-detects fresh each cold start and self-heals to a clean persist once
+    # the read succeeds.
     if (
         prior_capabilities is None
         and coordinator.data is not None
         and coordinator.data.capabilities is not None
+        and not coordinator.last_partial_failures
     ):
         await _save_capabilities(hass, entry.entry_id, coordinator.data.capabilities)
 

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -280,7 +280,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # the read succeeds.
     if (
         prior_capabilities is None
-        and coordinator.data is not None
         and coordinator.data.capabilities is not None
         and not coordinator.last_partial_failures
     ):

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -133,16 +133,32 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
             return plant
         except RefreshPartiallySucceeded as exc:
             if reconnecting:
-                # No reliable per-device fallback on a (re)connect seed: a
-                # half-populated initial plant (the dropped device reads
-                # "unknown") is worse than a clean full retry. detect() already
-                # gated device presence, so a partial seed is most likely a
-                # transient hiccup on a present device. Route through the same
-                # tolerance gate as a timeout — serves last-known data on an
-                # in-process reconnect, or raises UpdateFailed (→
-                # ConfigEntryNotReady) on a cold start so HA retries setup.
+                if self.data is None and exc.plant.inverter_serial_number:
+                    # Cold start with an identified inverter: serve the partial so
+                    # the integration *loads* (the failed reads' entities go
+                    # unavailable — a structurally-absent block like AC-config on a
+                    # hybrid, or a flaky device) instead of looping forever in
+                    # ConfigEntryNotReady. Those entities recover automatically if a
+                    # later poll reads them. _record_partial sets
+                    # last_partial_failures, which also blocks the cold-start
+                    # capabilities persist in __init__ — never commit a degraded
+                    # topology to disk.
+                    self._record_partial(exc)
+                    self._mark_success(exc.plant)
+                    return exc.plant
+                # Either an in-process reconnect (serve last-known within the
+                # tolerance window — unchanged) or a cold start too sparse to set up
+                # at all (no inverter identity → raise → ConfigEntryNotReady, retry).
                 self._record_failure()
-                return await self._serve_last_known_or_fail("Partial data on (re)connect seed", exc)
+                failure_summary = ", ".join(
+                    f"{'HR' if 'Holding' in f.request_type else 'IR'}({f.base_register})"
+                    f" on device 0x{f.device_address:02x}"
+                    for f in exc.failures
+                )
+                return await self._serve_last_known_or_fail(
+                    f"Partial data on (re)connect seed: {failure_summary}",
+                    exc,
+                )
             # Steady state: serve the partial. The dropped device's last-known
             # register values ride along (frozen) while the rest stay fresh —
             # this is the behaviour change #125 buys us (one offline battery no

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.0b3,<3.0.0"
+    "givenergy-modbus>=2.1.0b8,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.0b3,<3.0.0",
+    "givenergy-modbus>=2.1.0b8,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -412,10 +412,10 @@ async def test_clean_poll_clears_stale_partial_detail(hass, mock_plant):
     assert coordinator.partial_failures == 1  # counter is cumulative, retained
 
 
-async def test_partial_on_cold_seed_raises_update_failed(hass, mock_plant):
-    """A partial on a cold (re)connect seed (no prior data) must NOT be served —
-    it fails so HA retries setup (→ ConfigEntryNotReady) rather than locking in a
-    half-populated initial plant."""
+async def test_partial_on_cold_seed_with_identity_serves(hass, mock_plant):
+    """A partial on a cold seed whose inverter identified itself (serial present) is
+    SERVED, so the integration loads — the failed reads' entities go unavailable
+    rather than the whole integration looping in ConfigEntryNotReady."""
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
 
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
@@ -424,12 +424,36 @@ async def test_partial_on_cold_seed_raises_update_failed(hass, mock_plant):
         client.plant = mock_plant
         client.refresh = AsyncMock(side_effect=_partial(mock_plant))
         mock_cls.return_value = client
-        # _client is None → reconnecting=True, and coordinator.data is None (cold).
+        # _client is None → reconnecting=True, coordinator.data is None (cold),
+        # mock_plant.inverter_serial_number is set → usable.
 
-        with pytest.raises(UpdateFailed):
+        result = await coordinator._async_update_data()
+
+    assert result is mock_plant  # served the partial, not a fail-hard
+    assert coordinator.partial_failures == 1
+    assert coordinator.consecutive_failures == 0  # served counts as success
+    assert coordinator.last_partial_failures  # set → blocks the cold-start persist
+    assert coordinator._client is client  # kept
+
+
+async def test_partial_on_cold_seed_without_identity_raises(hass, mock_plant):
+    """A cold-seed partial too sparse to set up (the inverter didn't even identify
+    itself) still fails so HA retries setup (→ ConfigEntryNotReady), and the message
+    names the failed register block."""
+    mock_plant.inverter_serial_number = None  # not identifiable → unusable seed
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.refresh = AsyncMock(side_effect=_partial(mock_plant))
+        mock_cls.return_value = client
+
+        with pytest.raises(UpdateFailed, match=r"on device 0x34"):
             await coordinator._async_update_data()
 
-    # Counted as a hard failure, not a partial; client reset for a clean retry.
+    # Fail-hard, not counted as a partial; client reset for a clean retry.
     assert coordinator.partial_failures == 0
     assert coordinator.total_failures == 1
     assert coordinator.consecutive_failures == 1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -311,6 +311,45 @@ async def test_cold_start_saves_capabilities_on_first_successful_refresh(
     save_mock.assert_awaited_with(hass, mock_config_entry.entry_id, mock_client.plant.capabilities)
 
 
+async def test_cold_start_skips_capabilities_persist_on_partial_seed(
+    hass, mock_client, mock_config_entry
+):
+    """A partial cold seed still loads the integration (the inverter identified
+    itself), but its possibly-degraded topology must NOT be persisted — otherwise
+    flaky kit could vanish permanently on the next warm start."""
+    from givenergy_modbus.exceptions import ReadFailure, RefreshPartiallySucceeded
+
+    failure = ReadFailure(
+        device_address=0x31,
+        request_type="ReadHoldingRegisters",
+        base_register=300,
+        register_count=60,
+    )
+    mock_client.refresh = AsyncMock(
+        side_effect=RefreshPartiallySucceeded(
+            "partial seed",
+            plant=mock_client.plant,
+            failures=[failure],
+            cause=ExceptionGroup("reads", [TimeoutError()]),
+        )
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.givenergy_local._load_capabilities",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("custom_components.givenergy_local._save_capabilities", new=AsyncMock()) as save_mock,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Loaded (served the partial), but topology deliberately not committed.
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    save_mock.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Capabilities Store helper unit tests
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0b3,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0b8,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.0b3"
+version = "2.1.0b8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/27/188c51063267d3283c9c9b76bf3735510141c4e46da16d15c436080b02df/givenergy_modbus-2.1.0b3.tar.gz", hash = "sha256:cd26914c34e7d35b93614d486699f2998b9437e58b55b0897b8583501cd539ad", size = 274582, upload-time = "2026-06-01T15:00:49.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/f1/7e0591607d64eb65817e0b5ba60f2588130d3cbb8d6c7022f847ffab367c/givenergy_modbus-2.1.0b8.tar.gz", hash = "sha256:50e8ee9906f87693669a9696c33888b03ef804d16834c471b39189c487ddaddf", size = 279884, upload-time = "2026-06-02T00:48:03.349Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/c9/2b8e9f25c3a5772831e8ea532ee4c873d51f674af90632a67952d4e66131/givenergy_modbus-2.1.0b3-py3-none-any.whl", hash = "sha256:3eb8470005c13626a075cb9d18a9abd229a4f20ce70ebd86ab94e6e3230707dd", size = 99735, upload-time = "2026-06-01T15:00:47.885Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ac/d0d1161fc5c8a1143fa2d5223525d712ab3fc021b9d0bd404b796e002801/givenergy_modbus-2.1.0b8-py3-none-any.whl", hash = "sha256:de4ad83efc0a6652f2817eda0e9d362ba4b61cfac7916a320beb7960f2d82c32", size = 106213, upload-time = "2026-06-02T00:48:01.88Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

On rc10 (modbus b3+), a HYBRID_GEN1 inverter loops permanently in
`ConfigEntryNotReady` and exposes **no** entities. The library polls the
HR(300–359) AC-config block (added in b3) on all non-EMS models, but a hybrid
doesn't have those registers, so the read times out → a partial seed → the
coordinator fails-hard → setup retries forever.

## Root cause

The (re)connect-seed policy treats **any** partial as a transient hiccup that a
clean retry will fix. For a **structural** gap (register block absent on this
model) the retry never succeeds, so a single optional block bricks the whole
integration — discarding PV/battery/grid/load data that came back fine.

## Fix

A cold seed whose inverter **identified itself** (serial present — the floor for
building devices/entities) is now **served**: the integration loads, and the
failed reads' entities go unavailable (recovering automatically if a later poll
reads them) rather than bricking everything. A seed too sparse to set up at all
(no inverter identity) still fails-hard and retries; the message now names the
failed register block for self-diagnosis.

In-process reconnect (tolerance window) and steady-state partials are unchanged.

This is the **defensive** half — it stops *any* optional block (not just HR300)
from bricking setup. The **root-cause** fix for this specific case is already
done library-side: modbus #162 gates the HR(300–359) poll on `is_ac_coupled`
(released in b7/b8), so a hybrid no longer polls the block at all. rc11 carries
both (this PR + a pin bump to `>=2.1.0b8`).

## Guardrails (raised in review of the approach)

- **Don't persist a degraded topology.** The cold-start capabilities save is
  gated on a *clean* seed (`last_partial_failures` empty), so flaky equipment
  can't get baked out of the cached topology and vanish on the next warm start.
  A permanently-partial plant re-detects fresh each start and self-heals once
  the read succeeds.
- **Retry vs give up.** hass keeps polling the failed block — transient failures
  recover automatically; structural ones stay unavailable (honest surface).
  "Stop polling a block that doesn't exist on this model" belongs in the library
  — done in modbus #162.
- **Manual escape hatch.** The existing `redetect_plant` service clears the
  cached topology and forces a fresh cold `detect()` — the user-facing recovery
  lever for the out-of-scope cases below (e.g. a topology that did get persisted
  degraded via another path).

## Follow-ups (not this PR)

- `detect()` itself silently dropping a flaky *device* (→ reduced capabilities,
  possibly persisted via the `PlantTopologyMismatch` path) is detect-robustness,
  a library/modbus#106 concern — not addressed here.
- A real per-bank essential/tolerable hierarchy (vs the minimal "inverter
  identity = required" floor here) belongs in the library / modbus#106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)