### PR TITLE
feat(number): expose EMS export power limit control (#85)

### DIFF
--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -7,7 +7,7 @@ from givenergy_modbus.client import commands
 from givenergy_modbus.model.ems import Ems
 from homeassistant.components.number import NumberEntity, NumberEntityDescription, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfPower
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -176,7 +176,22 @@ def _ems_number_descriptions() -> tuple[GivEnergyEmsNumberEntityDescription, ...
 
 
 EMS_NUMBER_DESCRIPTIONS: tuple[GivEnergyEmsNumberEntityDescription, ...] = (
-    _ems_number_descriptions()
+    *_ems_number_descriptions(),
+    GivEnergyEmsNumberEntityDescription(
+        key="ems_export_power_limit",
+        name="EMS Export Power Limit",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        native_min_value=0,
+        # Provisional ceiling — the raw register is uint16 (0-65535 W), which is no
+        # sensible slider. 6000 W covers a single inverter's rating; confirm a realistic
+        # plant-level figure with a real EMS plant (#52) and raise if needed.
+        native_max_value=6000,
+        native_step=100,
+        mode=NumberMode.BOX,
+        value_fn=lambda ems: ems.export_power_limit,
+        set_value_cmd=lambda v: commands.set_ems_export_power_limit(int(v)),
+        entity_category=EntityCategory.CONFIG,
+    ),
 )
 
 

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -38,6 +38,7 @@ def mock_ems() -> MagicMock:
     ems.export_target_1 = 100
     ems.export_target_2 = 4
     ems.export_target_3 = 4
+    ems.export_power_limit = 3600
     ems.plant_enabled = True
     return ems
 
@@ -63,14 +64,14 @@ def _entity_id(hass, platform: str, unique_id: str) -> str | None:
 
 
 async def test_ems_entities_created_for_ems_plant(hass, ems_setup):
-    """EMS plant exposes 18 slot-time + 9 SoC-target + 1 switch entities."""
+    """EMS plant exposes 18 slot-time + 10 number + 1 switch entities."""
     registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(registry, ems_setup.entry_id)
     ems_times = [e for e in entries if e.domain == "time" and "_ems_" in e.unique_id]
     ems_numbers = [e for e in entries if e.domain == "number" and "_ems_" in e.unique_id]
     ems_switches = [e for e in entries if e.domain == "switch" and "_ems_" in e.unique_id]
     assert len(ems_times) == 18  # charge+discharge+export x slots 1-3 x start/end
-    assert len(ems_numbers) == 9  # charge+discharge+export x slots 1-3 target SoC
+    assert len(ems_numbers) == 10  # 9 slot SoC targets + export power limit
     assert len(ems_switches) == 1  # Flexi EMS Control
 
 
@@ -78,6 +79,7 @@ async def test_no_ems_entities_for_non_ems_plant(hass, setup_integration):
     """A plant without an EMS (the default) must not get EMS entities."""
     assert _entity_id(hass, "time", "SA1234G123_ems_charge_slot_1_start") is None
     assert _entity_id(hass, "number", "SA1234G123_ems_charge_target_soc_1") is None
+    assert _entity_id(hass, "number", "SA1234G123_ems_export_power_limit") is None
 
 
 async def test_no_smart_load_entities_for_ems_plant(hass, ems_setup):
@@ -128,6 +130,24 @@ async def test_set_ems_export_target_soc_writes_to_ems_controller(hass, mock_cli
     (request,) = mock_client.one_shot_command.call_args[0][0]
     # EMS export target SoC writes go to the EMS controller (0x11) with the value.
     assert request.value == 50
+    assert request.device_address == 0x11
+
+
+async def test_ems_export_power_limit_initial_value(hass, ems_setup):
+    state = hass.states.get(_entity_id(hass, "number", "SA1234G123_ems_export_power_limit"))
+    assert float(state.state) == 3600
+    assert state.attributes["min"] == 0
+    assert state.attributes["max"] == 6000
+
+
+async def test_set_ems_export_power_limit_writes_command(hass, mock_client, ems_setup):
+    entity_id = _entity_id(hass, "number", "SA1234G123_ems_export_power_limit")
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": entity_id, "value": 2500}, blocking=True
+    )
+    mock_client.one_shot_command.assert_called_once()
+    (request,) = mock_client.one_shot_command.call_args[0][0]
+    assert request.value == 2500
     assert request.device_address == 0x11
 
 


### PR DESCRIPTION
## Summary
- Adds an EMS plant-level number entity for `Ems.export_power_limit`, wired to `commands.set_ems_export_power_limit`, created automatically for EMS plants alongside the existing per-slot SoC targets.
- The raw register is a uint16 (0–65535 W), which makes no sensible slider, so the entity is bounded to a **provisional 6000 W** ceiling, step 100, `BOX` mode.

This closes out the export-power-limit half of #85. The "Set Date/Time" half already shipped as the `set_system_datetime` service, so #85 can close once this lands.

## Open question for review
The 6000 W max is a placeholder covering a single inverter's rating. An EMS plant coordinates several inverters, so a realistic plant-level ceiling may be higher — I'd like to confirm a sensible figure against live EMS hardware (cc the #52 thread) before treating it as final, and will bump `native_max_value` if needed.

## Test plan
- [x] `test_ems_export_power_limit_initial_value` — reads back 3600 W, min 0 / max 6000
- [x] `test_set_ems_export_power_limit_writes_command` — write reaches the EMS controller (0x11) with the value
- [x] entity-count gating: 10 EMS numbers on an EMS plant, absent on a non-EMS plant
- [x] full suite green (196 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)