### PR TITLE
feat: House Consumption Today + correct the load mislabel (modbus 2.1.1)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -233,6 +233,37 @@ async def _missing_dashboard_cards(hass: HomeAssistant) -> list[str]:
     return [card for card in _REQUIRED_HACS_CARDS if card not in urls]
 
 
+# unique_id suffixes renamed in givenergy-modbus #174 (2.1.1). The old data is
+# valid — IR35 was always AC charge, merely mislabelled "load" — so re-point the
+# existing registry entry to the new unique_id, carrying its history, statistics
+# and customisations across rather than orphaning it and starting fresh.
+_RENAMED_UNIQUE_ID_SUFFIXES = {
+    "e_load_day": "e_ac_charge_today",
+}
+
+
+def _migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Re-point entities registered under a renamed unique_id suffix in place."""
+    registry = er.async_get(hass)
+    for ent in er.async_entries_for_config_entry(registry, entry.entry_id):
+        for old, new in _RENAMED_UNIQUE_ID_SUFFIXES.items():
+            if not ent.unique_id.endswith(f"_{old}"):
+                continue
+            new_uid = ent.unique_id[: -len(old)] + new
+            if registry.async_get_entity_id(ent.domain, DOMAIN, new_uid):
+                # Target already exists (already migrated, or a genuine collision)
+                # — don't clobber it; leave the old entry for manual cleanup.
+                _LOGGER.debug(
+                    "Skipping unique_id migration for %s: %s already exists",
+                    ent.entity_id,
+                    new_uid,
+                )
+                break
+            _LOGGER.info("Migrating unique_id %s -> %s", ent.unique_id, new_uid)
+            registry.async_update_entity(ent.entity_id, new_unique_id=new_uid)
+            break
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Persisted topology lets the coordinator skip the cold-detect sweep on
     # most reconnects/restarts. Client.detect(prior=...) accepts the cached
@@ -286,6 +317,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await _save_capabilities(hass, entry.entry_id, coordinator.data.capabilities)
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    # Re-point any entities under renamed unique_ids before the platforms create
+    # them, so the existing entity (and its history) is reused rather than orphaned.
+    _migrate_unique_ids(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -43,9 +43,9 @@ EXPOSE_RECOMMENDED_ENTITY_KEYS = (
     "e_grid_out_day",
     "e_grid_in_total",
     "e_grid_out_total",
-    # Load
+    # Load / Consumption
     "p_load_demand",
-    "e_load_day",
+    "e_consumption_today",
     # Inverter output
     "e_inverter_out_total",
     # Health — entity description's `key` is "status"; `inverter_status` is

--- a/custom_components/givenergy_local/dashboard.py
+++ b/custom_components/givenergy_local/dashboard.py
@@ -9,7 +9,7 @@ import yaml
 # Increment whenever the generated YAML layout changes in a meaningful way.
 # __init__.py compares this against the last-generated version stored in HA's
 # persistent Store and raises a Repairs issue when they diverge.
-DASHBOARD_VERSION = 5
+DASHBOARD_VERSION = 6
 
 
 class _NoAliasDumper(yaml.SafeDumper):
@@ -194,7 +194,7 @@ def _overview_view(inv: str, max_power_kw: int) -> str:
             name: Imported
           - entity: {_i(inv, "grid_export_today")}
             name: Exported
-          - entity: {_i(inv, "load_energy_today")}
+          - entity: {_i(inv, "house_consumption_today")}
             name: Consumed
 
       - type: custom:apexcharts-card
@@ -253,7 +253,7 @@ def _energy_view(inv: str) -> str:
         graph_span: 30d
         series:
 {col_series(_i(inv, "pv_energy_today"), "PV Generated", "#FFB300")}
-{col_series(_i(inv, "load_energy_today"), "Consumed", "#EF5350")}
+{col_series(_i(inv, "house_consumption_today"), "Consumed", "#EF5350")}
 
       - type: custom:apexcharts-card
         header:

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.0,<3.0.0"
+    "givenergy-modbus>=2.1.1,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -490,20 +490,43 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         value_fn=lambda inv: inv.p_load_demand,
     ),
     GivEnergyInverterSensorDescription(
-        key="e_load_day",
-        name="Load Energy Today",
+        # Derived house consumption (single-phase only) — matches the GE app's
+        # "Consumption today". Single-phase inverters expose no consumption
+        # register; givenergy-modbus computes it (PV gen + grid-in − grid-out −
+        # AC-charge). Three-phase has no such field, so skip_if_none drops it
+        # there (and the value_fn getattr keeps it None-safe).
+        key="e_consumption_today",
+        name="House Consumption Today",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda inv: inv.e_load_day,
+        value_fn=lambda inv: getattr(inv, "e_consumption_today", None),
+        skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
+        # Renamed from "Load Energy Today" / e_load_day (givenergy-modbus #174):
+        # IR35 was a GivTCP-era mislabel — it has always been AC charge, not house
+        # load. A unique_id migration in __init__.py carries the existing history
+        # across so it lands under the correct name.
+        key="e_ac_charge_today",
+        name="AC Charge Today",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda inv: inv.e_ac_charge_today,
+    ),
+    GivEnergyInverterSensorDescription(
+        # NB: givenergy-modbus #174 found IR44 is PV generation, not inverter AC
+        # output, and renamed the field e_inverter_out_day -> e_pv_generation_today.
+        # We HOLD the entity rename (key/name) until the matching *total* (IR45/46)
+        # is verified and renamed too, so today+total move together — but read the
+        # new field name directly to avoid the deprecation warning on every poll.
         key="e_inverter_out_day",
         name="Inverter Output Today",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda inv: inv.e_inverter_out_day,
+        value_fn=lambda inv: inv.e_pv_generation_today,
     ),
     GivEnergyInverterSensorDescription(
         key="e_inverter_out_total",

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -492,7 +492,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
     GivEnergyInverterSensorDescription(
         # Derived house consumption (single-phase only) — matches the GE app's
         # "Consumption today". Single-phase inverters expose no consumption
-        # register; givenergy-modbus computes it (PV gen + grid-in − grid-out −
+        # register; givenergy-modbus computes it (PV gen + grid-in - grid-out -
         # AC-charge). Three-phase has no such field, so skip_if_none drops it
         # there (and the value_fn getattr keeps it None-safe).
         key="e_consumption_today",

--- a/dashboard/template.yaml
+++ b/dashboard/template.yaml
@@ -65,7 +65,7 @@ views:
             name: Imported
           - entity: sensor.givenergy_inverter_INVERTER_SERIAL_grid_export_today
             name: Exported
-          - entity: sensor.givenergy_inverter_INVERTER_SERIAL_load_energy_today
+          - entity: sensor.givenergy_inverter_INVERTER_SERIAL_house_consumption_today
             name: Consumed
 
       - type: custom:apexcharts-card
@@ -106,7 +106,7 @@ views:
             statistics:
               type: max
               period: day
-          - entity: sensor.givenergy_inverter_INVERTER_SERIAL_load_energy_today
+          - entity: sensor.givenergy_inverter_INVERTER_SERIAL_house_consumption_today
             name: Consumed
             color: "#EF5350"
             type: column

--- a/docs/migration-from-givtcp.md
+++ b/docs/migration-from-givtcp.md
@@ -49,7 +49,7 @@ Suffixes shown are after stripping the integration prefix and the inverter/batte
 | ✅ | `import_energy_total_kwh` | `grid_import_total` | Grid import lifetime |
 | ✅ | `invertor_energy_today_kwh` | `inverter_output_today` | Inverter AC output today |
 | ✅ | `invertor_energy_total_kwh` | `inverter_output_total` | Inverter AC output lifetime |
-| ✅ | `load_energy_today_kwh` | `load_energy_today` | House load today |
+| ✅ | `load_energy_today_kwh` | `house_consumption_today` | House consumption today (the integration's derived consumption — givenergy-modbus #174; the old `load_energy_today` was a mislabel that read ~0) |
 | ✅ | `pv_energy_today_kwh` | `pv_energy_today` | Solar generation today |
 | ✅ | `pv_energy_total_kwh` | `pv_energy_total` | Solar generation lifetime |
 | ⚠️ | `ac_charge_energy_total_kwh` | `charge_from_grid_total` | Live values disagree by ~36× (25.5 kWh vs 0.7 kWh). Likely reads a different register block, or has been reset more recently. |
@@ -413,4 +413,3 @@ Three viable paths:
 - **(c) Document the limitation** and let users decide per-entity.
 
 Option (b) is the cleanest long-term answer but depends on upstream work.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.0,<3.0.0",
+    "givenergy-modbus>=2.1.1,<3.0.0",
 ]
 
 [dependency-groups]

--- a/scripts/migrate_from_givtcp.py
+++ b/scripts/migrate_from_givtcp.py
@@ -120,7 +120,7 @@ INVERTER_PAIRS: list[tuple[str, str, str, bool]] = [
     # consumption. The old givenergy_local "load_energy_today" (e_load_day/IR35)
     # was a mislabel that read ~0, so this pair was excluded. givenergy-modbus
     # #174 added the real derived figure, surfaced as house_consumption_today —
-    # the correct target. Both are PV + grid-in − grid-out − AC-charge, so they
+    # the correct target. Both are PV + grid-in - grid-out - AC-charge, so they
     # align; validate the overlap before an --apply.
     ("load_energy_today_kwh", "house_consumption_today", "House consumption today", True),
     # ⚠️  Diverged — the two integrations read different register blocks for this
@@ -472,6 +472,92 @@ async def migrate_entity(
 # ---------------------------------------------------------------------------
 
 
+def _print_cutover_suggestion(last_givtcp: date | None, first_ge: date | None) -> None:
+    """Print the detected dates and a suggested --cutover (auto-detect mode)."""
+    print("  Last GivTCP data point  :", last_givtcp or "not found")
+    print("  First givenergy_local   :", first_ge or "not found")
+    print()
+    if last_givtcp and first_ge:
+        # Suggest the later of the two dates — the tail of the overlap window. The
+        # boundary is midnight at the *start* of this date, so GivTCP history
+        # through the previous day is migrated and GE takes over from 00:00 on the
+        # suggested date regardless of when GivTCP actually stopped that day.
+        suggested = max(last_givtcp, first_ge)
+        print(f"  Suggested --cutover date: {suggested}")
+        print()
+        print(f"  GivTCP data through {suggested - timedelta(days=1)} 23:59 UTC → migrated")
+        print(f"  givenergy_local data from {suggested} 00:00 UTC    → kept")
+        print(f"  givenergy_local data before {suggested} 00:00 UTC  → discarded")
+        print()
+        print("  Rerun with --cutover YYYY-MM-DD to preview the migration,")
+        print("  then add --apply to write the changes.")
+    elif last_givtcp:
+        print("  givenergy_local has no statistics yet — install it and let it")
+        print("  run for at least one full day before migrating.")
+    else:
+        print("  GivTCP statistics not found. Nothing to migrate.")
+
+
+def _build_plan(
+    inv_serials: list[str],
+    batt_serials: list[str],
+    meta_by_id: dict[str, dict[str, Any]],
+    include_charge_from_grid: bool,
+) -> list[tuple[str, str, str, str, bool]]:
+    """Construct the per-entity migration plan from the detected serials."""
+    plan: list[tuple[str, str, str, str, bool]] = []
+    for sn in inv_serials:
+        for gt_sfx, ge_sfx, desc, default in INVERTER_PAIRS:
+            if not default and not include_charge_from_grid:
+                continue
+            givtcp_id = f"sensor.givtcp_{sn}_{gt_sfx}"
+            ge_id = f"sensor.givenergy_inverter_{sn}_{ge_sfx}"
+            unit = meta_by_id.get(ge_id, {}).get("unit_of_measurement") or "kWh"
+            plan.append((givtcp_id, ge_id, desc, unit, not default))
+    for sn in batt_serials:
+        for gt_sfx, ge_sfx, desc, fallback_unit in BATTERY_PAIRS:
+            givtcp_id = f"sensor.givtcp_{sn}_{gt_sfx}"
+            ge_id = f"sensor.givenergy_battery_{sn}_{ge_sfx}"
+            unit = meta_by_id.get(ge_id, {}).get("unit_of_measurement") or fallback_unit
+            plan.append((givtcp_id, ge_id, desc, unit, False))
+    return plan
+
+
+def _print_summary(results: list[MigrationResult], applying: bool) -> int:
+    """Print the results table + counts; return the process exit code."""
+    width = 46
+    print()
+    print("─" * 88)
+    print(f"  {'Sensor':<{width}} {'GivTCP':>8} {'GE pre':>7} {'GE post':>8}  Result")
+    print("─" * 88)
+    for r in results:
+        warn_tag = (
+            "  ⚠️  verify values" if r.warn_diverged and r.status in ("migrated", "dry_run") else ""
+        )
+        print(
+            f"  {r.description:<{width}} {r.givtcp_rows:>8} {r.ge_pre_rows:>7}"
+            f" {r.ge_post_rows:>8}  {r.status}{warn_tag}"
+        )
+    print("─" * 88)
+
+    migrated = sum(1 for r in results if r.status == "migrated")
+    planned = sum(1 for r in results if r.status == "dry_run")
+    skipped = sum(1 for r in results if r.status == "no_givtcp_data")
+    errored = sum(1 for r in results if r.status == "error")
+
+    if not applying:
+        print(f"\n  Planned: {planned}  |  No GivTCP data: {skipped}  |  Errors: {errored}")
+        print("  Add --apply to write changes (back up your DB first).")
+    else:
+        print(f"\n  Migrated: {migrated}  |  No GivTCP data: {skipped}  |  Errors: {errored}")
+
+    for r in results:
+        if r.status == "error":
+            print(f"\n  ERROR — {r.description}: {r.error}", file=sys.stderr)
+
+    return 0 if errored == 0 else 2
+
+
 async def run(args: argparse.Namespace) -> int:
     applying = args.apply
 
@@ -515,29 +601,7 @@ async def run(args: argparse.Namespace) -> int:
         last_givtcp, first_ge = await detect_cutover(ws, inv_serials[0])
         print("done")
         print()
-        print("  Last GivTCP data point  :", last_givtcp or "not found")
-        print("  First givenergy_local   :", first_ge or "not found")
-        print()
-        if last_givtcp and first_ge:
-            # Suggest the later of the two dates — the tail of the overlap
-            # window. The boundary is midnight at the *start* of this date,
-            # so GivTCP history through the previous day is migrated and GE
-            # takes over from 00:00 on the suggested date regardless of when
-            # GivTCP actually stopped that day.
-            suggested = max(last_givtcp, first_ge)
-            print(f"  Suggested --cutover date: {suggested}")
-            print()
-            print(f"  GivTCP data through {suggested - timedelta(days=1)} 23:59 UTC → migrated")
-            print(f"  givenergy_local data from {suggested} 00:00 UTC    → kept")
-            print(f"  givenergy_local data before {suggested} 00:00 UTC  → discarded")
-            print()
-            print("  Rerun with --cutover YYYY-MM-DD to preview the migration,")
-            print("  then add --apply to write the changes.")
-        elif last_givtcp:
-            print("  givenergy_local has no statistics yet — install it and let it")
-            print("  run for at least one full day before migrating.")
-        else:
-            print("  GivTCP statistics not found. Nothing to migrate.")
+        _print_cutover_suggestion(last_givtcp, first_ge)
         await ws.close()
         return 0
 
@@ -567,24 +631,7 @@ async def run(args: argparse.Namespace) -> int:
 
     print()
 
-    # Build migration plan
-    plan: list[tuple[str, str, str, str, bool]] = []
-
-    for sn in inv_serials:
-        for gt_sfx, ge_sfx, desc, default in INVERTER_PAIRS:
-            if not default and not args.include_charge_from_grid:
-                continue
-            givtcp_id = f"sensor.givtcp_{sn}_{gt_sfx}"
-            ge_id = f"sensor.givenergy_inverter_{sn}_{ge_sfx}"
-            unit = meta_by_id.get(ge_id, {}).get("unit_of_measurement") or "kWh"
-            plan.append((givtcp_id, ge_id, desc, unit, not default))
-
-    for sn in batt_serials:
-        for gt_sfx, ge_sfx, desc, fallback_unit in BATTERY_PAIRS:
-            givtcp_id = f"sensor.givtcp_{sn}_{gt_sfx}"
-            ge_id = f"sensor.givenergy_battery_{sn}_{ge_sfx}"
-            unit = meta_by_id.get(ge_id, {}).get("unit_of_measurement") or fallback_unit
-            plan.append((givtcp_id, ge_id, desc, unit, False))
+    plan = _build_plan(inv_serials, batt_serials, meta_by_id, args.include_charge_from_grid)
 
     # Execute
     results: list[MigrationResult] = []
@@ -600,38 +647,7 @@ async def run(args: argparse.Namespace) -> int:
 
     await ws.close()
 
-    # Summary table
-    W = 46
-    print()
-    print("─" * 88)
-    print(f"  {'Sensor':<{W}} {'GivTCP':>8} {'GE pre':>7} {'GE post':>8}  Result")
-    print("─" * 88)
-    for r in results:
-        warn_tag = (
-            "  ⚠️  verify values" if r.warn_diverged and r.status in ("migrated", "dry_run") else ""
-        )
-        print(
-            f"  {r.description:<{W}} {r.givtcp_rows:>8} {r.ge_pre_rows:>7}"
-            f" {r.ge_post_rows:>8}  {r.status}{warn_tag}"
-        )
-    print("─" * 88)
-
-    migrated = sum(1 for r in results if r.status == "migrated")
-    planned = sum(1 for r in results if r.status == "dry_run")
-    skipped = sum(1 for r in results if r.status == "no_givtcp_data")
-    errored = sum(1 for r in results if r.status == "error")
-
-    if not applying:
-        print(f"\n  Planned: {planned}  |  No GivTCP data: {skipped}  |  Errors: {errored}")
-        print("  Add --apply to write changes (back up your DB first).")
-    else:
-        print(f"\n  Migrated: {migrated}  |  No GivTCP data: {skipped}  |  Errors: {errored}")
-
-    for r in results:
-        if r.status == "error":
-            print(f"\n  ERROR — {r.description}: {r.error}", file=sys.stderr)
-
-    return 0 if errored == 0 else 2
+    return _print_summary(results, applying)
 
 
 def main() -> None:

--- a/scripts/migrate_from_givtcp.py
+++ b/scripts/migrate_from_givtcp.py
@@ -54,17 +54,17 @@ What is migrated by default (all verified ✅ pairs):
   Inverter output today / lifetime
   Battery throughput lifetime
   Battery charge cycles (per battery pack)
+  House consumption today  (GivTCP's load_energy_today_kwh → givenergy_local's
+    derived house_consumption_today; givenergy-modbus #174. The old
+    load_energy_today read ~0 and was excluded; the derived figure is correct.)
 
 Opt-in (--include-charge-from-grid):
   Charge from grid lifetime  ⚠️  values differ on some systems — verify manually
 
-Not migrated:
-  House load today  ❌  givenergy_local's e_load_day (IR35) reads ~0 on some
-    inverters while the GE app's "Consumption today" is correct — splicing it
-    produces a cliff at the seam. Excluded pending a library register fix.
+Not migrated (no GivTCP equivalent or register-level gap):
   battery_discharge_this_year, work_time_total, total_refresh_failures,
   battery_charge_energy_total_kwh, battery_discharge_energy_total_kwh,
-  load_energy_total_kwh  (no GivTCP equivalent or register-level gap)
+  load_energy_total_kwh
 
 See docs/migration-from-givtcp.md for the full sensor catalogue and design notes.
 """
