### PR TITLE
feat(sensor): suppress single-phase-only sensors on three-phase plants (#94)

### DIFF
--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -47,6 +47,10 @@ class GivEnergyInverterSensorDescription(SensorEntityDescription):
     value_fn: Callable[[InverterModel], Any] = field(default=lambda _: None)
     # If True, the entity is not created when value_fn returns None at first refresh.
     skip_if_none: bool = False
+    # If True, the entity is not created on three-phase inverters, where the
+    # underlying field is single-phase-only (e.g. a p_pv1+p_pv2 sum) and so would
+    # be meaningless or surface as a permanently-unavailable orphan entity.
+    single_phase_only: bool = False
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -203,6 +207,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         # Computed (p_pv1 + p_pv2) so not register-backed; watts -> 0 decimals.
         suggested_display_precision=0,
         value_fn=lambda inv: inv.p_pv(),
+        single_phase_only=True,
     ),
     GivEnergyInverterSensorDescription(
         key="p_pv1",
@@ -265,6 +270,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         # Computed (e_pv1_day + e_pv2_day, each deci-scaled kWh) -> 1 decimal.
         suggested_display_precision=1,
         value_fn=lambda inv: inv.e_pv_day(),
+        single_phase_only=True,
     ),
     GivEnergyInverterSensorDescription(
         key="e_pv1_day",
@@ -734,6 +740,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         suggested_display_precision=2,
         value_fn=lambda inv: inv.battery_capacity_kwh,
         entity_category=EntityCategory.DIAGNOSTIC,
+        single_phase_only=True,
     ),
 )
 
@@ -986,9 +993,16 @@ COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
 
 
 def _include_inverter_sensor(
-    description: GivEnergyInverterSensorDescription, inverter: InverterModel
+    description: GivEnergyInverterSensorDescription,
+    inverter: InverterModel,
+    is_three_phase: bool,
 ) -> bool:
     """Whether to create an inverter sensor at setup.
+
+    `single_phase_only` descriptions are dropped on three-phase inverters, where
+    the underlying field is single-phase-only — gating on plant topology rather
+    than a runtime None avoids suppressing a genuine single-phase sensor during a
+    transient partial first read.
 
     `skip_if_none` descriptions have their `value_fn` evaluated eagerly here, so a
     single bad descriptor — e.g. a library field renamed out from under us — must
@@ -996,6 +1010,8 @@ def _include_inverter_sensor(
     field rename in givenergy-modbus once dropped every sensor). Guard the call:
     skip the offending sensor with a warning, but keep the rest.
     """
+    if description.single_phase_only and is_three_phase:
+        return False
     if not description.skip_if_none:
         return True
     try:
@@ -1016,11 +1032,13 @@ async def async_setup_entry(
 ) -> None:
     coordinator: GivEnergyUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     inverter = coordinator.data.inverter
+    capabilities = coordinator.data.capabilities
+    is_three_phase = bool(capabilities and capabilities.is_three_phase)
 
     entities: list[SensorEntity] = [
         GivEnergyInverterSensor(coordinator, description)
         for description in INVERTER_SENSORS
-        if _include_inverter_sensor(description, inverter)
+        if _include_inverter_sensor(description, inverter, is_three_phase)
     ]
 
     for battery_index, battery in enumerate(coordinator.data.batteries):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -85,10 +85,30 @@ def test_setup_filter_skips_bad_descriptor_instead_of_crashing():
     )
 
     inv = MagicMock()
-    assert _include_inverter_sensor(bad, inv) is False  # skipped, no raise
-    assert _include_inverter_sensor(good, inv) is True
+    assert _include_inverter_sensor(bad, inv, False) is False  # skipped, no raise
+    assert _include_inverter_sensor(good, inv, False) is True
     # non-skip descriptors aren't evaluated at setup, so they're always included
