### PR TITLE
feat: capture frames landing page + signed download (#64)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import importlib.metadata
 import logging
+import platform
+import sys
+from datetime import datetime
 from pathlib import Path
 
 import voluptuous as vol
@@ -14,6 +18,7 @@ from homeassistant.components.persistent_notification import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
@@ -22,6 +27,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.loader import async_get_integration
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -44,6 +50,12 @@ from .const import (
 )
 from .coordinator import GivEnergyUpdateCoordinator
 from .dashboard import DASHBOARD_VERSION
+from .http import (
+    CaptureDownloadView,
+    CaptureLandingView,
+    build_capture_notification_url,
+    capture_dir,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -258,6 +270,53 @@ async def _async_register_frontend_card(hass: HomeAssistant) -> None:
         _LOGGER.warning("Could not register the bundled cell-heatmap card: %s", exc)
 
 
+async def _build_capture_header(
+    hass: HomeAssistant, *, generated: datetime, duration: float, frame_count: int
+) -> str:
+    """Hash-prefixed environment header prepended to a wire capture (issue #64).
+
+    Pure environment introspection — deliberately no ``coordinator.data`` access
+    (works even if the coordinator is in a bad state) and no inverter
+    serial/model/firmware, which the library's redaction principle keeps out of
+    shared diagnostics (those are recoverable from the wire frames by anyone with
+    a parser anyway).
+    """
+    try:
+        library_version = importlib.metadata.version("givenergy-modbus")
+    except importlib.metadata.PackageNotFoundError:
+        library_version = "unknown"
+    integration = await async_get_integration(hass, DOMAIN)
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    lines = [
+        "# GivEnergy Local — Modbus wire capture",
+        f"# Generated:      {generated.isoformat()}",
+        f"# Duration:       {duration:g}s",
+        f"# Frames:         {frame_count}",
+        "#",
+        f"# Home Assistant: {HA_VERSION}",
+        f"# Python:         {python_version}",
+        f"# OS:             {platform.platform()}",
+        f"# Integration:    {integration.version}",
+        f"# Library:        givenergy-modbus {library_version}",
+        "#",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+async def _async_register_capture_http(hass: HomeAssistant) -> None:
+    """Register the capture landing/download views and ensure the capture dir.
+
+    Component-scope (run once from :func:`async_setup`): the views are global and
+    the directory is shared across config entries, so neither belongs per-entry.
+    """
+    await hass.async_add_executor_job(lambda: capture_dir(hass).mkdir(exist_ok=True))
+    if hass.http is None:
+        # No web server (e.g. a minimal test harness) — nothing to serve from.
+        return
+    hass.http.register_view(CaptureLandingView())
+    hass.http.register_view(CaptureDownloadView())
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Integration-wide setup, run once before any config entry.
 
@@ -267,6 +326,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     concurrently.
     """
     await _async_register_frontend_card(hass)
+    await _async_register_capture_http(hass)
     return True
 
 
@@ -557,25 +617,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
                 await coordinator._client.capture_frames(_sink, duration=float(duration))
 
-                filename = f"capture_givenergy_{inv}.txt"
-                www_dir = Path(hass.config.path("www"))
-                await hass.async_add_executor_job(lambda d=www_dir: d.mkdir(exist_ok=True))
-                content = "\n".join(frames) if frames else "(no frames captured)"
-                await hass.async_add_executor_job((www_dir / filename).write_text, content)
-                url = f"/local/{filename}"
-                _LOGGER.info("GivEnergy frame capture saved at %s (%d frames)", url, len(frames))
-                await hass.services.async_call(
-                    "persistent_notification",
-                    "create",
-                    {
-                        "title": "GivEnergy frame capture complete",
-                        "message": (
-                            f"Captured {len(frames)} frames over {duration} s — "
-                            f"[download]({url})\n\n"
-                            "Attach this file when reporting connectivity issues."
-                        ),
-                        "notification_id": f"givenergy_capture_{inv}",
-                    },
+                header = await _build_capture_header(
+                    hass,
+                    generated=dt_util.now(),
+                    duration=float(duration),
+                    frame_count=len(frames),
+                )
+                body = "\n".join(frames) if frames else "(no frames captured)"
+                content = header + "\n" + body + "\n"
+
+                epoch = int(dt_util.utcnow().timestamp())
+                filename = f"capture_givenergy_{epoch}.txt"
+                directory = capture_dir(hass)
+                await hass.async_add_executor_job(lambda d=directory: d.mkdir(exist_ok=True))
+                await hass.async_add_executor_job((directory / filename).write_text, content)
+
+                landing_url = build_capture_notification_url(hass, filename)
+                _LOGGER.info(
+                    "GivEnergy frame capture saved to %s (%d frames)", filename, len(frames)
+                )
+                async_create_notification(
+                    hass,
+                    (
+                        f"Captured {len(frames)} frames over {duration} s.\n\n"
+                        f"[Open the capture]({landing_url}) to inspect it, download "
+                        "the file, or open a pre-filled GitHub issue."
+                    ),
+                    title="GivEnergy frame capture complete",
+                    notification_id=f"givenergy_capture_{inv}",
                 )
 
         hass.services.async_register(

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -313,8 +313,8 @@ async def _async_register_capture_http(hass: HomeAssistant) -> None:
     if hass.http is None:
         # No web server (e.g. a minimal test harness) — nothing to serve from.
         return
-    hass.http.register_view(CaptureLandingView())
-    hass.http.register_view(CaptureDownloadView())
+    hass.http.register_view(CaptureLandingView(hass))
+    hass.http.register_view(CaptureDownloadView(hass))
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/givenergy_local/http.py
+++ b/custom_components/givenergy_local/http.py
@@ -103,10 +103,13 @@ class CaptureLandingView(HomeAssistantView):
     name = f"api:{DOMAIN}:capture"
     requires_auth = True  # accepts a valid bearer header or a signed authSig query
 
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+
     async def get(self, request: web.Request, filename: str) -> web.StreamResponse:
         if not CAPTURE_FILENAME_RE.match(filename):
             return web.Response(status=404)
-        hass: HomeAssistant = request.app["hass"]
+        hass = self.hass
         path = capture_dir(hass) / filename
         content = await hass.async_add_executor_job(_read_if_present, path)
         if content is None:
@@ -149,10 +152,13 @@ class CaptureDownloadView(HomeAssistantView):
     name = f"api:{DOMAIN}:capture:download"
     requires_auth = True  # signed authSig query works here too, so curl can fetch
 
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+
     async def get(self, request: web.Request, filename: str) -> web.StreamResponse:
         if not CAPTURE_FILENAME_RE.match(filename):
             return web.Response(status=404)
-        hass: HomeAssistant = request.app["hass"]
+        hass = self.hass
         path = capture_dir(hass) / filename
         content = await hass.async_add_executor_job(_read_if_present, path)
         if content is None:

--- a/custom_components/givenergy_local/http.py
+++ b/custom_components/givenergy_local/http.py
@@ -1,0 +1,229 @@
+"""HTTP views backing the frame-capture issue-report flow (issue #64).
+
+A capture is written to ``<config>/givenergy_local_captures/`` (out of ``/local/``,
+so it's never served unauthenticated). The persistent notification links to
+:class:`CaptureLandingView`, a single page that lets the user inspect the capture
+inline, switch between past captures, download the file, or open a pre-filled
+GitHub issue.
+
+Auth note: HA's HTTP stack authenticates via a bearer header or a signed-request
+``authSig`` query param — there is no cookie auth, so a plain ``<a href>``
+navigation from a notification would otherwise 401. Every link the user follows
+(the notification → landing URL, each dropdown entry, the download link) is
+therefore individually signed via :func:`async_sign_path` with a ~1h expiry.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from datetime import timedelta
+from pathlib import Path
+from urllib.parse import urlencode
+
+from aiohttp import web
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.http.auth import async_sign_path
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+CAPTURE_DIR_NAME = "givenergy_local_captures"
+
+# Captures are named purely from an epoch — no user/inverter input reaches the
+# filename, but the views still re-validate against this allowlist so a crafted
+# URL can never escape the capture directory (path-traversal-proof).
+CAPTURE_FILENAME_RE = re.compile(r"^capture_givenergy_\d+\.txt$")
+
+_SIGNED_URL_TTL = timedelta(hours=1)
+
+_GITHUB_ISSUE_URL = "https://github.com/dewet22/givenergy-hass/issues/new"
+_GITHUB_ISSUE_BODY = """\
+**What happened?**
+
+
+**Steps to reproduce**
+
+
+**Modbus wire capture**
+Please attach the capture file you downloaded from this page — drag-and-drop it
+into this issue (GitHub doesn't support attaching files via a link). The capture
+includes the environment details needed to triage, so there's no need to fill
+those in by hand.
+"""
+
+
+def capture_dir(hass: HomeAssistant) -> Path:
+    """Directory holding wire captures for this integration."""
+    return Path(hass.config.path(CAPTURE_DIR_NAME))
+
+
+def landing_path(filename: str) -> str:
+    return f"/api/{DOMAIN}/capture/{filename}"
+
+
+def download_path(filename: str) -> str:
+    return f"/api/{DOMAIN}/capture/{filename}/download"
+
+
+def _epoch_from_filename(filename: str) -> int:
+    # capture_givenergy_<epoch>.txt — regex-validated before we get here.
+    return int(filename[len("capture_givenergy_") : -len(".txt")])
+
+
+def _split_header(content: str) -> tuple[str, str]:
+    """Split a capture into its leading ``# ``-prefixed env header and the body."""
+    lines = content.splitlines()
+    cut = 0
+    for cut, line in enumerate(lines):  # noqa: B007 - cut is used after the loop
+        if line and not line.startswith("#"):
+            break
+    else:
+        cut = len(lines)
+    return "\n".join(lines[:cut]), "\n".join(lines[cut:])
+
+
+async def _list_captures(hass: HomeAssistant) -> list[str]:
+    """Capture filenames, newest first."""
+    directory = capture_dir(hass)
+
+    def _scan() -> list[str]:
+        if not directory.is_dir():
+            return []
+        names = [p.name for p in directory.iterdir() if CAPTURE_FILENAME_RE.match(p.name)]
+        return sorted(names, key=_epoch_from_filename, reverse=True)
+
+    return await hass.async_add_executor_job(_scan)
+
+
+class CaptureLandingView(HomeAssistantView):
+    """Landing page for a single capture: inspect, switch, download, file issue."""
+
+    url = "/api/" + DOMAIN + "/capture/{filename}"
+    name = f"api:{DOMAIN}:capture"
+    requires_auth = True  # accepts a valid bearer header or a signed authSig query
+
+    async def get(self, request: web.Request, filename: str) -> web.StreamResponse:
+        if not CAPTURE_FILENAME_RE.match(filename):
+            return web.Response(status=404)
+        hass: HomeAssistant = request.app["hass"]
+        path = capture_dir(hass) / filename
+        content = await hass.async_add_executor_job(_read_if_present, path)
+        if content is None:
+            return web.Response(status=404)
+
+        captures = await _list_captures(hass)
+        header, body = _split_header(content)
+
+        options = []
+        for name in captures:
+            signed = async_sign_path(hass, landing_path(name), _SIGNED_URL_TTL)
+            selected = " selected" if name == filename else ""
+            options.append(
+                f'<option value="{html.escape(signed, quote=True)}" '
+                f'data-epoch="{_epoch_from_filename(name)}"{selected}>'
+                f"{html.escape(name)}</option>"
+            )
+
+        download_url = async_sign_path(hass, download_path(filename), _SIGNED_URL_TTL)
+        github_url = (
+            _GITHUB_ISSUE_URL
+            + "?"
+            + urlencode({"title": "", "body": _GITHUB_ISSUE_BODY, "labels": "bug"})
+        )
+
+        page = _LANDING_TEMPLATE.format(
+            options="\n".join(options),
+            header=html.escape(header),
+            body=html.escape(body),
+            download_url=html.escape(download_url, quote=True),
+            github_url=html.escape(github_url, quote=True),
+        )
+        return web.Response(text=page, content_type="text/html")
+
+
+class CaptureDownloadView(HomeAssistantView):
+    """Serve a capture as a file download (browser cookie-less click or curl)."""
+
+    url = "/api/" + DOMAIN + "/capture/{filename}/download"
+    name = f"api:{DOMAIN}:capture:download"
+    requires_auth = True  # signed authSig query works here too, so curl can fetch
+
+    async def get(self, request: web.Request, filename: str) -> web.StreamResponse:
+        if not CAPTURE_FILENAME_RE.match(filename):
+            return web.Response(status=404)
+        hass: HomeAssistant = request.app["hass"]
+        path = capture_dir(hass) / filename
+        content = await hass.async_add_executor_job(_read_if_present, path)
+        if content is None:
+            return web.Response(status=404)
+        return web.Response(
+            text=content,
+            content_type="text/plain",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+
+def _read_if_present(path: Path) -> str | None:
+    try:
+        return path.read_text()
+    except FileNotFoundError:
+        return None
+
+
+def build_capture_notification_url(hass: HomeAssistant, filename: str) -> str:
+    """Signed landing-page URL for the persistent notification link."""
+    return async_sign_path(hass, landing_path(filename), _SIGNED_URL_TTL)
+
+
+_LANDING_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>GivEnergy Local — wire capture</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; margin: 1.5rem; max-width: 70rem; }}
+  h1 {{ font-size: 1.3rem; }}
+  pre {{ background: #f5f5f5; padding: 1rem; overflow-x: auto; border-radius: 6px;
+         white-space: pre-wrap; word-break: break-all; }}
+  .env {{ background: #eef4ff; }}
+  .actions a {{ display: inline-block; margin-right: 1rem; padding: 0.5rem 1rem;
+                background: #03a9f4; color: #fff; text-decoration: none;
+                border-radius: 6px; }}
+  .actions a.github {{ background: #24292f; }}
+  select {{ padding: 0.4rem; }}
+</style>
+</head>
+<body>
+<h1>GivEnergy Local — Modbus wire capture</h1>
+
+<form>
+  <label>Capture:
+    <select id="capture-select" onchange="window.location = this.value;">
+{options}
+    </select>
+  </label>
+</form>
+
+<pre class="env">{header}</pre>
+
+<p class="actions">
+  <a href="{download_url}">Download capture</a>
+  <a class="github" href="{github_url}" target="_blank" rel="noopener">Open a GitHub issue</a>
+</p>
+
+<h2 style="font-size:1.1rem">Captured frames</h2>
+<pre>{body}</pre>
+
+<script>
+  // Render each capture's epoch in the viewer's locale; the value stays a signed URL.
+  for (const opt of document.querySelectorAll('#capture-select option')) {{
+    const epoch = Number(opt.dataset.epoch);
+    if (epoch) opt.textContent = new Date(epoch * 1000).toLocaleString();
+  }}
+</script>
+</body>
+</html>
+"""

--- a/custom_components/givenergy_local/services.yaml
+++ b/custom_components/givenergy_local/services.yaml
@@ -61,9 +61,10 @@ capture_frames:
   name: Capture debug frames
   description: >
     Records raw Modbus wire frames from the inverter for a set duration and
-    saves them as a redacted text file in /local/. A persistent notification
-    with a download link appears when the capture finishes. Attach the file
-    when reporting connectivity or communication issues.
+    saves them as a redacted text file with an environment header. A persistent
+    notification appears when the capture finishes, linking to a page where you
+    can inspect the capture, download it, or open a pre-filled GitHub issue —
+    handy when reporting connectivity or communication problems.
   fields:
     device_id:
       name: Device

--- a/custom_components/givenergy_local/strings.json
+++ b/custom_components/givenergy_local/strings.json
@@ -57,7 +57,7 @@
   "services": {
     "capture_frames": {
       "name": "Capture debug frames",
-      "description": "Records raw Modbus wire frames from the inverter for a set duration and saves them as a redacted text file in /local/.",
+      "description": "Records raw Modbus wire frames from the inverter for a set duration and saves them as a redacted text file with an environment header. A persistent notification links to a page to inspect, download, or report the capture.",
       "fields": {
         "device_id": {
           "name": "Device",

--- a/custom_components/givenergy_local/translations/en.json
+++ b/custom_components/givenergy_local/translations/en.json
@@ -79,7 +79,7 @@
     },
     "capture_frames": {
       "name": "Capture debug frames",
-      "description": "Records raw Modbus wire frames from the inverter for a set duration and saves them as a redacted text file in /local/.",
+      "description": "Records raw Modbus wire frames from the inverter for a set duration and saves them as a redacted text file with an environment header. A persistent notification links to a page to inspect, download, or report the capture.",
       "fields": {
         "device_id": {
           "name": "Device",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,6 +202,7 @@ def mock_client(mock_plant) -> AsyncMock:
             "detect",
             "close",
             "one_shot_command",
+            "capture_frames",
         ]
     )
     client.connected = True

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,0 +1,196 @@
+"""Tests for the frame-capture issue-report flow (issue #64).
+
+The capture service writes a header-prefixed file to
+``<config>/givenergy_local_captures/`` and posts a persistent notification
+linking to a signed landing page. Two authenticated views serve the page and a
+download; both reject anything outside the strict capture-filename allowlist.
+"""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from custom_components.givenergy_local import _build_capture_header
+from custom_components.givenergy_local.const import DOMAIN, SERVICE_CAPTURE_FRAMES
+from custom_components.givenergy_local.http import (
+    CAPTURE_FILENAME_RE,
+    _split_header,
+    capture_dir,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_capture_dir(hass):
+    """The test config dir is shared/persistent, so wipe captures around each test."""
+    import shutil
+
+    directory = capture_dir(hass)
+    shutil.rmtree(directory, ignore_errors=True)
+    yield
+    shutil.rmtree(directory, ignore_errors=True)
+
+
+@pytest.fixture
+async def capture_setup(hass, mock_client, mock_config_entry):
+    """Set up the integration with the http component available.
+
+    Signing capture URLs and registering the capture views both need
+    ``http`` up *before* the integration's ``async_setup`` runs, so unlike the
+    shared ``setup_integration`` fixture this sets up http first.
+    """
+    assert await async_setup_component(hass, "http", {})
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
+
+
+def _make_capture_sink(frames: list[str]):
+    """Return an async stand-in for client.capture_frames that emits `frames`."""
+
+    async def _capture_frames(sink, duration):  # noqa: ARG001
+        for line in frames:
+            direction, _, data = line.partition(": ")
+            sink(direction, bytes.fromhex(data))
+
+    return _capture_frames
+
+
+# ---------------------------------------------------------------------------
+# Header builder + helpers (no web server needed)
+# ---------------------------------------------------------------------------
+
+
+async def test_build_capture_header_contains_env_and_no_serial(hass):
+    header = await _build_capture_header(
+        hass, generated=dt_util.now(), duration=60.0, frame_count=247
+    )
+    assert "# GivEnergy Local — Modbus wire capture" in header
+    assert "# Duration:       60s" in header
+    assert "# Frames:         247" in header
+    assert "# Home Assistant:" in header
+    assert "# Python:" in header
+    assert "# OS:" in header
+    assert "# Integration:" in header
+    assert "# Library:        givenergy-modbus" in header
+    # Redaction principle: never an inverter serial in the shared header.
+    assert "SA1234G123" not in header
+
+
+def test_split_header_separates_env_block_from_body():
+    content = "# GivEnergy\n# Generated: x\n#\nTX: 0102\nRX: 0304\n"
+    header, body = _split_header(content)
+    assert header == "# GivEnergy\n# Generated: x\n#"
+    assert body == "TX: 0102\nRX: 0304\n".strip("\n")
+
+
+@pytest.mark.parametrize(
+    ("name", "ok"),
+    [
+        ("capture_givenergy_1717500000.txt", True),
+        ("capture_givenergy_0.txt", True),
+        ("capture_givenergy_.txt", False),
+        ("capture_givenergy_abc.txt", False),
+        ("../secrets.yaml", False),
+        ("capture_givenergy_1.txt.bak", False),
+        ("dashboard_givenergy_x.yaml", False),
+    ],
+)
+def test_capture_filename_allowlist(name, ok):
+    assert bool(CAPTURE_FILENAME_RE.match(name)) is ok
+
+
+# ---------------------------------------------------------------------------
+# Service: writes a capture file + posts a landing-page notification
+# ---------------------------------------------------------------------------
+
+
+async def test_capture_dir_created_at_setup(hass, capture_setup):
+    assert capture_dir(hass).is_dir()
+
+
+async def test_capture_frames_writes_file_with_header(hass, mock_client, capture_setup):
+    mock_client.capture_frames.side_effect = _make_capture_sink(["TX: 0102", "RX: 0304"])
+    await hass.services.async_call(DOMAIN, SERVICE_CAPTURE_FRAMES, {"duration": 10}, blocking=True)
+    files = list(capture_dir(hass).glob("capture_givenergy_*.txt"))
+    assert len(files) == 1
+    content = files[0].read_text()
+    assert content.startswith("# GivEnergy Local")
+    assert "# Frames:         2" in content
+    assert "TX: 0102" in content and "RX: 0304" in content
+
+
+async def test_capture_frames_posts_landing_notification(hass, mock_client, capture_setup):
+    mock_client.capture_frames.side_effect = _make_capture_sink([])
+    await hass.services.async_call(DOMAIN, SERVICE_CAPTURE_FRAMES, {"duration": 10}, blocking=True)
+    notifications = hass.data.get("persistent_notification", {})
+    note = next(n for nid, n in notifications.items() if "givenergy_capture_" in nid)
+    message = note["message"]
+    assert f"/api/{DOMAIN}/capture/" in message
+    assert "authSig=" in message  # signed landing link
+
+
+# ---------------------------------------------------------------------------
+# Views (served over the authenticated test client)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def captured(hass, mock_client, capture_setup):
+    """Run a capture and return its filename."""
+    mock_client.capture_frames.side_effect = _make_capture_sink(["TX: dead", "RX: beef"])
+    await hass.services.async_call(DOMAIN, SERVICE_CAPTURE_FRAMES, {"duration": 10}, blocking=True)
+    (path,) = list(capture_dir(hass).glob("capture_givenergy_*.txt"))
+    return path.name
+
+
+async def test_landing_view_renders_page(hass, hass_client, captured):
+    client = await hass_client()
+    resp = await client.get(f"/api/{DOMAIN}/capture/{captured}")
+    assert resp.status == 200
+    text = await resp.text()
+    assert "GivEnergy Local — Modbus wire capture" in text
+    assert captured in text  # dropdown option for this capture
+    assert "dead" in text and "beef" in text  # frames embedded inline
+    assert "/issues/new" in text  # GitHub link
+
+
+async def test_landing_view_rejects_bad_filename(hass, hass_client, capture_setup):
+    client = await hass_client()
+    resp = await client.get(f"/api/{DOMAIN}/capture/evil.txt")
+    assert resp.status == 404
+
+
+async def test_download_view_serves_attachment(hass, hass_client, captured):
+    client = await hass_client()
+    resp = await client.get(f"/api/{DOMAIN}/capture/{captured}/download")
+    assert resp.status == 200
+    assert resp.headers["Content-Disposition"] == f'attachment; filename="{captured}"'
+    assert "dead" in await resp.text()
+
+
+async def test_download_view_rejects_bad_filename(hass, hass_client, capture_setup):
+    client = await hass_client()
+    resp = await client.get(f"/api/{DOMAIN}/capture/evil.txt/download")
+    assert resp.status == 404
+
+
+async def test_download_via_signed_url_without_auth(hass, hass_client_no_auth, captured):
+    """A signed download URL works without an auth header (curl from a terminal)."""
+    from datetime import timedelta
+
+    from homeassistant.components.http.auth import async_sign_path
+
+    signed = async_sign_path(hass, f"/api/{DOMAIN}/capture/{captured}/download", timedelta(hours=1))
+    client = await hass_client_no_auth()
+    resp = await client.get(signed)
+    assert resp.status == 200
+    assert "dead" in await resp.text()
+
+
+async def test_unsigned_download_without_auth_is_rejected(hass, hass_client_no_auth, captured):
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/api/{DOMAIN}/capture/{captured}/download")
+    assert resp.status == 401

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -126,7 +126,8 @@ async def test_capture_frames_posts_landing_notification(hass, mock_client, capt
     mock_client.capture_frames.side_effect = _make_capture_sink([])
     await hass.services.async_call(DOMAIN, SERVICE_CAPTURE_FRAMES, {"duration": 10}, blocking=True)
     notifications = hass.data.get("persistent_notification", {})
-    note = next(n for nid, n in notifications.items() if "givenergy_capture_" in nid)
+    note = next((n for nid, n in notifications.items() if "givenergy_capture_" in nid), None)
+    assert note is not None, "expected a givenergy_capture_* notification"
     message = note["message"]
     assert f"/api/{DOMAIN}/capture/" in message
     assert "authSig=" in message  # signed landing link

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -71,7 +71,10 @@ async def test_frontend_card_served_and_autoloaded():
     hass.data = {}
     hass.http.async_register_static_paths = AsyncMock()
 
-    with patch("custom_components.givenergy_local.add_extra_js_url") as add_js:
+    with (
+        patch("custom_components.givenergy_local.add_extra_js_url") as add_js,
+        patch("custom_components.givenergy_local._async_register_capture_http"),
+    ):
         assert await async_setup(hass, {}) is True
 
     hass.http.async_register_static_paths.assert_awaited_once()
@@ -108,7 +111,10 @@ async def test_frontend_card_skipped_when_http_unavailable():
     hass.data = {}
     hass.http = None
 
-    with patch("custom_components.givenergy_local.add_extra_js_url") as add_js:
+    with (
+        patch("custom_components.givenergy_local.add_extra_js_url") as add_js,
+        patch("custom_components.givenergy_local._async_register_capture_http"),
+    ):
         assert await async_setup(hass, {}) is True
 
     add_js.assert_not_called()
@@ -120,7 +126,10 @@ async def test_frontend_card_failure_does_not_break_setup():
     hass.data = {}
     hass.http.async_register_static_paths = AsyncMock(side_effect=RuntimeError("boom"))
 
-    with patch("custom_components.givenergy_local.add_extra_js_url") as add_js:
+    with (
+        patch("custom_components.givenergy_local.add_extra_js_url") as add_js,
+        patch("custom_components.givenergy_local._async_register_capture_http"),
+    ):
         assert await async_setup(hass, {}) is True  # must not raise
 
     add_js.assert_not_called()


### PR DESCRIPTION
## Summary

Extends `capture_frames` so each capture produces a proper landing page rather than dumping a raw file into `/local/`.

**What changed:**

- Captures now land in `<config>/givenergy_local_captures/` (created at setup) rather than the web-accessible `www/` directory.
- Each capture file gets a prepended environment header: HA version, Python, OS, integration version, and library version. No inverter serial/model/firmware — respects the library's redaction principle.
- A persistent notification links to a signed landing page (`/api/givenergy_local/capture/<filename>`) that shows the environment block, an inline frame dump, a download link (signed, ~1 h TTL), and a pre-filled GitHub issue link.
- A separate download endpoint (`…/<filename>/download`) validates the filename against a strict allowlist regex to prevent path traversal.
- Two new `HomeAssistantView` subclasses in a new `http.py` module, registered at setup.

The landing-page links use HA's signed-URL mechanism rather than cookie auth — HA's HTTP layer accepts bearer tokens or signed `authSig` query params, not cookies, so all nav links are signed.

## Test plan

- [ ] Capture dir created on integration setup
- [ ] Capture file written with correct env header (no serial/model)
- [ ] Notification message contains a signed link to the landing page
- [ ] Landing page returns 200, shows environment block, inline frames, download link, GitHub issue link
- [ ] Download endpoint returns `Content-Disposition: attachment`
- [ ] Bad filename rejected with 404 at both endpoints
- [ ] Signed URL accepted without auth header; unsigned request returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Frame captures now include environment metadata: generation timestamp, capture duration, frame count, Home Assistant version, Python version, operating system, and integration version.
  * New landing page for inspecting, downloading, and reporting captured frames.
  * Captures can generate pre-filled GitHub issue reports.

* **Documentation**
  * Updated capture service documentation to reflect new landing page workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->