### PR TITLE
feat: rename inverter-output pair to PV Generation + modbus 2.1.2

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -238,7 +238,12 @@ async def _missing_dashboard_cards(hass: HomeAssistant) -> list[str]:
 # existing registry entry to the new unique_id, carrying its history, statistics
 # and customisations across rather than orphaning it and starting fresh.
 _RENAMED_UNIQUE_ID_SUFFIXES = {
+    # givenergy-modbus #174 (2.1.1): IR35 was AC charge, not house load.
     "e_load_day": "e_ac_charge_today",
+    # givenergy-modbus #174/#176 (2.1.2): IR44/IR45-46 are PV generation, not
+    # inverter AC output. Move both sensors together so today+total stay paired.
+    "e_inverter_out_day": "e_pv_generation_today",
+    "e_inverter_out_total": "e_pv_generation_total",
 }
 
 

--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -46,8 +46,8 @@ EXPOSE_RECOMMENDED_ENTITY_KEYS = (
     # Load / Consumption
     "p_load_demand",
     "e_consumption_today",
-    # Inverter output
-    "e_inverter_out_total",
+    # PV generation total (was e_inverter_out_total / "Inverter Output Total")
+    "e_pv_generation_total",
     # Health — entity description's `key` is "status"; `inverter_status` is
     # the translation_key, which is not what's in the unique_id suffix.
     "status",

--- a/custom_components/givenergy_local/dashboard.py
+++ b/custom_components/givenergy_local/dashboard.py
@@ -285,7 +285,7 @@ def _energy_view(inv: str) -> str:
           - entity: {_i(inv, "grid_import_total")}
             name: Grid Imported
           - entity: {_i(inv, "pv_generation_total")}
-            name: Inverter Output
+            name: PV Generation Total
           - entity: {_i(inv, "charge_from_grid_total")}
             name: Charged from Grid
           - entity: {_i(inv, "battery_discharge_this_year")}

--- a/custom_components/givenergy_local/dashboard.py
+++ b/custom_components/givenergy_local/dashboard.py
@@ -284,7 +284,7 @@ def _energy_view(inv: str) -> str:
             name: Grid Exported
           - entity: {_i(inv, "grid_import_total")}
             name: Grid Imported
-          - entity: {_i(inv, "inverter_output_total")}
+          - entity: {_i(inv, "pv_generation_total")}
             name: Inverter Output
           - entity: {_i(inv, "charge_from_grid_total")}
             name: Charged from Grid

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.1,<3.0.0"
+    "givenergy-modbus>=2.1.2,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -516,25 +516,25 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         value_fn=lambda inv: inv.e_ac_charge_today,
     ),
     GivEnergyInverterSensorDescription(
-        # NB: givenergy-modbus #174 found IR44 is PV generation, not inverter AC
-        # output, and renamed the field e_inverter_out_day -> e_pv_generation_today.
-        # We HOLD the entity rename (key/name) until the matching *total* (IR45/46)
-        # is verified and renamed too, so today+total move together — but read the
-        # new field name directly to avoid the deprecation warning on every poll.
-        key="e_inverter_out_day",
-        name="Inverter Output Today",
+        # IR44 is PV generation, not inverter AC output. givenergy-modbus #174
+        # renamed e_inverter_out_day -> e_pv_generation_today (single-phase). The
+        # total (IR45/46) was confirmed as PV-generation-total in #176 and renamed
+        # e_inverter_out_total -> e_pv_generation_total. Both entity keys and names
+        # move together; unique_id migrations in __init__.py carry existing history.
+        key="e_pv_generation_today",
+        name="PV Generation Today",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda inv: inv.e_pv_generation_today,
     ),
     GivEnergyInverterSensorDescription(
-        key="e_inverter_out_total",
-        name="Inverter Output Total",
+        key="e_pv_generation_total",
+        name="PV Generation Total",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda inv: inv.e_inverter_out_total,
+        value_fn=lambda inv: inv.e_pv_generation_total,
     ),
     GivEnergyInverterSensorDescription(
         key="e_inverter_export_total",

--- a/dashboard/template.yaml
+++ b/dashboard/template.yaml
@@ -168,7 +168,7 @@ views:
           - entity: sensor.givenergy_inverter_INVERTER_SERIAL_grid_import_total
             name: Grid Imported
           - entity: sensor.givenergy_inverter_INVERTER_SERIAL_pv_generation_total
-            name: Inverter Output
+            name: PV Generation Total
           - entity: sensor.givenergy_inverter_INVERTER_SERIAL_charge_from_grid_total
             name: Charged from Grid
           - entity: sensor.givenergy_inverter_INVERTER_SERIAL_battery_discharge_this_year

--- a/dashboard/template.yaml
+++ b/dashboard/template.yaml
@@ -167,7 +167,7 @@ views:
             name: Grid Exported
           - entity: sensor.givenergy_inverter_INVERTER_SERIAL_grid_import_total
             name: Grid Imported
-          - entity: sensor.givenergy_inverter_INVERTER_SERIAL_inverter_output_total
+          - entity: sensor.givenergy_inverter_INVERTER_SERIAL_pv_generation_total
             name: Inverter Output
           - entity: sensor.givenergy_inverter_INVERTER_SERIAL_charge_from_grid_total
             name: Charged from Grid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.1,<3.0.0",
+    "givenergy-modbus>=2.1.2,<3.0.0",
 ]
 
 [dependency-groups]

