### PR TITLE
feat: rename 'Grid Export Power' to 'Grid Power' (signed net)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ When enabled, the integration connects to the inverter but sends no Modbus read 
 | Battery Charge Today | kWh | |
 | Battery Discharge Today | kWh | |
 | Battery Throughput Total | kWh | |
-| Grid Export Power | W | Positive = exporting, negative = importing |
+| Grid Power | W | Positive = exporting, negative = importing |
 | Grid Export / Import Today | kWh | |
 | Grid Export / Import Total | kWh | |
 | AC Voltage / Frequency | V / Hz | |
@@ -310,7 +310,7 @@ The dashboard's live view shows current power flow between solar, grid, battery 
 | Dashboard slot | Entity | Sign convention |
 |---|---|---|
 | Solar power | `PV Power` | Positive when producing |
-| Grid power | `Grid Export Power` | Positive = exporting, negative = importing |
+| Grid power | `Grid Power` | Positive = exporting, negative = importing |
 | Battery power | `Battery Power` | Positive = discharging, negative = charging |
 | Household demand | `Load Power` | This would be universally positive, unless you have another generation source |
 

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -370,6 +370,10 @@ _RENAMED_UNIQUE_ID_SUFFIXES = {
     # inverter AC output. Move both sensors together so today+total stay paired.
     "e_inverter_out_day": "e_pv_generation_today",
     "e_inverter_out_total": "e_pv_generation_total",
+    # #52: p_grid_out (IR30) is a signed net flow, not export-only — rename the
+    # surfaced entity to "Grid Power" to match. Existing history is valid (the
+    # underlying register hasn't changed), so re-point in place.
+    "p_grid_out": "grid_power",
 }
 
 

