### PR TITLE
feat: dashboard Maintenance section + serial-based service targeting

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -99,6 +99,16 @@ async def _save_capabilities(
     await _capabilities_store(hass, entry_id).async_save(capabilities.to_dict())
 
 
+# Callers may identify the target inverter by HA-assigned device_id (convenient
+# in the Settings → Services UI) OR by inverter serial (convenient in dashboards
+# and automations that only know the serial). Exactly one must be supplied.
+SERVICE_DEVICE_OR_SERIAL_SCHEMA = vol.Schema(
+    {
+        vol.Exclusive("device_id", "target"): cv.string,
+        vol.Exclusive("serial", "target"): cv.string,
+    }
+)
+
 SERVICE_DEVICE_SCHEMA = vol.Schema({vol.Required("device_id"): cv.string})
 
 SERVICE_GENERATE_DASHBOARD_SCHEMA = vol.Schema(
@@ -141,6 +151,53 @@ def _coordinator_for_device(
         if coordinator is not None:
             return coordinator
     return None
+
+
+def _entry_id_for_serial(hass: HomeAssistant, serial: str) -> str | None:
+    """Return the config-entry ID whose plant matches `serial`, or None.
+
+    The config flow stores the inverter serial as the entry's unique_id (normalised
+    to uppercase). The device registry also carries an identifier
+    ("givenergy_local", serial) — we try both to be robust across installs where
+    one or the other might be absent.
+    """
+    serial_upper = serial.upper()
+    # Primary: config-entry unique_id (set by the config flow to the serial).
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.unique_id and entry.unique_id.upper() == serial_upper:
+            return entry.entry_id
+    # Fallback: device registry identifier.
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, serial_upper)})
+    if device is not None:
+        for entry_id in device.config_entries:
+            if entry_id in hass.data.get(DOMAIN, {}):
+                return entry_id
+    return None
+
+
+def _resolve_target(hass: HomeAssistant, call_data: dict) -> tuple[str | None, str]:
+    """Resolve a device_id-or-serial service call to a config entry_id.
+
+    Returns (entry_id, error_message). If resolution succeeds, error_message is
+    empty; if it fails, entry_id is None and error_message explains why.
+    """
+    if "serial" in call_data:
+        entry_id = _entry_id_for_serial(hass, call_data["serial"])
+        if entry_id is None:
+            return None, f"No GivEnergy inverter found for serial {call_data['serial']!r}"
+        return entry_id, ""
+    # device_id path — find the config entry via the device registry.
+    device_id = call_data["device_id"]
+    device = dr.async_get(hass).async_get(device_id)
+    if device is None:
+        return None, f"No GivEnergy device found for device_id {device_id!r}"
+    entry_id = next(
+        (eid for eid in device.config_entries if eid in hass.data.get(DOMAIN, {})),
+        None,
+    )
+    if entry_id is None:
+        return None, f"No GivEnergy config entry found for device {device_id!r}"
+    return entry_id, ""
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -401,12 +458,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await c._client.one_shot_command(commands.set_calibrate_battery_soc())
 
         async def handle_set_system_datetime(call: ServiceCall) -> None:
-            c = _coordinator_for_device(hass, call.data["device_id"])
+            entry_id, err = _resolve_target(hass, call.data)
+            if err:
+                raise HomeAssistantError(err)
+            c = hass.data.get(DOMAIN, {}).get(entry_id)
             if c is None or c._client is None or not c._client.connected:
-                raise HomeAssistantError(
-                    f"GivEnergy inverter for device {call.data['device_id']!r} "
-                    "is not currently connected"
-                )
+                raise HomeAssistantError("GivEnergy inverter is not currently connected")
             # Sync the inverter's clock to Home Assistant's current local time.
             await c._client.one_shot_command(commands.set_system_date_time(dt_util.now()))
 
@@ -520,7 +577,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             DOMAIN,
             SERVICE_SET_SYSTEM_DATETIME,
             handle_set_system_datetime,