@@ -76,6 +76,7 @@ import asyncio
 import json
 import re
 import sys
+from collections import Counter
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
@@ -540,16 +541,15 @@ def _print_summary(results: list[MigrationResult], applying: bool) -> int:
         )
     print("─" * 88)
 
-    migrated = sum(1 for r in results if r.status == "migrated")
-    planned = sum(1 for r in results if r.status == "dry_run")
-    skipped = sum(1 for r in results if r.status == "no_givtcp_data")
-    errored = sum(1 for r in results if r.status == "error")
+    counts = Counter(r.status for r in results)
+    errored = counts["error"]
+    tail = f"No GivTCP data: {counts['no_givtcp_data']}  |  Errors: {errored}"
 
     if not applying:
-        print(f"\n  Planned: {planned}  |  No GivTCP data: {skipped}  |  Errors: {errored}")
+        print(f"\n  Planned: {counts['dry_run']}  |  {tail}")
         print("  Add --apply to write changes (back up your DB first).")
     else:
-        print(f"\n  Migrated: {migrated}  |  No GivTCP data: {skipped}  |  Errors: {errored}")
+        print(f"\n  Migrated: {counts['migrated']}  |  {tail}")
 
     for r in results:
         if r.status == "error":

--- a/scripts/migrate_from_givtcp.py
+++ b/scripts/migrate_from_givtcp.py
@@ -52,17 +52,19 @@ What is migrated by default (all verified ✅ pairs):
   Grid export today / lifetime
   Battery charge today / discharge today
   Inverter output today / lifetime
