### PR TITLE
fix: gate AC-config controls on has_ac_config_block (AIO support)

### DIFF
--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -99,13 +99,14 @@ NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
 )
 
 
-# --- AC-coupled-only controls (only created for AC-coupled inverters) ---
+# --- AC-config-block controls (AC-coupled inverters + single-phase All-in-One) ---
 
 # The AC charge/discharge power limits (HR313/314) are distinct from the DC-side
-# limits above (HR111/112) and are only meaningful on AC-coupled inverters.
-# Gated via PlantCapabilities.is_ac_coupled (and not is_three_phase — three-phase AC
-# remaps the read-back to different registers than the command writes; see modbus#75).
-# The setter rejects values below 1, hence the 1–100 range.
+# limits above (HR111/112) and are only meaningful on models that expose the
+# AC-config register block (HR300+). Gated via PlantCapabilities.has_ac_config_block
+# (and not is_three_phase — three-phase AC remaps the read-back to different registers
+# than the command writes; see modbus#75). The setter rejects values below 1, hence the
+# 1–100 range.
 AC_COUPLED_NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
     GivEnergyNumberEntityDescription(
         key="battery_charge_limit_ac",
@@ -194,7 +195,7 @@ async def async_setup_entry(
             for description in EMS_NUMBER_DESCRIPTIONS
         )
     caps = coordinator.data.capabilities
-    if caps is not None and caps.is_ac_coupled and not caps.is_three_phase:
+    if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
         entities.extend(
             GivEnergyNumberEntity(coordinator, description)
             for description in AC_COUPLED_NUMBER_DESCRIPTIONS

--- a/custom_components/givenergy_local/select.py
+++ b/custom_components/givenergy_local/select.py
@@ -74,10 +74,10 @@ SELECT_DESCRIPTIONS: tuple[GivEnergySelectEntityDescription, ...] = (
 )
 
 
-# --- AC-coupled-only select controls ---
+# --- AC-config-block select controls (AC-coupled inverters + single-phase All-in-One) ---
 
-# Export priority (HR311): only meaningful on AC-coupled inverters; three-phase AC
-# excluded pending per-model register work (modbus#75).
+# Export priority (HR311): only meaningful on models exposing the AC-config block;
+# three-phase AC excluded pending per-model register work (modbus#75).
 _EXPORT_PRIORITY_LABELS: dict[ExportPriority, str] = {
     ExportPriority.BATTERY_FIRST: "Battery First",
     ExportPriority.GRID_FIRST: "Grid First",
@@ -118,7 +118,7 @@ async def async_setup_entry(
         GivEnergySelectEntity(coordinator, description) for description in SELECT_DESCRIPTIONS
     ]
     caps = coordinator.data.capabilities
-    if caps is not None and caps.is_ac_coupled and not caps.is_three_phase:
+    if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
         entities.extend(
             GivEnergySelectEntity(coordinator, description)
             for description in AC_COUPLED_SELECT_DESCRIPTIONS

--- a/custom_components/givenergy_local/switch.py
+++ b/custom_components/givenergy_local/switch.py
@@ -51,10 +51,10 @@ SWITCH_DESCRIPTIONS: tuple[GivEnergySwitchEntityDescription, ...] = (
 )
 
 
-# --- AC-coupled-only switches (only created for AC-coupled inverters) ---
+# --- AC-config-block switches (AC-coupled inverters + single-phase All-in-One) ---
 
-# EPS (HR317): only meaningful on AC-coupled inverters; three-phase AC excluded
-# pending per-model register work (modbus#75).
+# EPS (HR317): only meaningful on models exposing the AC-config block; three-phase AC
+# excluded pending per-model register work (modbus#75).
 AC_COUPLED_SWITCH_DESCRIPTIONS: tuple[GivEnergySwitchEntityDescription, ...] = (
     GivEnergySwitchEntityDescription(
         key="enable_eps",
@@ -99,7 +99,7 @@ async def async_setup_entry(
         GivEnergySwitchEntity(coordinator, description) for description in SWITCH_DESCRIPTIONS
     ]
     caps = coordinator.data.capabilities
-    if caps is not None and caps.is_ac_coupled and not caps.is_three_phase:
+    if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
         entities.extend(
             GivEnergySwitchEntity(coordinator, description)
             for description in AC_COUPLED_SWITCH_DESCRIPTIONS

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -128,5 +128,5 @@ async def aio_setup(hass, mock_client, mock_plant, mock_inverter, mock_config_en
 
 async def test_ac_limits_present_on_all_in_one_plant(hass, aio_setup):
     """AIO exposes the AC-config block, so the AC limits must be created."""
-    assert _maybe_entity_id(hass, "SA1234G123_battery_charge_limit_ac") is not None
-    assert _maybe_entity_id(hass, "SA1234G123_battery_discharge_limit_ac") is not None
+    _entity_id(hass, "SA1234G123_battery_charge_limit_ac")
+    _entity_id(hass, "SA1234G123_battery_discharge_limit_ac")

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -60,7 +60,7 @@ async def test_set_active_power_rate_sends_command(hass, mock_client, setup_inte
 
 
 # ---------------------------------------------------------------------------
-# AC-coupled limits — only created for AC-coupled inverters (Model.AC)
+# AC-config-block limits — created for AC-coupled inverters and single-phase AIO
 # ---------------------------------------------------------------------------
 
 
@@ -102,3 +102,31 @@ async def test_set_ac_charge_limit_sends_command(hass, mock_client, ac_coupled_s
         "number", "set_value", {"entity_id": entity_id, "value": 40}, blocking=True
     )
     mock_client.one_shot_command.assert_called_once()
+
+
+@pytest.fixture
+async def aio_setup(hass, mock_client, mock_plant, mock_inverter, mock_config_entry):
+    """Set up the integration with a single-phase All-in-One plant.
+
+    AIO exposes the AC-config register block (HR300+) despite not being AC-coupled,
+    so the AC limits must be created — gated on has_ac_config_block, not is_ac_coupled.
+    """
+    mock_plant.capabilities = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    mock_inverter.battery_charge_limit_ac = 50
+    mock_inverter.battery_discharge_limit_ac = 60
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
+
+
+async def test_ac_limits_present_on_all_in_one_plant(hass, aio_setup):
+    """AIO exposes the AC-config block, so the AC limits must be created."""
+    assert _maybe_entity_id(hass, "SA1234G123_battery_charge_limit_ac") is not None
+    assert _maybe_entity_id(hass, "SA1234G123_battery_discharge_limit_ac") is not None

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -146,4 +146,4 @@ async def aio_setup(hass, mock_client, mock_plant, mock_inverter, mock_config_en
 
 async def test_export_priority_present_on_all_in_one_plant(hass, aio_setup):
     """AIO exposes the AC-config block, so export priority must be created."""
-    assert _maybe_entity_id(hass, "SA1234G123_export_priority") is not None
+    _entity_id(hass, "SA1234G123_export_priority")

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -79,7 +79,7 @@ async def test_select_pause_both_sends_command(hass, mock_client, setup_integrat
 
 
 # ---------------------------------------------------------------------------
-# AC-coupled controls — only created for AC-coupled inverters (Model.AC)
+# AC-config-block controls — created for AC-coupled inverters and single-phase AIO
 # ---------------------------------------------------------------------------
 
 
@@ -121,3 +121,29 @@ async def test_select_export_priority_sends_command(hass, mock_client, ac_couple
         blocking=True,
     )
     mock_client.one_shot_command.assert_called_once()
+
+
+@pytest.fixture
+async def aio_setup(hass, mock_client, mock_plant, mock_inverter, mock_config_entry):
+    """Set up the integration with a single-phase All-in-One plant.
+
+    AIO exposes the AC-config register block (HR300+) despite not being AC-coupled,
+    so export priority must be created — gated on has_ac_config_block, not is_ac_coupled.
+    """
+    mock_plant.capabilities = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    mock_inverter.export_priority = ExportPriority.BATTERY_FIRST
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
+
+
+async def test_export_priority_present_on_all_in_one_plant(hass, aio_setup):
+    """AIO exposes the AC-config block, so export priority must be created."""
+    assert _maybe_entity_id(hass, "SA1234G123_export_priority") is not None

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -114,4 +114,4 @@ async def aio_setup(hass, mock_client, mock_plant, mock_inverter, mock_config_en
 
 async def test_enable_eps_present_on_all_in_one_plant(hass, aio_setup):
     """AIO exposes the AC-config block, so EPS must be created."""
-    assert _maybe_entity_id(hass, "SA1234G123_enable_eps") is not None
+    _entity_id(hass, "SA1234G123_enable_eps")

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -53,7 +53,7 @@ async def test_toggle_rtc_sends_command(hass, mock_client, setup_integration):
 
 
 # ---------------------------------------------------------------------------
-# AC-coupled controls — only created for AC-coupled inverters (Model.AC)
+# AC-config-block controls — created for AC-coupled inverters and single-phase AIO
 # ---------------------------------------------------------------------------
 
 
@@ -89,3 +89,29 @@ async def test_turn_on_eps_sends_command(hass, mock_client, ac_coupled_setup):
     entity_id = _entity_id(hass, "SA1234G123_enable_eps")
     await hass.services.async_call("switch", "turn_on", {"entity_id": entity_id}, blocking=True)
     mock_client.one_shot_command.assert_called_once()
+
+
+@pytest.fixture
+async def aio_setup(hass, mock_client, mock_plant, mock_inverter, mock_config_entry):
+    """Set up the integration with a single-phase All-in-One plant.
+
+    AIO exposes the AC-config register block (HR300+) despite not being AC-coupled,
+    so EPS must be created — gated on has_ac_config_block, not is_ac_coupled.
+    """
+    mock_plant.capabilities = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    mock_inverter.enable_eps = False
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
+
+
+async def test_enable_eps_present_on_all_in_one_plant(hass, aio_setup):
+    """AIO exposes the AC-config block, so EPS must be created."""
+    assert _maybe_entity_id(hass, "SA1234G123_enable_eps") is not None


### PR DESCRIPTION
The EPS, export-priority and AC charge/discharge-limit controls read from the
HR300+ AC-config block. That block also exists on single-phase All-in-One
inverters, but the gate keyed on `is_ac_coupled`, so AIO owners didn't get
controls their hardware actually supports.

This swaps the gate in number/switch/select to `has_ac_config_block`
(added on `PlantCapabilities` in modbus b8, already pinned on main), keeping
`and not is_three_phase` so AC_3PH stays excluded until the per-model
register remap lands (modbus#75).

Capability matrix after the change:

| Model | has_ac_config_block | is_three_phase | AC-config controls |
|-------|--------------------|----------------|--------------------|
| HYBRID | False | False | no (unchanged) |
| AC | True | False | yes (unchanged) |
| AC_3PH | True | True | no (unchanged) |
| ALL_IN_ONE | True | False | **yes (new)** |

Tests: added an AIO presence case to each of test_number/switch/select; the
existing absent-on-hybrid / present-on-AC cases are unchanged. Full suite
green (178), mypy at baseline.

This is a stopgap until modbus#106's typed-device reorg gives a cleaner
per-model control surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)