### PR TITLE
fix: stop a slow BMS dropping a battery on detect; tidy service selectors

### DIFF
--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -41,6 +41,14 @@ _FULL_REFRESH_INTERVAL = 300  # seconds (~5 minutes)
 # flood the log. The cumulative partial_failures counter/sensor is unaffected.
 _PARTIAL_LOG_EVERY = 20
 
+# Per-slot probe budget for detect()'s peripheral sweep (batteries, meters).
+# More generous than the library defaults (0.5s / 1 retry): the battery sweep
+# breaks at the first non-responding slot, so a transiently slow BMS can
+# truncate the whole chain. The break means at most one empty slot is probed,
+# so the extra latency is bounded to ~one slow probe per detect.
+PROBE_TIMEOUT_SECONDS = 1.0
+PROBE_RETRIES = 3
+
 
 class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
     """Wraps a long-lived Modbus Client, polling the inverter on a fixed interval.
@@ -355,7 +363,20 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         self._client = Client(host=self.host, port=self.port)
         await self._client.connect()
         try:
-            await self._client.detect(prior=self._prior_capabilities)
+            # The library's battery sweep probes additional packs (0x33+) with a
+            # stingy default budget (probe_timeout=0.5s, probe_retries=1) and
+            # BREAKS at the first non-responding slot — so a single transiently
+            # slow BMS during a reconnect truncates the whole battery chain, and
+            # that reduced topology then gets persisted (a 2nd battery silently
+            # vanished after a reconnect this way). Because of the break, a detect
+            # probes at most one empty slot, so a generous probe budget costs only
+            # ~one extra slow probe on a cold sweep — cheap insurance against
+            # dropping a real pack.
+            await self._client.detect(
+                prior=self._prior_capabilities,
+                probe_timeout=PROBE_TIMEOUT_SECONDS,
+                probe_retries=PROBE_RETRIES,
+            )
         except PlantTopologyMismatch as exc:
             _LOGGER.warning(
                 "Plant topology has changed since last seen — accepting new layout "

--- a/custom_components/givenergy_local/services.yaml
+++ b/custom_components/givenergy_local/services.yaml
@@ -11,6 +11,8 @@ reboot_inverter:
       selector:
         device:
           integration: givenergy_local
+          entity:
+            domain: number
 
 calibrate_battery_soc:
   name: Calibrate battery state of charge
@@ -26,6 +28,8 @@ calibrate_battery_soc:
       selector:
         device:
           integration: givenergy_local
+          entity:
+            domain: number
 
 set_system_datetime:
   name: Set inverter date & time
@@ -41,6 +45,8 @@ set_system_datetime:
       selector:
         device:
           integration: givenergy_local
+          entity:
+            domain: number
 
 capture_frames:
   name: Capture debug frames
@@ -59,6 +65,8 @@ capture_frames:
       selector:
         device:
           integration: givenergy_local
+          entity:
+            domain: number
     duration:
       name: Duration (seconds)
       description: How long to capture frames for. Defaults to 60 seconds.
@@ -87,6 +95,8 @@ expose_recommended_entities:
       selector:
         device:
           integration: givenergy_local
+          entity:
+            domain: number
     assistants:
       name: Assistants
       description: >
@@ -119,6 +129,8 @@ redetect_plant:
       selector:
         device:
           integration: givenergy_local
+          entity:
+            domain: number
 
 generate_dashboard:
   name: Generate dashboard

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -17,6 +17,8 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.givenergy_local.coordinator import (
     _PARTIAL_LOG_EVERY,
+    PROBE_RETRIES,
+    PROBE_TIMEOUT_SECONDS,
     GivEnergyUpdateCoordinator,
 )
 
@@ -905,7 +907,9 @@ async def test_connect_passes_prior_capabilities_to_detect(hass, mock_plant):
 
         await coordinator._connect()
 
-    client.detect.assert_awaited_once_with(prior=prior)
+    client.detect.assert_awaited_once_with(
+        prior=prior, probe_timeout=PROBE_TIMEOUT_SECONDS, probe_retries=PROBE_RETRIES
+    )
 
 
 async def test_connect_passes_none_prior_when_no_cache(hass, mock_plant):
@@ -921,7 +925,9 @@ async def test_connect_passes_none_prior_when_no_cache(hass, mock_plant):
 
         await coordinator._connect()
 
-    client.detect.assert_awaited_once_with(prior=None)
+    client.detect.assert_awaited_once_with(
+        prior=None, probe_timeout=PROBE_TIMEOUT_SECONDS, probe_retries=PROBE_RETRIES
+    )
 
 
 async def test_topology_mismatch_accepts_actual_and_invokes_callback(hass, mock_plant):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -307,7 +307,8 @@ async def test_cold_start_saves_capabilities_on_first_successful_refresh(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    mock_client.detect.assert_awaited_once_with(prior=None)
+    mock_client.detect.assert_awaited_once()
+    assert mock_client.detect.await_args.kwargs["prior"] is None
     save_mock.assert_awaited_with(hass, mock_config_entry.entry_id, mock_client.plant.capabilities)
 
 


### PR DESCRIPTION
Two fixes from diagnosing a live report where a second battery (DZ2228G532)
silently disappeared and stayed gone across restarts.

## Root cause

`detect()`'s battery sweep reads pack #1 (0x32) with the robust `timeout/retries`
budget, but probes each *additional* pack (0x33+) with the library's stingy
defaults (`probe_timeout=0.5s`, `probe_retries=1`) and **breaks at the first
non-responding slot**. So a single transiently slow BMS during a reconnect
truncates the whole battery chain. That reduced one-battery topology then gets
persisted (a clean detect, no partial failure — so the #97 guard doesn't catch
it), and `detect(prior=…)` trusts it forever without re-probing the empty slot.

Confirmed live: the pack reported normally until a single clean transition at
the moment of an update's reconnect, then stayed unavailable for days; no
`plant_topology_changed` repair (the cold-detect persist path, not the mismatch
path). `redetect_plant` recovered it immediately, which validated the diagnosis.

## Fixes

1. **Widen the probe budget** at our `detect()` call to `probe_timeout=1.0s`,
   `probe_retries=3`. Because the sweep breaks at the first miss, a detect probes
   at most one empty slot, so the added latency is bounded to ~one slow probe per
   cold detect — cheap insurance against dropping a real pack. Also protects the
   warm/hinted path, where a transient miss would otherwise raise
   `PlantTopologyMismatch` and persist the reduced topology.

2. **Scope the service device selectors** for the six inverter-targeted services
   to `entity: domain: number` (the inverter/EMS controller has number entities,
   batteries don't), so battery devices no longer clutter those pickers.

## Notes

- This is the detect-robustness gap flagged as out-of-scope in the #97 plan.
- The library already exposed the probe knobs, so no modbus change is needed.
- Tests: the two exact-kwargs `detect()` assertions updated to expect the probe
  budget; the cold-start init test relaxed to assert `prior is None` without
  coupling to the constants. Full suite green (178), mypy at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device detection now supports configurable timeout and retry settings for improved control during peripheral sweep operations.

* **Bug Fixes**
  * Service selectors now properly constrain device selection to display only relevant entity types.

* **Tests**
  * Updated test coverage to verify detection configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->