-            SERVICE_DEVICE_SCHEMA,
+            SERVICE_DEVICE_OR_SERIAL_SCHEMA,
         )
         hass.services.async_register(
             DOMAIN,
@@ -534,19 +591,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # reload — the next setup_entry will see no prior and do a cold
             # detect(), which is exactly the "I changed the hardware, please
             # rediscover" semantic the issue calls for.
-            device = dr.async_get(hass).async_get(call.data["device_id"])
-            if device is None:
-                raise HomeAssistantError(
-                    f"No GivEnergy device found for {call.data['device_id']!r}"
-                )
-            target_entry_id = next(
-                (eid for eid in device.config_entries if eid in hass.data.get(DOMAIN, {})),
-                None,
-            )
-            if target_entry_id is None:
-                raise HomeAssistantError(
-                    f"No GivEnergy config entry found for device {call.data['device_id']!r}"
-                )
+            target_entry_id, err = _resolve_target(hass, call.data)
+            if err or target_entry_id is None:
+                raise HomeAssistantError(err or "Could not resolve target entry")
             await _capabilities_store(hass, target_entry_id).async_remove()
             hass.config_entries.async_schedule_reload(target_entry_id)
 
@@ -619,7 +666,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             DOMAIN,
             SERVICE_REDETECT_PLANT,
             handle_redetect_plant,
-            SERVICE_DEVICE_SCHEMA,
+            SERVICE_DEVICE_OR_SERIAL_SCHEMA,
         )
         hass.services.async_register(
             DOMAIN,

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -102,11 +102,20 @@ async def _save_capabilities(
 # Callers may identify the target inverter by HA-assigned device_id (convenient
 # in the Settings → Services UI) OR by inverter serial (convenient in dashboards
 # and automations that only know the serial). Exactly one must be supplied.
+def _require_one_of_device_or_serial(value: dict) -> dict:
+    if "device_id" not in value and "serial" not in value:
+        raise vol.Invalid("Supply either 'device_id' or 'serial'")
+    return value
+
+
 SERVICE_DEVICE_OR_SERIAL_SCHEMA = vol.Schema(
-    {
-        vol.Exclusive("device_id", "target"): cv.string,
-        vol.Exclusive("serial", "target"): cv.string,
-    }
+    vol.All(
+        {
+            vol.Exclusive("device_id", "target"): cv.string,
+            vol.Exclusive("serial", "target"): cv.string,
+        },
+        _require_one_of_device_or_serial,
+    )
 )
 
 SERVICE_DEVICE_SCHEMA = vol.Schema({vol.Required("device_id"): cv.string})

--- a/custom_components/givenergy_local/dashboard.py
+++ b/custom_components/givenergy_local/dashboard.py
@@ -9,7 +9,7 @@ import yaml
 # Increment whenever the generated YAML layout changes in a meaningful way.
 # __init__.py compares this against the last-generated version stored in HA's
 # persistent Store and raises a Repairs issue when they diverge.
-DASHBOARD_VERSION = 6
+DASHBOARD_VERSION = 7
 
 
 class _NoAliasDumper(yaml.SafeDumper):
@@ -598,6 +598,30 @@ def _controls_view(inv: str) -> str:
             name: Slot 2 Start
           - entity: time.givenergy_inverter_{inv}_discharge_slot_2_end
             name: Slot 2 End
+
+      - type: entities
+        title: Maintenance
+        entities:
+          - type: button
+            name: Redetect Plant
+            icon: mdi:radar
+            tap_action:
+              action: perform-action
+              perform_action: givenergy_local.redetect_plant
+              confirmation:
+                text: >-
+                  This will reload the GivEnergy integration and force a full
+                  hardware detection sweep. Continue?
+              data:
+                serial: {inv.upper()}
+          - type: button
+            name: Sync Inverter Clock
+            icon: mdi:clock-sync-outline
+            tap_action:
+              action: perform-action
+              perform_action: givenergy_local.set_system_datetime
+              data:
+                serial: {inv.upper()}
 """
 
 

--- a/custom_components/givenergy_local/services.yaml
+++ b/custom_components/givenergy_local/services.yaml
@@ -36,17 +36,26 @@ set_system_datetime:
   description: >
     Sets the GivEnergy inverter's internal clock to Home Assistant's current
     local time. Useful if the inverter's clock has drifted — it affects
-    charge/discharge slot scheduling.
+    charge/discharge slot scheduling. Supply either device_id (device picker)
+    or serial (inverter serial number, e.g. SA2114G047).
   fields:
     device_id:
       name: Device
       description: The GivEnergy inverter whose clock to set.
-      required: true
+      required: false
       selector:
         device:
           integration: givenergy_local
           entity:
             domain: number
+    serial:
+      name: Inverter serial
+      description: >
+        Inverter serial number (e.g. SA2114G047). Alternative to device_id —
+        useful in dashboards and automations that work from serials.
+      required: false
+      selector:
+        text:
 
 capture_frames:
   name: Capture debug frames
@@ -120,17 +129,26 @@ redetect_plant:
   description: >
     Clears the cached plant topology and reloads the integration, forcing a
     full hardware detection sweep on the next connect. Use this after adding
-    or removing a battery, or any other change to the plant layout.
+    or removing a battery, or any other change to the plant layout. Supply
+    either device_id (device picker) or serial (inverter serial number).
   fields:
     device_id:
       name: Device
       description: The GivEnergy inverter whose plant topology should be re-detected.
-      required: true
+      required: false
       selector:
         device:
           integration: givenergy_local
           entity:
             domain: number
+    serial:
+      name: Inverter serial
+      description: >
+        Inverter serial number (e.g. SA2114G047). Alternative to device_id —
+        useful in dashboards and automations that work from serials.
+      required: false
+      selector:
+        text:
 
 generate_dashboard:
   name: Generate dashboard

--- a/dashboard/template.yaml
+++ b/dashboard/template.yaml
@@ -416,6 +416,30 @@ views:
           - entity: time.givenergy_inverter_INVERTER_SERIAL_discharge_slot_2_end
             name: Slot 2 End
 
+      - type: entities
+        title: Maintenance
+        entities:
+          - type: button
+            name: Redetect Plant
+            icon: mdi:radar
+            tap_action:
+              action: perform-action
+              perform_action: givenergy_local.redetect_plant
+              confirmation:
+                text: >-
+                  This will reload the GivEnergy integration and force a full
+                  hardware detection sweep. Continue?
+              data:
+                serial: INVERTER_SERIAL
+          - type: button
+            name: Sync Inverter Clock
+            icon: mdi:clock-sync-outline
+            tap_action:
+              action: perform-action
+              perform_action: givenergy_local.set_system_datetime
+              data:
+                serial: INVERTER_SERIAL
+
   # ── Diagnostics ───────────────────────────────────────────────────────────
   - title: Diagnostics
     path: diagnostics

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -32,7 +32,7 @@ def test_dashboard_is_valid_yaml_with_expected_views():
 
 
 def test_dashboard_version_is_current():
-    assert DASHBOARD_VERSION == 6
+    assert DASHBOARD_VERSION == 7
 
 
 def test_battery_health_is_full_width_sections():
@@ -176,3 +176,45 @@ def test_ems_dashboard_covers_all_slot_kinds_and_indices():
     for kind in ("charge", "discharge", "export"):
         for idx in (1, 2, 3):
             assert f"ems_{kind}_slot_{idx}_target_soc" in out
+
+
+def test_controls_view_has_maintenance_section():
+    """The Controls view must include a Maintenance section with the Redetect button."""
+    views = _views()
+    controls = views["Controls"]
+    yaml_str = str(controls)
+    assert "Maintenance" in yaml_str
+    assert "redetect_plant" in yaml_str
+    assert "set_system_datetime" in yaml_str
+
+
+def test_maintenance_buttons_carry_the_serial(inv: str = INV):
+    """Each button's data dict must carry the inverted serial so multi-plant installs
+    target the right inverter."""
+    import yaml as _yaml
+
+    raw = generate_dashboard(INV, BATS)
+    doc = _yaml.safe_load(raw)
+    controls_view = next(v for v in doc["views"] if v["title"] == "Controls")
+
+    # Find all perform_action calls and collect serials from their data
+    def _collect_serials(obj: object) -> list[str]:
+        if isinstance(obj, dict):
+            results = []
+            if obj.get("perform_action", "").startswith("givenergy_local."):
+                results.append(obj.get("data", {}).get("serial", ""))
+            for v in obj.values():
+                results.extend(_collect_serials(v))
+            return results
+        if isinstance(obj, list):
+            out = []
+            for item in obj:
+                out.extend(_collect_serials(item))
+            return out
+        return []
+
+    serials = _collect_serials(controls_view)
+    assert serials, "no service calls with a serial found in Controls view"
+    assert all(s == INV.upper() for s in serials), (
+        f"expected serial {INV.upper()!r} in all buttons, got {serials}"
+    )

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -191,11 +191,10 @@ def test_controls_view_has_maintenance_section():
 def test_maintenance_buttons_carry_the_serial(inv: str = INV):
     """Each button's data dict must carry the inverted serial so multi-plant installs
     target the right inverter."""
-    import yaml as _yaml
-
     raw = generate_dashboard(INV, BATS)
-    doc = _yaml.safe_load(raw)
-    controls_view = next(v for v in doc["views"] if v["title"] == "Controls")
+    doc = yaml.safe_load(raw)
+    controls_view = next((v for v in doc["views"] if v["title"] == "Controls"), None)
+    assert controls_view is not None, "Controls view not found in generated dashboard"
 
     # Find all perform_action calls and collect serials from their data
     def _collect_serials(obj: object) -> list[str]:


### PR DESCRIPTION
## Summary

**Service changes:** `redetect_plant` and `set_system_datetime` now accept either `device_id` (HA device-picker, as before) or `serial` (inverter serial string, e.g. `SA2114G047`). New `_resolve_target()` helper and `SERVICE_DEVICE_OR_SERIAL_SCHEMA` route either form to the correct config entry — unambiguous in multi-plant installs, and the dashboard can supply the serial at generation time without needing to know HA-internal device IDs.

**Dashboard:** a new **Maintenance** section in the Controls view adds two button cards:
- **Redetect Plant** (`mdi:radar`) — calls `redetect_plant` with `serial`, with a confirmation dialog; the one-click recovery for a missing battery or topology issue.
- **Sync Inverter Clock** (`mdi:clock-sync-outline`) — calls `set_system_datetime` with `serial`.

`DASHBOARD_VERSION` 6 → 7; existing users see the *Dashboard schema outdated* repair and can regenerate in one click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)