### PR TITLE
feat(migrate): copy per-battery charge-cycle history from GivTCP

### DIFF
--- a/scripts/migrate_from_givtcp.py
+++ b/scripts/migrate_from_givtcp.py
@@ -46,7 +46,7 @@ GivTCP actually stopped.
 Serials are auto-detected — no hard-coding needed. Multi-inverter and
 multi-battery setups are handled automatically.
 
-What is migrated by default (all verified ✅ pairs):
+What is migrated by default:
   Solar generation today / lifetime
   Grid import today / lifetime
   Grid export today / lifetime
@@ -136,11 +136,12 @@ INVERTER_PAIRS: list[tuple[str, str, str, bool]] = [
 # Suffixes relative to: sensor.givtcp_<batt_sn>_<givtcp_suffix>
 #                  and: sensor.givenergy_battery_<batt_sn>_<ge_suffix>
 #
-# NOTE: GivTCP tracks battery metrics under the inverter serial only — it does
-# not create per-battery-pack LTS statistics. The givenergy_local charge_cycles
-# sensors (per battery serial) have no GivTCP counterpart to backfill from, so
-# this list is intentionally empty.
-BATTERY_PAIRS: list[tuple[str, str, str, str]] = []
+BATTERY_PAIRS: list[tuple[str, str, str, str]] = [
+    # GivTCP exposes per-battery cycle counts (sensor.givtcp_<batt_sn>_battery_cycles).
+    # The givenergy_local target entity_id is ..._charge_cycles — the slug of the
+    # sensor's "Charge Cycles" name, NOT its internal description key (num_cycles).
+    ("battery_cycles", "charge_cycles", "Battery charge cycles", ""),
+]
 
 # ---------------------------------------------------------------------------
 # Serial detection

--- a/tests/test_script_entity_refs.py
+++ b/tests/test_script_entity_refs.py
@@ -38,17 +38,16 @@ def _registered_entity_ids(hass) -> set[str]:
     return {e.entity_id for e in er.async_get(hass).entities.values()}
 
 
-def _inverter_pairs_from_source() -> list[tuple]:
-    """Extract INVERTER_PAIRS from the migrate script without importing it.
+def _pairs_from_source(var_name: str) -> list[tuple]:
+    """Extract a ``*_PAIRS`` literal from the migrate script without importing it.
 
     The script imports ``websockets`` at module load (sys.exit if absent), so a
-    direct import isn't viable in CI. The mapping is a pure literal, so parse it
-    out of the AST instead.
+    direct import isn't viable in CI. The mappings are pure literals declared as
+    annotated assignments (``NAME: list[tuple[...]] = [...]``), so parse them out
+    of the AST instead.
     """
     tree = ast.parse(_MIGRATE_SCRIPT.read_text())
     for node in tree.body:
-        # The script declares it as an annotated assignment:
-        #   INVERTER_PAIRS: list[tuple[...]] = [...]
         targets = (
             node.targets
             if isinstance(node, ast.Assign)
@@ -56,10 +55,10 @@ def _inverter_pairs_from_source() -> list[tuple]:
             if isinstance(node, ast.AnnAssign)
             else []
         )
-        if any(isinstance(t, ast.Name) and t.id == "INVERTER_PAIRS" for t in targets):
+        if any(isinstance(t, ast.Name) and t.id == var_name for t in targets):
             assert node.value is not None
             return ast.literal_eval(node.value)
-    raise AssertionError("INVERTER_PAIRS not found in migrate_from_givtcp.py")
+    raise AssertionError(f"{var_name} not found in migrate_from_givtcp.py")
 
 
 async def test_dashboard_entity_refs_all_registered(hass, setup_integration):
@@ -83,7 +82,7 @@ async def test_migrate_script_targets_all_registered(hass, setup_integration):
     targets a non-existent statistics ID.
     """
     registered = _registered_entity_ids(hass)
-    pairs = _inverter_pairs_from_source()
+    pairs = _pairs_from_source("INVERTER_PAIRS")
     assert pairs, "INVERTER_PAIRS is empty"
     missing = sorted(
         f"sensor.givenergy_inverter_{INV}_{ge_suffix}"
@@ -93,4 +92,27 @@ async def test_migrate_script_targets_all_registered(hass, setup_integration):
     assert not missing, (
         "migrate_from_givtcp.py maps to entities the integration no longer "
         f"creates (entity rename not propagated to the script?): {missing}"
+    )
+
+
+async def test_migrate_script_battery_targets_all_registered(hass, setup_integration):
+    """Every givenergy_local battery target the migrate script maps to must exist.
+
+    The script writes statistics to ``sensor.givenergy_battery_<sn>_<ge_suffix>``;
+    a battery suffix that drifts from the real entity slug — e.g. the description
+    *key* ``num_cycles`` vs the *entity_id* slug ``charge_cycles`` (derived from
+    the "Charge Cycles" name) — would silently target a non-existent statistics
+    ID. ``BATTERY_PAIRS`` may legitimately be empty, in which case there is
+    nothing to check.
+    """
+    registered = _registered_entity_ids(hass)
+    pairs = _pairs_from_source("BATTERY_PAIRS")
+    missing = sorted(
+        f"sensor.givenergy_battery_{BATT}_{ge_suffix}"
+        for _givtcp, ge_suffix, *_rest in pairs
+        if f"sensor.givenergy_battery_{BATT}_{ge_suffix}" not in registered
+    )
+    assert not missing, (
+        "migrate_from_givtcp.py maps to battery entities the integration no "
+        f"longer creates (entity rename not propagated to the script?): {missing}"
     )


### PR DESCRIPTION
## What

- Adds the missing `battery_cycles → charge_cycles` pair to `BATTERY_PAIRS` in the GivTCP migration script, so per-battery cycle-count history is carried across on cut-over.
- Extends `tests/test_script_entity_refs.py` to validate `BATTERY_PAIRS` targets against the live registry (it previously only checked `INVERTER_PAIRS`).

## Why

GivTCP exposes per-battery cycle counts (`sensor.givtcp_<sn>_battery_cycles`), but `BATTERY_PAIRS` was empty, so that statistic wasn't migrated.

## The subtle bit (for reviewers)

The givenergy_local target entity_id is **`..._charge_cycles`**, not `..._num_cycles`. v1.1 renamed the sensor's description **key** to `num_cycles`, but the **entity_id** is the slug of the unchanged `name="Charge Cycles"` → `charge_cycles`. Targeting `num_cycles` would write history into a non-existent statistic ID. Confirmed live and against the test fixture's registry.

The guard-test gap is what let this class of error hide: it only checked `INVERTER_PAIRS`. The new `test_migrate_script_battery_targets_all_registered` closes it.

## Testing

- Full suite green (`uv run pytest` → 243 passed); ruff clean; mypy-clean for the touched files.
- New battery guard test passes with `charge_cycles` and fails on `num_cycles` (verified).

## Out of scope (noticed, not addressed here)

- `tests/test_script_entity_refs.py::test_dashboard_entity_refs_all_registered` is **flaky** under full-suite ordering — `switch`/`time` entities intermittently fail to re-register after other tests run first. Pre-existing; unrelated to this change.
- Pre-existing mypy errors in `custom_components/givenergy_local/__init__.py` (lines 417/482/606/671).

🤖 Generated with [Claude Code](https://claude.com/claude-code)