-  House load today
   Battery throughput lifetime
   Battery charge cycles (per battery pack)
 
 Opt-in (--include-charge-from-grid):
   Charge from grid lifetime  ⚠️  values differ on some systems — verify manually
 
-Not migrated (no GivTCP equivalent or register-level gap):
+Not migrated:
+  House load today  ❌  givenergy_local's e_load_day (IR35) reads ~0 on some
+    inverters while the GE app's "Consumption today" is correct — splicing it
+    produces a cliff at the seam. Excluded pending a library register fix.
   battery_discharge_this_year, work_time_total, total_refresh_failures,
   battery_charge_energy_total_kwh, battery_discharge_energy_total_kwh,
-  load_energy_total_kwh
+  load_energy_total_kwh  (no GivTCP equivalent or register-level gap)
 
 See docs/migration-from-givtcp.md for the full sensor catalogue and design notes.
 """
@@ -74,7 +76,7 @@ import asyncio
 import json
 import re
 import sys
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 try:
@@ -93,22 +95,38 @@ except ImportError:
 #   givtcp  : sensor.givtcp_<inv_sn>_<givtcp_suffix>
 #   ge_local: sensor.givenergy_inverter_<inv_sn>_<ge_suffix>
 INVERTER_PAIRS: list[tuple[str, str, str, bool]] = [
-    ("pv_energy_today_kwh",                "pv_energy_today",          "Solar generation today",         True),
-    ("pv_energy_total_kwh",                "pv_energy_total",          "Solar generation lifetime",      True),
-    ("import_energy_today_kwh",            "grid_import_today",        "Grid import today",              True),
-    ("import_energy_total_kwh",            "grid_import_total",        "Grid import lifetime",           True),
-    ("export_energy_today_kwh",            "grid_export_today",        "Grid export today",              True),
-    ("export_energy_total_kwh",            "grid_export_total",        "Grid export lifetime",           True),
-    ("battery_charge_energy_today_kwh",    "battery_charge_today",     "Battery charge today",           True),
-    ("battery_discharge_energy_today_kwh", "battery_discharge_today",  "Battery discharge today",        True),
-    ("invertor_energy_today_kwh",          "inverter_output_today",    "Inverter output today",          True),
-    ("invertor_energy_total_kwh",          "inverter_output_total",    "Inverter output lifetime",       True),
-    ("load_energy_today_kwh",              "load_energy_today",        "House load today",               True),
-    ("battery_throughput_total_kwh",       "battery_throughput_total", "Battery throughput lifetime",    True),
+    ("pv_energy_today_kwh", "pv_energy_today", "Solar generation today", True),
+    ("pv_energy_total_kwh", "pv_energy_total", "Solar generation lifetime", True),
+    ("import_energy_today_kwh", "grid_import_today", "Grid import today", True),
+    ("import_energy_total_kwh", "grid_import_total", "Grid import lifetime", True),
+    ("export_energy_today_kwh", "grid_export_today", "Grid export today", True),
+    ("export_energy_total_kwh", "grid_export_total", "Grid export lifetime", True),
+    ("battery_charge_energy_today_kwh", "battery_charge_today", "Battery charge today", True),
+    (
+        "battery_discharge_energy_today_kwh",
+        "battery_discharge_today",
+        "Battery discharge today",
+        True,
+    ),
+    ("invertor_energy_today_kwh", "inverter_output_today", "Inverter output today", True),
+    ("invertor_energy_total_kwh", "inverter_output_total", "Inverter output lifetime", True),
+    (
+        "battery_throughput_total_kwh",
+        "battery_throughput_total",
+        "Battery throughput lifetime",
+        True,
+    ),
+    # House consumption: GivTCP's load_energy_today_kwh is its computed house
+    # consumption. The old givenergy_local "load_energy_today" (e_load_day/IR35)
+    # was a mislabel that read ~0, so this pair was excluded. givenergy-modbus
+    # #174 added the real derived figure, surfaced as house_consumption_today —
+    # the correct target. Both are PV + grid-in − grid-out − AC-charge, so they
+    # align; validate the overlap before an --apply.
+    ("load_energy_today_kwh", "house_consumption_today", "House consumption today", True),
     # ⚠️  Diverged — the two integrations read different register blocks for this
     # sensor, so live values disagree on some systems. Included only with
     # --include-charge-from-grid; verify the imported values manually afterwards.
-    ("ac_charge_energy_total_kwh",         "charge_from_grid_total",   "Charge from grid lifetime",      False),
+    ("ac_charge_energy_total_kwh", "charge_from_grid_total", "Charge from grid lifetime", False),
 ]
 
 # (givtcp_suffix, ge_suffix, description, fallback_unit)
@@ -127,27 +145,44 @@ BATTERY_PAIRS: list[tuple[str, str, str, str]] = []
 
 _SERIAL = r"[a-zA-Z]{2}\d{4}[a-zA-Z]\d+"
 
-_INV_DETECT  = re.compile(rf"^sensor\.givtcp_({_SERIAL})_pv_energy_today_kwh$",  re.IGNORECASE)
-_BATT_DETECT = re.compile(rf"^sensor\.givtcp_({_SERIAL})_battery_cycles$",        re.IGNORECASE)
+_INV_DETECT = re.compile(rf"^sensor\.givtcp_({_SERIAL})_pv_energy_today_kwh$", re.IGNORECASE)
+_BATT_DETECT = re.compile(rf"^sensor\.givtcp_({_SERIAL})_battery_cycles$", re.IGNORECASE)
 
 # Reference suffixes used for cut-over date detection
 _CUTOVER_DETECT_GIVTCP = "pv_energy_today_kwh"
-_CUTOVER_DETECT_GE     = "pv_energy_today"
+_CUTOVER_DETECT_GE = "pv_energy_today"
+
+
+# ---------------------------------------------------------------------------
+# Recorder write resilience
+# ---------------------------------------------------------------------------
+#
+# HA's recorder runs single-threaded. A large import_statistics call blocks that
+# thread, so a following clear_statistics can wait past HA's internal command
+# timeout and return a 'timeout' error — even though the queued delete still
+# executes. That leaves an entity cleared but not re-imported. To avoid it:
+#   - chunk imports so no single call monopolises the recorder thread;
+#   - retry recorder mutations on a timeout (both clear and import are
+#     idempotent — clear of an empty series is a no-op; import upserts by
+#     (statistic_id, start) — so a retry after a timed-out-but-applied call is
+#     safe);
+#   - pace entities so the recorder can drain between them.
+_IMPORT_CHUNK_ROWS = 1000
+_RETRY_ATTEMPTS = 5
+_RETRY_BASE_DELAY = 2.0  # seconds; linear backoff: delay * attempt
+_ENTITY_PAUSE_SECONDS = 0.5
 
 
 # ---------------------------------------------------------------------------
 # Home Assistant WebSocket client
 # ---------------------------------------------------------------------------
 
+
 class HAWebSocket:
     """Minimal async HA WebSocket client covering only what the migration needs."""
 
     def __init__(self, base_url: str, token: str) -> None:
-        ws_base = (
-            base_url.rstrip("/")
-            .replace("https://", "wss://")
-            .replace("http://", "ws://")
-        )
+        ws_base = base_url.rstrip("/").replace("https://", "wss://").replace("http://", "ws://")
         self._url = f"{ws_base}/api/websocket"
         self._token = token
         self._ws: Any = None
@@ -171,7 +206,7 @@ class HAWebSocket:
             await self._ws.close()
 
     async def _recv(self) -> dict[str, Any]:
-        return json.loads(await self._ws.recv())  # type: ignore[arg-type]
+        return json.loads(await self._ws.recv())
 
     async def _call(self, msg_type: str, **kwargs: Any) -> Any:
         self._msg_id += 1
@@ -181,10 +216,28 @@ class HAWebSocket:
             msg = await self._recv()
             if msg.get("id") == msg_id:
                 if not msg.get("success", True):
-                    raise RuntimeError(
-                        f"HA returned an error for '{msg_type}': {msg.get('error')}"
-                    )
+                    raise RuntimeError(f"HA returned an error for '{msg_type}': {msg.get('error')}")
                 return msg.get("result")
+
+    async def _call_with_retry(self, msg_type: str, **kwargs: Any) -> Any:
+        """Call a recorder mutation, retrying on HA's 'timeout' error.
+
+        A recorder command that times out client-side may still be queued and
+        applied server-side, so we only retry on timeout (not other errors) and
+        rely on the operations being idempotent.
+        """
+        last_exc: RuntimeError | None = None
+        for attempt in range(1, _RETRY_ATTEMPTS + 1):
+            try:
+                return await self._call(msg_type, **kwargs)
+            except RuntimeError as exc:
+                if "timeout" not in str(exc).lower():
+                    raise
+                last_exc = exc
+                if attempt < _RETRY_ATTEMPTS:
+                    await asyncio.sleep(_RETRY_BASE_DELAY * attempt)
+        assert last_exc is not None
+        raise last_exc
 
     async def list_statistic_ids(self, statistic_type: str = "sum") -> list[dict[str, Any]]:
         result = await self._call("recorder/list_statistic_ids", statistic_type=statistic_type)
@@ -208,28 +261,43 @@ class HAWebSocket:
         return result or {}
 
     async def clear_statistics(self, statistic_ids: list[str]) -> None:
-        await self._call("recorder/clear_statistics", statistic_ids=statistic_ids)
+        await self._call_with_retry("recorder/clear_statistics", statistic_ids=statistic_ids)
 
-    async def import_statistics(self, metadata: dict[str, Any], stats: list[dict[str, Any]]) -> None:
-        await self._call("recorder/import_statistics", metadata=metadata, stats=stats)
+    async def import_statistics(
+        self, metadata: dict[str, Any], stats: list[dict[str, Any]]
+    ) -> None:
+        # Chunk so no single import monopolises the recorder thread long enough
+        # to time out a following command. Each chunk carries the same metadata;
+        # import upserts by (statistic_id, start), so chunks accumulate.
+        if len(stats) <= _IMPORT_CHUNK_ROWS:
+            await self._call_with_retry(
+                "recorder/import_statistics", metadata=metadata, stats=stats
+            )
+            return
+        for i in range(0, len(stats), _IMPORT_CHUNK_ROWS):
+            chunk = stats[i : i + _IMPORT_CHUNK_ROWS]
+            await self._call_with_retry(
+                "recorder/import_statistics", metadata=metadata, stats=chunk
+            )
 
 
 # ---------------------------------------------------------------------------
 # Timestamp helpers
 # ---------------------------------------------------------------------------
 
+
 def _to_utc(ts: int | float | str) -> datetime:
-    """Accept a Unix timestamp (int/float, seconds or ms) or ISO-8601 string; return UTC datetime."""
+    """Accept a Unix timestamp (int/float, s or ms) or ISO-8601 string; return UTC datetime."""
     if isinstance(ts, (int, float)):
         # HA returns millisecond timestamps in modern versions (values > 1e11).
         if ts > 1e11:
             ts = ts / 1000
-        return datetime.fromtimestamp(ts, tz=timezone.utc)
-    return datetime.fromisoformat(str(ts)).astimezone(timezone.utc)
+        return datetime.fromtimestamp(ts, tz=UTC)
+    return datetime.fromisoformat(str(ts)).astimezone(UTC)
 
 
 def _as_iso(dt: datetime) -> str:
-    return dt.astimezone(timezone.utc).isoformat()
+    return dt.astimezone(UTC).isoformat()
 
 
 def _normalise(row: dict[str, Any]) -> dict[str, Any]:
@@ -243,6 +311,7 @@ def _normalise(row: dict[str, Any]) -> dict[str, Any]:
 # Cut-over date detection
 # ---------------------------------------------------------------------------
 
+
 async def detect_cutover(ws: HAWebSocket, inv_sn: str) -> tuple[date | None, date | None]:
     """
     Return (last_givtcp_date, first_ge_date) for the reference inverter sensor.