--- a/scripts/migrate_from_givtcp.py
+++ b/scripts/migrate_from_givtcp.py
@@ -51,7 +51,7 @@ What is migrated by default (all verified ✅ pairs):
   Grid import today / lifetime
   Grid export today / lifetime
   Battery charge today / discharge today
-  Inverter output today / lifetime
+  PV generation today / lifetime
   Battery throughput lifetime
   Battery charge cycles (per battery pack)
   House consumption today  (GivTCP's load_energy_today_kwh → givenergy_local's
@@ -109,8 +109,10 @@ INVERTER_PAIRS: list[tuple[str, str, str, bool]] = [
         "Battery discharge today",
         True,
     ),
-    ("invertor_energy_today_kwh", "inverter_output_today", "Inverter output today", True),
-    ("invertor_energy_total_kwh", "inverter_output_total", "Inverter output lifetime", True),
+    # givenergy-modbus #174/#176: IR44/45-46 are PV generation, so these
+    # sensors were renamed from "inverter output" to "PV generation".
+    ("invertor_energy_today_kwh", "pv_generation_today", "PV generation today", True),
+    ("invertor_energy_total_kwh", "pv_generation_total", "PV generation lifetime", True),
     (
         "battery_throughput_total_kwh",
         "battery_throughput_total",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,13 +69,12 @@ def mock_inverter() -> MagicMock:
     inv.v_ac1 = 240.1
     inv.f_ac1 = 50.02
     inv.p_load_demand = 1200
-    # givenergy-modbus #174: e_load_day was a mislabel (it's AC charge); the real
-    # house consumption is a derived computed field. e_inverter_out_day is held
-    # under its old entity but sourced from the renamed e_pv_generation_today.
+    # givenergy-modbus #174/#176: e_load_day was AC charge; e_inverter_out_day/total
+    # are PV generation. Consumption is derived. All entity keys renamed in 2.1.1/2.
     inv.e_ac_charge_today = 3.8
     inv.e_consumption_today = 21.4
     inv.e_pv_generation_today = 11.2
-    inv.e_inverter_out_total = 5100.2
+    inv.e_pv_generation_total = 5100.2
     inv.t_inverter_heatsink = 45.3
     inv.t_charger = 38.7
     inv.enable_charge = True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -437,3 +437,52 @@ async def test_unique_id_migration_repoints_e_load_day(hass, mock_client, mock_c
     assert migrated is not None, "entity_id was not preserved across the migration"
     assert migrated.unique_id == "SA1234G123_e_ac_charge_today"
     assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_e_load_day") is None
+
+
+# --- givenergy-modbus #174/#176: inverter-output pair renamed to PV generation ---
+
+
+async def test_pv_generation_today_sensor(hass, setup_integration):
+    """IR44 is PV generation (not inverter AC output); entity renamed accordingly."""
+    state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_e_pv_generation_today"))
+    assert state.state == "11.2"
+
+
+async def test_pv_generation_total_sensor(hass, setup_integration):
+    """IR45/46 is PV generation total; entity renamed from 'Inverter Output Total'."""
+    state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_e_pv_generation_total"))
+    assert state.state == "5100.2"
+
+
+async def test_inverter_output_old_uids_gone(hass, setup_integration):
+    """Old unique_ids must be absent — they've been migrated to the PV generation names."""
+    registry = er.async_get(hass)
+    for old_uid in ("SA1234G123_e_inverter_out_day", "SA1234G123_e_inverter_out_total"):
+        assert registry.async_get_entity_id("sensor", DOMAIN, old_uid) is None, (
+            f"Old unique_id {old_uid!r} still registered — unique_id migration didn't run"
+        )
+
+
+async def test_unique_id_migration_repoints_inverter_output_pair(
+    hass, mock_client, mock_config_entry
+):
+    """Pre-2.1.2 entities under the old inverter-output unique_ids are re-pointed in place."""
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    old_today = registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_e_inverter_out_day", config_entry=mock_config_entry
+    )
+    old_total = registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_e_inverter_out_total", config_entry=mock_config_entry
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    for old_entry, expected_new_uid in (
+        (old_today, "SA1234G123_e_pv_generation_today"),
+        (old_total, "SA1234G123_e_pv_generation_total"),
+    ):
+        migrated = registry.async_get(old_entry.entity_id)
+        assert migrated is not None, f"entity_id {old_entry.entity_id!r} lost after migration"
+        assert migrated.unique_id == expected_new_uid

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.1,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.2,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,15 +960,15 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.1"
+version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/0f/1e12e9950bdf0c230fe60e07b2e463689b78f3b2108fc4900e0fc3429d15/givenergy_modbus-2.1.1.tar.gz", hash = "sha256:150139f20dae16c53055aefea663669c75bced2ebffb1822501cc51933f4f052", size = 300945, upload-time = "2026-06-02T22:29:24.275Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/95/7d8624e2261fa0359bee8b2305e136c87a160e34ed7600ef116833c9935d/givenergy_modbus-2.1.2.tar.gz", hash = "sha256:097b740821c2bb9672516564d0d5ce21e116eb250268c6c4c51024bdaf966d34", size = 301878, upload-time = "2026-06-03T12:53:32.934Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/9d/910699aa247a8ca56d9f42e0acaca633576ed2955ad4894dbf8dbf131475/givenergy_modbus-2.1.1-py3-none-any.whl", hash = "sha256:5b14fb6e98b5ad00b7bdd76e41c38303938d6a644284f4a6fe2d32f3b92a6f3f", size = 120103, upload-time = "2026-06-02T22:29:22.595Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/77/caf4acca15b14f38b087b16796aa231c44eab3f92ceb51910ce922dba0a6/givenergy_modbus-2.1.2-py3-none-any.whl", hash = "sha256:2554bdc1f7de4748ad6de480b353cde20b2eff920c4a625b5765345e73783ff6", size = 120490, upload-time = "2026-06-03T12:53:31.305Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Renames the two incorrectly-labelled "Inverter Output" sensors to **PV Generation Today** and **PV Generation Total** — IR44 and IR45/46 are PV generation registers, not inverter AC output (confirmed by givenergy-modbus #174/#176 sentinel cross-correlation).
- Both unique_ids migrate in place, preserving entity history.
- Pin bumped to `givenergy-modbus>=2.1.2`, which also makes `battery_max_power` return `None` (not `0`) for unknown DTCs — better signal for watt-limit consumers.
- Migration script and dashboard All-Time Totals retargeted to the new entity slugs.
- 4 new tests: value assertions + migration round-trip for both renamed entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected "Inverter Output" energy sensor labels to "PV Generation Today/Total" for accurate data representation.
  * Updated dashboard to display corrected PV generation metrics.

* **Improvements**
  * Added automatic migration for existing installations to seamlessly transition to renamed sensors while preserving entity history.

* **Chores**
  * Updated dependency requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->