-    assert _include_inverter_sensor(plain, inv) is True
+    assert _include_inverter_sensor(plain, inv, False) is True
+
+
+def test_single_phase_only_sensors_gated_on_three_phase():
+    """single_phase_only descriptions are dropped on three-phase plants but kept on
+    single-phase — otherwise the single-phase-only PV/capacity fields surface as
+    permanently-unavailable orphan entities on three-phase inverters (#94)."""
+    inv = MagicMock()
+    gated_keys = {"p_pv", "e_pv_day", "battery_capacity_kwh"}
+
+    # Every gated key must actually carry the flag (guards against silent drift if
+    # one is renamed/removed) ...
+    flagged = {d.key for d in INVERTER_SENSORS if d.single_phase_only}
+    assert flagged == gated_keys
+
+    # ... is excluded on three-phase ...
+    for key in gated_keys:
+        assert _include_inverter_sensor(_inverter_desc(key), inv, True) is False
+    # ... and retained on single-phase.
+    for key in gated_keys:
+        assert _include_inverter_sensor(_inverter_desc(key), inv, False) is True
 
 
 def test_device_kind_buckets_to_inverter_ems_gateway():
@@ -125,6 +145,35 @@ async def test_expected_sensor_count(hass, setup_integration):
     # 1 battery → inverter sensors + battery sensors + coordinator diagnostics
     expected = len(INVERTER_SENSORS) + len(BATTERY_SENSORS) + len(COORDINATOR_SENSORS)
     assert len(sensors) == expected
+
+
+async def test_single_phase_only_sensors_absent_on_three_phase(
+    hass, mock_client, mock_config_entry
+):
+    """On a three-phase plant the single-phase-only PV/capacity sensors must not be
+    created — otherwise they render as permanently-unavailable orphans (#94). The
+    default (single-phase) fixture keeps them, asserted by test_expected_sensor_count.
+    """
+    from givenergy_modbus.model.inverter import Model
+    from givenergy_modbus.model.plant import PlantCapabilities
+
+    mock_client.plant.capabilities = PlantCapabilities(
+        device_type=Model.HYBRID_3PH,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    for key in ("p_pv", "e_pv_day", "battery_capacity_kwh"):
+        assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is None, (
+            f"{key} should be suppressed on three-phase"
+        )
 
 
 async def test_pv_power_sensor(hass, setup_integration):


### PR DESCRIPTION
## Summary

Stops single-phase-only inverter sensors rendering as permanently-unavailable orphan entities on three-phase plants.

**What changed:**

- Adds a `single_phase_only: bool = False` field to `GivEnergyInverterSensorDescription`.
- `_include_inverter_sensor` gains an `is_three_phase` parameter; it returns `False` early for any `single_phase_only` description when the plant is three-phase.
- `async_setup_entry` derives `is_three_phase` from `coordinator.data.capabilities.is_three_phase` (guarded against `None` for the pre-capabilities-cache path), and passes it through.
- Three descriptions are marked `single_phase_only=True`: `p_pv` (combined PV power, 2-string sum meaningless on 3-phase), `e_pv_day` (same reasoning), `battery_capacity_kwh` (single-phase computed field).
- `p_grid_out_ph1` ("Grid Power Phase 1") is deliberately *not* gated — Phase 1 is a real, meaningful quantity on three-phase too.

Gating on plant topology rather than a runtime `None` avoids accidentally suppressing a genuine single-phase sensor during a transient partial first read.

**Note:** the installed `givenergy-modbus` only ships `SinglePhaseInverter` today — there is no `ThreePhaseInverter` class yet, so this is the interim hass-side guard. Genuine three-phase parity (correct combined computed fields, aligned field names, a proper three-phase model) is a modbus-library change filed as a coordination handoff; once that lands, the `single_phase_only` flags can be removed and the sensors wired to the real three-phase fields.

## Test plan

- [ ] `test_single_phase_only_sensors_gated_on_three_phase` — unit-level: all three flagged descriptions are excluded when `is_three_phase=True`, retained when `False`
- [ ] `test_single_phase_only_sensors_absent_on_three_phase` — integration-level: set up with `HYBRID_3PH` capabilities, assert `p_pv` / `e_pv_day` / `battery_capacity_kwh` entity IDs are absent from the registry
- [ ] `test_expected_sensor_count` — existing test confirms single-phase default still creates all sensors

🤖 Generated with [Claude Code](https://claude.com/claude-code)