@@ -250,22 +319,22 @@ async def detect_cutover(ws: HAWebSocket, inv_sn: str) -> tuple[date | None, dat
     Either value may be None if no data was found.
     """
     givtcp_id = f"sensor.givtcp_{inv_sn}_{_CUTOVER_DETECT_GIVTCP}"
-    ge_id     = f"sensor.givenergy_inverter_{inv_sn}_{_CUTOVER_DETECT_GE}"
+    ge_id = f"sensor.givenergy_inverter_{inv_sn}_{_CUTOVER_DETECT_GE}"
 
-    now    = datetime.now(tz=timezone.utc)
-    epoch  = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    now = datetime.now(tz=UTC)
+    epoch = datetime(2000, 1, 1, tzinfo=UTC)
     # Scan the past 5 years for the last GivTCP data point; go back further if
     # the recorder has a longer history.
     lookback_start = now - timedelta(days=5 * 365)
 
     raw_givtcp = await ws.get_statistics([givtcp_id], lookback_start, end=now)
-    raw_ge     = await ws.get_statistics([ge_id],     epoch,          end=now)
+    raw_ge = await ws.get_statistics([ge_id], epoch, end=now)
 
     givtcp_rows = raw_givtcp.get(givtcp_id, [])
-    ge_rows     = raw_ge.get(ge_id, [])
+    ge_rows = raw_ge.get(ge_id, [])
 
     last_givtcp = _to_utc(givtcp_rows[-1]["start"]).date() if givtcp_rows else None
-    first_ge    = _to_utc(ge_rows[0]["start"]).date()      if ge_rows    else None
+    first_ge = _to_utc(ge_rows[0]["start"]).date() if ge_rows else None
 
     return last_givtcp, first_ge
 
@@ -273,6 +342,7 @@ async def detect_cutover(ws: HAWebSocket, inv_sn: str) -> tuple[date | None, dat
 # ---------------------------------------------------------------------------
 # Sum rebase
 # ---------------------------------------------------------------------------
+
 
 def rebase_sum(stats: list[dict[str, Any]], base_sum: float) -> list[dict[str, Any]]:
     """
@@ -300,11 +370,19 @@ def rebase_sum(stats: list[dict[str, Any]], base_sum: float) -> list[dict[str, A
 # Per-entity migration
 # ---------------------------------------------------------------------------
 
+
 class MigrationResult:
     __slots__ = (
-        "description", "ge_id", "warn_diverged",
-        "status", "givtcp_rows", "ge_pre_rows", "ge_post_rows",
-        "merged_rows", "sum_at_cutover", "error",
+        "description",
+        "ge_id",
+        "warn_diverged",
+        "status",
+        "givtcp_rows",
+        "ge_pre_rows",
+        "ge_post_rows",
+        "merged_rows",
+        "sum_at_cutover",
+        "error",
     )
 
     def __init__(self, description: str, ge_id: str, warn_diverged: bool = False) -> None:
@@ -320,7 +398,7 @@ class MigrationResult:
         self.error: str | None = None
 
 
-_EPOCH = datetime(2000, 1, 1, tzinfo=timezone.utc)
+_EPOCH = datetime(2000, 1, 1, tzinfo=UTC)
 
 
 async def migrate_entity(
@@ -337,20 +415,20 @@ async def migrate_entity(
 
     try:
         raw_givtcp = await ws.get_statistics([givtcp_id], _EPOCH, end=cutover)
-        raw_ge     = await ws.get_statistics([ge_id],     _EPOCH)
+        raw_ge = await ws.get_statistics([ge_id], _EPOCH)
     except Exception as exc:
         r.status = "error"
         r.error = str(exc)
         return r
 
     givtcp_stats = [_normalise(s) for s in raw_givtcp.get(givtcp_id, [])]
-    ge_all       = [_normalise(s) for s in raw_ge.get(ge_id, [])]
+    ge_all = [_normalise(s) for s in raw_ge.get(ge_id, [])]
 
-    ge_pre  = [s for s in ge_all if _to_utc(s["start"]) <  cutover]
+    ge_pre = [s for s in ge_all if _to_utc(s["start"]) < cutover]
     ge_post = [s for s in ge_all if _to_utc(s["start"]) >= cutover]
 
     r.givtcp_rows = len(givtcp_stats)
-    r.ge_pre_rows  = len(ge_pre)
+    r.ge_pre_rows = len(ge_pre)
     r.ge_post_rows = len(ge_post)
 
     if not givtcp_stats:
@@ -393,11 +471,13 @@ async def migrate_entity(
 # Main
 # ---------------------------------------------------------------------------
 
+
 async def run(args: argparse.Namespace) -> int:
     applying = args.apply
 
+    mode = "APPLY — will modify statistics" if applying else "DRY RUN — nothing will be written"
     print(f"Home Assistant : {args.ha_url}")
-    print(f"Mode           : {'APPLY — will modify statistics' if applying else 'DRY RUN — nothing will be written'}")
+    print(f"Mode           : {mode}")
     print()
 
     print("Connecting …", end=" ", flush=True)
@@ -410,11 +490,11 @@ async def run(args: argparse.Namespace) -> int:
     print("OK")
 
     # Discover serials
-    all_meta    = await ws.list_statistic_ids()
+    all_meta = await ws.list_statistic_ids()
     meta_by_id: dict[str, dict[str, Any]] = {m["statistic_id"]: m for m in all_meta}
-    all_ids     = list(meta_by_id)
+    all_ids = list(meta_by_id)
 
-    inv_serials  = sorted({m.group(1).lower() for s in all_ids if (m := _INV_DETECT.match(s))})
+    inv_serials = sorted({m.group(1).lower() for s in all_ids if (m := _INV_DETECT.match(s))})
     batt_serials = sorted({m.group(1).lower() for s in all_ids if (m := _BATT_DETECT.match(s))})
 
     if not inv_serials:
@@ -436,7 +516,7 @@ async def run(args: argparse.Namespace) -> int:
         print("done")
         print()
         print("  Last GivTCP data point  :", last_givtcp or "not found")
-        print("  First givenergy_local   :", first_ge    or "not found")
+        print("  First givenergy_local   :", first_ge or "not found")
         print()
         if last_givtcp and first_ge:
             # Suggest the later of the two dates — the tail of the overlap
@@ -466,7 +546,7 @@ async def run(args: argparse.Namespace) -> int:
     # moment onwards is kept. If GivTCP stopped mid-day on the cutover date, GE
     # picks up from 00:00 that day and covers the full day cleanly.
     cutover_date = date.fromisoformat(args.cutover)
-    cutover = datetime.combine(cutover_date, datetime.min.time(), tzinfo=timezone.utc)
+    cutover = datetime.combine(cutover_date, datetime.min.time(), tzinfo=UTC)
     print(f"Cut-over date    : {cutover_date} 00:00 UTC")
 
     if applying:
@@ -495,25 +575,28 @@ async def run(args: argparse.Namespace) -> int:
             if not default and not args.include_charge_from_grid:
                 continue
             givtcp_id = f"sensor.givtcp_{sn}_{gt_sfx}"
-            ge_id     = f"sensor.givenergy_inverter_{sn}_{ge_sfx}"
-            unit      = meta_by_id.get(ge_id, {}).get("unit_of_measurement") or "kWh"
+            ge_id = f"sensor.givenergy_inverter_{sn}_{ge_sfx}"
+            unit = meta_by_id.get(ge_id, {}).get("unit_of_measurement") or "kWh"
             plan.append((givtcp_id, ge_id, desc, unit, not default))
 
     for sn in batt_serials:
         for gt_sfx, ge_sfx, desc, fallback_unit in BATTERY_PAIRS:
             givtcp_id = f"sensor.givtcp_{sn}_{gt_sfx}"
-            ge_id     = f"sensor.givenergy_battery_{sn}_{ge_sfx}"
-            unit      = meta_by_id.get(ge_id, {}).get("unit_of_measurement") or fallback_unit
+            ge_id = f"sensor.givenergy_battery_{sn}_{ge_sfx}"
+            unit = meta_by_id.get(ge_id, {}).get("unit_of_measurement") or fallback_unit
             plan.append((givtcp_id, ge_id, desc, unit, False))
 
     # Execute
     results: list[MigrationResult] = []
-    for givtcp_id, ge_id, desc, unit, warn in plan:
+    for idx, (givtcp_id, ge_id, desc, unit, warn) in enumerate(plan):
         verb = "Applying" if applying else "Previewing"
         print(f"  {verb}: {desc} …", end=" ", flush=True)
         r = await migrate_entity(ws, givtcp_id, ge_id, desc, cutover, unit, applying, warn)
         results.append(r)
         print(r.status)
+        # Pace writes so the single-threaded recorder can drain between entities.
+        if applying and idx < len(plan) - 1:
+            await asyncio.sleep(_ENTITY_PAUSE_SECONDS)
 
     await ws.close()
 
@@ -524,7 +607,9 @@ async def run(args: argparse.Namespace) -> int:
     print(f"  {'Sensor':<{W}} {'GivTCP':>8} {'GE pre':>7} {'GE post':>8}  Result")
     print("─" * 88)
     for r in results:
-        warn_tag = "  ⚠️  verify values" if r.warn_diverged and r.status in ("migrated", "dry_run") else ""
+        warn_tag = (
+            "  ⚠️  verify values" if r.warn_diverged and r.status in ("migrated", "dry_run") else ""
+        )
         print(
             f"  {r.description:<{W}} {r.givtcp_rows:>8} {r.ge_pre_rows:>7}"
             f" {r.ge_post_rows:>8}  {r.status}{warn_tag}"
@@ -532,9 +617,9 @@ async def run(args: argparse.Namespace) -> int:
     print("─" * 88)
 
     migrated = sum(1 for r in results if r.status == "migrated")
-    planned  = sum(1 for r in results if r.status == "dry_run")
-    skipped  = sum(1 for r in results if r.status == "no_givtcp_data")
-    errored  = sum(1 for r in results if r.status == "error")
+    planned = sum(1 for r in results if r.status == "dry_run")
+    skipped = sum(1 for r in results if r.status == "no_givtcp_data")
+    errored = sum(1 for r in results if r.status == "error")
 
     if not applying:
         print(f"\n  Planned: {planned}  |  No GivTCP data: {skipped}  |  Errors: {errored}")
@@ -554,20 +639,23 @@ def main() -> None:
         description="Migrate GivTCP long-term energy statistics to givenergy_local.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
-            "See docs/migration-from-givtcp.md for the full sensor catalogue "
-            "and design rationale."
+            "See docs/migration-from-givtcp.md for the full sensor catalogue and design rationale."
         ),
     )
     p.add_argument(
-        "--ha-url", required=True,
+        "--ha-url",
+        required=True,
         help="Home Assistant base URL, e.g. http://homeassistant.local:8123",
     )
     p.add_argument(
-        "--token", required=True,
+        "--token",
+        required=True,
         help="Long-Lived Access Token (Profile → Security → Long-Lived Access Tokens)",
     )
     p.add_argument(
-        "--cutover", default=None, metavar="YYYY-MM-DD",
+        "--cutover",
+        default=None,
+        metavar="YYYY-MM-DD",
         help=(
             "Boundary date. GivTCP history strictly before midnight on this date "
             "is migrated; givenergy_local data from midnight onwards is kept. "
@@ -577,14 +665,16 @@ def main() -> None:
         ),
     )
     p.add_argument(
-        "--apply", action="store_true",
+        "--apply",
+        action="store_true",
         help=(
             "Write changes to Home Assistant. Without this flag the script runs in "
             "dry-run mode and prints a preview without modifying anything."
         ),
     )
     p.add_argument(
-        "--include-charge-from-grid", action="store_true",
+        "--include-charge-from-grid",
+        action="store_true",
         help=(
             "Also migrate ac_charge_energy_total_kwh → charge_from_grid_total. "
             "⚠️  These sensors read different register blocks on some inverters — "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,8 +69,12 @@ def mock_inverter() -> MagicMock:
     inv.v_ac1 = 240.1
     inv.f_ac1 = 50.02
     inv.p_load_demand = 1200
-    inv.e_load_day = 9.8
-    inv.e_inverter_out_day = 11.2
+    # givenergy-modbus #174: e_load_day was a mislabel (it's AC charge); the real
+    # house consumption is a derived computed field. e_inverter_out_day is held
+    # under its old entity but sourced from the renamed e_pv_generation_today.
+    inv.e_ac_charge_today = 3.8
+    inv.e_consumption_today = 21.4
+    inv.e_pv_generation_today = 11.2
     inv.e_inverter_out_total = 5100.2
     inv.t_inverter_heatsink = 45.3
     inv.t_charger = 38.7

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -32,7 +32,7 @@ def test_dashboard_is_valid_yaml_with_expected_views():
 
 
 def test_dashboard_version_is_current():
-    assert DASHBOARD_VERSION == 5
+    assert DASHBOARD_VERSION == 6
 
 
 def test_battery_health_is_full_width_sections():

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -401,3 +401,39 @@ async def test_computed_sensors_use_explicit_precision(hass, setup_integration):
     assert _suggested_precision(hass, "SA1234G123_e_pv_day") == 1
     assert _suggested_precision(hass, "SA1234G123_battery_capacity_kwh") == 2
     assert _suggested_precision(hass, "SA1234G123_p_pv") == 0
+
+
+# --- givenergy-modbus #174: consumption sensor + e_load_day rename + migration ---
+
+
+async def test_house_consumption_today_sensor(hass, setup_integration):
+    """The new derived consumption sensor (the dashboard's real 'Consumed')."""
+    state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_e_consumption_today"))
+    assert state.state == "21.4"
+
+
+async def test_ac_charge_today_sensor_replaces_load_energy(hass, setup_integration):
+    """e_load_day was a mislabel (it's AC charge); the renamed sensor reads it, and
+    nothing remains registered under the old unique_id."""
+    state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_e_ac_charge_today"))
+    assert state.state == "3.8"
+    registry = er.async_get(hass)
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_e_load_day") is None
+
+
+async def test_unique_id_migration_repoints_e_load_day(hass, mock_client, mock_config_entry):
+    """A pre-2.1.1 entity under the old unique_id is re-pointed in place on setup —
+    same entity_id (so history/stats survive), new unique_id, old uid gone."""
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    old = registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_e_load_day", config_entry=mock_config_entry
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    migrated = registry.async_get(old.entity_id)
+    assert migrated is not None, "entity_id was not preserved across the migration"
+    assert migrated.unique_id == "SA1234G123_e_ac_charge_today"
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_e_load_day") is None

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.0,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.1,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/8c/48f6197678304e84043fd09760bd45c72b9c8390b3c7904b0c57120499d9/givenergy_modbus-2.1.0.tar.gz", hash = "sha256:d7912a660b5cc85efbf0914788a366a195c3d663195cfc2a0333019dab00b6f7", size = 297255, upload-time = "2026-06-02T18:31:24.911Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/0f/1e12e9950bdf0c230fe60e07b2e463689b78f3b2108fc4900e0fc3429d15/givenergy_modbus-2.1.1.tar.gz", hash = "sha256:150139f20dae16c53055aefea663669c75bced2ebffb1822501cc51933f4f052", size = 300945, upload-time = "2026-06-02T22:29:24.275Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/f2/b75800ddb8fe53b8d8b2da6e7c1497c9db46b4c4d2046878f8db92b723ed/givenergy_modbus-2.1.0-py3-none-any.whl", hash = "sha256:6d5168c41dad7adf7a8dc530dabc56a189741c458688509ebbd26c692c0cd0b1", size = 117929, upload-time = "2026-06-02T18:31:23.179Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9d/910699aa247a8ca56d9f42e0acaca633576ed2955ad4894dbf8dbf131475/givenergy_modbus-2.1.1-py3-none-any.whl", hash = "sha256:5b14fb6e98b5ad00b7bdd76e41c38303938d6a644284f4a6fe2d32f3b92a6f3f", size = 120103, upload-time = "2026-06-02T22:29:22.595Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adopts **givenergy-modbus 2.1.1** (#174), which corrected two single-phase field mislabels and added the real derived house-consumption figure. This fixes the dashboard's long-standing consumption cliff — givenergy_local showed ~0 consumption because the old "Load Energy Today" sensor read IR35, which is actually AC charge, not house load.

## Changes

- **New "House Consumption Today" sensor** (`e_consumption_today`) — the GE-app "Consumption today" derived value (PV generation + grid-in − grid-out − AC-charge), single-phase only (defensive getattr + `skip_if_none`). The dashboard "Consumed" series now points here; `DASHBOARD_VERSION` 5 → 6 so existing users are prompted to regenerate.
- **Renamed the mislabelled load sensor**: `e_load_day` → `e_ac_charge_today` ("AC Charge Today"). A **unique_id migration** (`_migrate_unique_ids` in `__init__.py`) re-points the existing entity in place so its history/statistics survive rather than orphaning it.
- **Held the inverter-output pair**: `e_inverter_out_day` entity (key/name) unchanged — the rename is deferred until the matching *total* (IR45/46) is verified and renamed library-side — but its `value_fn` reads the renamed `e_pv_generation_today` directly to avoid a per-poll DeprecationWarning.
- Pin → `givenergy-modbus>=2.1.1`.
- **GivTCP migration script**: resilient recorder writes (chunk large imports, retry on HA's command-timeout, pace entities — fixes the timeout cascade that left entities cleared-but-not-reimported mid-run), and the house-consumption pair retargeted at the real `house_consumption_today` sensor.

## Notes

- The `ha-entity-reviewer` agent confirmed the unique_id migration is correct on every edge case (slicing, multi-inverter serials, collision handling, ordering before platform setup).
- 188 tests pass (incl. a migration round-trip test); mypy at the established baseline.
- Inverter-output entity rename is **held** pending a modbus handoff to confirm/rename `e_inverter_out_total` (IR45/46) so today+total move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "House Consumption Today" and "AC Charge Today" sensors
  * Updated generated dashboards to display consumption from the new sensor

* **Bug Fixes**
  * Automatic entity unique-id migration preserves entity history and avoids collisions during sensor renames

* **Documentation**
  * Updated migration guide to reflect new sensor mappings

* **Tests**
  * Added tests covering new sensors and migration behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-hass/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->