### PR TITLE
fix(deps): bump givenergy-modbus to 2.1.2

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.1,<3.0.0"
+    "givenergy-modbus>=2.1.2,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.1,<3.0.0",
+    "givenergy-modbus>=2.1.2,<3.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.1,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.2,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.1"
+version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/0f/1e12e9950bdf0c230fe60e07b2e463689b78f3b2108fc4900e0fc3429d15/givenergy_modbus-2.1.1.tar.gz", hash = "sha256:150139f20dae16c53055aefea663669c75bced2ebffb1822501cc51933f4f052", size = 300945, upload-time = "2026-06-02T22:29:24.275Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/95/7d8624e2261fa0359bee8b2305e136c87a160e34ed7600ef116833c9935d/givenergy_modbus-2.1.2.tar.gz", hash = "sha256:097b740821c2bb9672516564d0d5ce21e116eb250268c6c4c51024bdaf966d34", size = 301878, upload-time = "2026-06-03T12:53:32.934Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/9d/910699aa247a8ca56d9f42e0acaca633576ed2955ad4894dbf8dbf131475/givenergy_modbus-2.1.1-py3-none-any.whl", hash = "sha256:5b14fb6e98b5ad00b7bdd76e41c38303938d6a644284f4a6fe2d32f3b92a6f3f", size = 120103, upload-time = "2026-06-02T22:29:22.595Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/77/caf4acca15b14f38b087b16796aa231c44eab3f92ceb51910ce922dba0a6/givenergy_modbus-2.1.2-py3-none-any.whl", hash = "sha256:2554bdc1f7de4748ad6de480b353cde20b2eff920c4a625b5765345e73783ff6", size = 120490, upload-time = "2026-06-03T12:53:31.305Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated bump triggered by [givenergy-modbus@2.1.2](https://github.com/dewet22/givenergy-modbus/releases/tag/v2.1.2).