### PR TITLE
fix(deps): bump givenergy-modbus to 2.1.0b10

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.0b8,<3.0.0"
+    "givenergy-modbus>=2.1.0b10,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.0b8,<3.0.0",
+    "givenergy-modbus>=2.1.0b10,<3.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0b8,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0b10,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.0b8"
+version = "2.1.0b10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/f1/7e0591607d64eb65817e0b5ba60f2588130d3cbb8d6c7022f847ffab367c/givenergy_modbus-2.1.0b8.tar.gz", hash = "sha256:50e8ee9906f87693669a9696c33888b03ef804d16834c471b39189c487ddaddf", size = 279884, upload-time = "2026-06-02T00:48:03.349Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/be/64ae2a01243dbc66cc2a7a28000af183dfc7332b84ad657ad55716bf7c71/givenergy_modbus-2.1.0b10.tar.gz", hash = "sha256:a8dca0a5bcf1d34b38c21cf4c87ef01eb2c71ce76d1d5da86f79dc36364cbda1", size = 286338, upload-time = "2026-06-02T10:48:11.002Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/ac/d0d1161fc5c8a1143fa2d5223525d712ab3fc021b9d0bd404b796e002801/givenergy_modbus-2.1.0b8-py3-none-any.whl", hash = "sha256:de4ad83efc0a6652f2817eda0e9d362ba4b61cfac7916a320beb7960f2d82c32", size = 106213, upload-time = "2026-06-02T00:48:01.88Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c8/63d61c600229f51a20b562325ff55d1cb24b1acd932f98d120b99e527a9f/givenergy_modbus-2.1.0b10-py3-none-any.whl", hash = "sha256:1fbba08da12ed4556ec051c468e43f0b72fda4208cfa91c677ee365110a34571", size = 111075, upload-time = "2026-06-02T10:48:09.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated bump triggered by [givenergy-modbus@2.1.0b10](https://github.com/dewet22/givenergy-modbus/releases/tag/v2.1.0b10).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the givenergy-modbus library dependency to require a newer minimum version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->