### PR TITLE
fix(deps): bump givenergy-modbus to 2.1.1

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.0b15,<3.0.0"
+    "givenergy-modbus>=2.1.1,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.0b15,<3.0.0",
+    "givenergy-modbus>=2.1.1,<3.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0b15,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.1,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.0b15"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/0a/bb111b797b67ded19147a45cfc0997a724f21c11093eb248e7c79bb15416/givenergy_modbus-2.1.0b15.tar.gz", hash = "sha256:47b5975aa5de6bfb20f48b3d04dfc64c60a015b5b3ef48b797883754ccfd830a", size = 296678, upload-time = "2026-06-02T14:41:10.831Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/0f/1e12e9950bdf0c230fe60e07b2e463689b78f3b2108fc4900e0fc3429d15/givenergy_modbus-2.1.1.tar.gz", hash = "sha256:150139f20dae16c53055aefea663669c75bced2ebffb1822501cc51933f4f052", size = 300945, upload-time = "2026-06-02T22:29:24.275Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/3d/da0d01d16661f7f150bb60b224daf0fc1d2dda8a3614d3ae4f99915a4ab0/givenergy_modbus-2.1.0b15-py3-none-any.whl", hash = "sha256:db370b4bb4ed7cfdb1ecd79869ddd68b41518467da4401ec0b99bf97c92bbe04", size = 117830, upload-time = "2026-06-02T14:41:09.318Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9d/910699aa247a8ca56d9f42e0acaca633576ed2955ad4894dbf8dbf131475/givenergy_modbus-2.1.1-py3-none-any.whl", hash = "sha256:5b14fb6e98b5ad00b7bdd76e41c38303938d6a644284f4a6fe2d32f3b92a6f3f", size = 120103, upload-time = "2026-06-02T22:29:22.595Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated bump triggered by [givenergy-modbus@2.1.1](https://github.com/dewet22/givenergy-modbus/releases/tag/v2.1.1).