--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -38,7 +38,7 @@ EXPOSE_RECOMMENDED_ENTITY_KEYS = (
     "e_battery_discharge_day",
     "e_battery_throughput",
     # Grid
-    "p_grid_out",
+    "grid_power",
     "e_grid_in_day",
     "e_grid_out_day",
     "e_grid_in_total",

--- a/custom_components/givenergy_local/dashboard.py
+++ b/custom_components/givenergy_local/dashboard.py
@@ -163,7 +163,7 @@ def _overview_view(inv: str, max_power_kw: int) -> str:
             entity: {_i(inv, "battery_power")}
             state_of_charge: {_i(inv, "battery_soc")}
           grid:
-            entity: {_i(inv, "grid_export_power")}
+            entity: {_i(inv, "grid_power")}
           home:
             entity: {_i(inv, "load_power")}
 
@@ -215,7 +215,7 @@ def _overview_view(inv: str, max_power_kw: int) -> str:
           - entity: {_i(inv, "battery_power")}
             name: Battery
             color: "#42A5F5"
-          - entity: {_i(inv, "grid_export_power")}
+          - entity: {_i(inv, "grid_power")}
             name: Grid
             color: "#66BB6A"
           - entity: {_i(inv, "load_power")}

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -367,8 +367,8 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
     ),
     # --- Grid ---
     GivEnergyInverterSensorDescription(
-        key="p_grid_out",
-        name="Grid Export Power",
+        key="grid_power",
+        name="Grid Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,

--- a/dashboard/template.yaml
+++ b/dashboard/template.yaml
@@ -34,7 +34,7 @@ views:
             entity: sensor.givenergy_inverter_INVERTER_SERIAL_battery_power
             state_of_charge: sensor.givenergy_inverter_INVERTER_SERIAL_battery_soc
           grid:
-            entity: sensor.givenergy_inverter_INVERTER_SERIAL_grid_export_power
+            entity: sensor.givenergy_inverter_INVERTER_SERIAL_grid_power
           home:
             entity: sensor.givenergy_inverter_INVERTER_SERIAL_load_power
 
@@ -80,7 +80,7 @@ views:
           - entity: sensor.givenergy_inverter_INVERTER_SERIAL_battery_power
             name: Battery
             color: "#42A5F5"
-          - entity: sensor.givenergy_inverter_INVERTER_SERIAL_grid_export_power
+          - entity: sensor.givenergy_inverter_INVERTER_SERIAL_grid_power
             name: Grid
             color: "#66BB6A"
           - entity: sensor.givenergy_inverter_INVERTER_SERIAL_load_power

--- a/docs/migration-from-givtcp.md
+++ b/docs/migration-from-givtcp.md
@@ -67,7 +67,7 @@ Suffixes shown are after stripping the integration prefix and the inverter/batte
 |---|---|---|---|
 | 🔁 | `battery_power` | `battery_power` | Signed in both |
 | 🔁 | `combined_generation_power` | `combined_generation_power` |  |
-| 🔁 | `export_power` | `grid_export_power` |  |
+| 🔁 | `export_power` | `grid_power` | Renamed in v1.1.x — signed net at meter, positive = export |
 | 🔁 | `grid_power` | `grid_power_phase_1` | Single-phase inverter; three-phase users get three of these |
 | 🔁 | `load_power` | `load_power` | House load power (same name, same concept) |
 | 🔁 | `pv_power` | `pv_power` | PV total |

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -453,7 +453,7 @@ async def test_expose_recommended_entities_service(hass, mock_client, setup_inte
     # translation_key instead of its description key.
     entity_reg = er.async_get(hass)
     inverter_serial = "SA1234G123"  # from mock_config_entry fixture
-    for key in ("p_pv", "battery_soc", "p_grid_out", "p_load_demand", "status"):
+    for key in ("p_pv", "battery_soc", "grid_power", "p_load_demand", "status"):
         entry = entity_reg.async_get_entity_id("sensor", DOMAIN, f"{inverter_serial}_{key}")
         assert entry is not None, (
             f"No entity registered with unique_id {inverter_serial}_{key!r} — "

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -190,7 +190,7 @@ async def test_battery_soc_sensor(hass, setup_integration):
 
 async def test_grid_power_sensor_negative_is_import(hass, setup_integration):
     # p_grid_out is negative when importing from grid
-    state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_p_grid_out"))
+    state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_grid_power"))
     assert float(state.state) == -800
 
 
@@ -535,3 +535,30 @@ async def test_unique_id_migration_repoints_inverter_output_pair(
         migrated = registry.async_get(old_entry.entity_id)
         assert migrated is not None, f"entity_id {old_entry.entity_id!r} lost after migration"
         assert migrated.unique_id == expected_new_uid
+
+
+# --- #52: p_grid_out renamed to grid_power (signed net, not export-only) ---
+
+
+async def test_grid_power_old_uid_gone(hass, setup_integration):
+    """Old p_grid_out unique_id must be absent after migration."""
+    registry = er.async_get(hass)
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_p_grid_out") is None, (
+        "Old unique_id 'SA1234G123_p_grid_out' still registered — migration didn't run"
+    )
+
+
+async def test_unique_id_migration_repoints_grid_power(hass, mock_client, mock_config_entry):
+    """Pre-rename entities under the old p_grid_out unique_id are re-pointed in place."""
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    old = registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_p_grid_out", config_entry=mock_config_entry
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    migrated = registry.async_get(old.entity_id)
+    assert migrated is not None, f"entity_id {old.entity_id!r} lost after migration"
+    assert migrated.unique_id == "SA1234G123_grid_power"


### PR DESCRIPTION
## Summary

- The `p_grid_out` register (IR30) has always been a signed net-flow value at the meter boundary (positive = export, negative = import), but the entity was named "Grid Export Power" — misleading enough that users (most recently Nick on #52) build helper templates to surface the import side as a separate signal.
- Rename the descriptor key from `p_grid_out` to `grid_power` and the display name to "Grid Power". The library field reference (`inv.p_grid_out`) is unchanged; only the surfaced entity name moves.
- Existing entities are re-pointed via `_RENAMED_UNIQUE_ID_SUFFIXES` (same mechanism used in #113 for the `e_inverter_out_*` → `e_pv_generation_*` rename), so statistics history and entity customisations carry across.
- Dashboard generation, the `template.yaml` example, the GivTCP migration table, and the README sensor table are updated for the new name.

Refs #52.

## Test plan

- [x] Full local test suite green (`uv run pytest`): 228 passed.
- [x] New `test_unique_id_migration_repoints_grid_power` covers the re-pointing path; `test_grid_power_old_uid_gone` asserts the old suffix is gone after migration.
- [ ] Manual check after install: existing entity's friendly name updates to "Grid Power"; statistics history persists (no orphan `grid_export_power` row in long-term stats).
- [ ] Manual check: regenerated dashboard renders with the new entity reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)