### PR TITLE
fix: carry device name in control-platform DeviceInfo to stabilise entity_ids

### DIFF
--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import GivEnergyUpdateCoordinator, InverterModel
+from .sensor import _device_kind
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -231,8 +232,10 @@ class GivEnergyNumberEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], Numbe
         self.entity_description = description
         serial = coordinator.data.inverter_serial_number
         self._attr_unique_id = f"{serial}_{description.key}"
+        model = coordinator.data.inverter.model
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy {_device_kind(model)} {serial}",
         )
 
     @property
@@ -262,8 +265,10 @@ class GivEnergyEmsNumberEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], Nu
         self.entity_description = description
         serial = coordinator.data.inverter_serial_number
         self._attr_unique_id = f"{serial}_{description.key}"
+        model = coordinator.data.inverter.model
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy {_device_kind(model)} {serial}",
         )
 
     @property

--- a/custom_components/givenergy_local/select.py
+++ b/custom_components/givenergy_local/select.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import GivEnergyUpdateCoordinator, InverterModel
+from .sensor import _device_kind
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -140,8 +141,13 @@ class GivEnergySelectEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], Selec
         serial = coordinator.data.inverter_serial_number
         self._attr_unique_id = f"{serial}_{description.key}"
         self._attr_options = list(description.options)
+        # Carry the device name (mirroring sensor.py/binary_sensor.py) so HA derives
+        # the device-name-prefixed entity_id slug even when the select platform sets
+        # up before the sensor platform has registered the named device record.
+        model = coordinator.data.inverter.model
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy {_device_kind(model)} {serial}",
         )
 
     @property

--- a/custom_components/givenergy_local/switch.py
+++ b/custom_components/givenergy_local/switch.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import GivEnergyUpdateCoordinator, InverterModel
+from .sensor import _device_kind
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -125,8 +126,13 @@ class GivEnergySwitchEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], Switc
         self.entity_description = description
         serial = coordinator.data.inverter_serial_number
         self._attr_unique_id = f"{serial}_{description.key}"
+        # Carry the device name (mirroring sensor.py/binary_sensor.py) so HA derives
+        # the device-name-prefixed entity_id slug even when the switch platform sets
+        # up before the sensor platform has registered the named device record.
+        model = coordinator.data.inverter.model
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy {_device_kind(model)} {serial}",
         )
 
     @property
@@ -162,8 +168,10 @@ class GivEnergyEmsSwitchEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], Sw
         self.entity_description = description
         serial = coordinator.data.inverter_serial_number
         self._attr_unique_id = f"{serial}_{description.key}"
+        model = coordinator.data.inverter.model
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy {_device_kind(model)} {serial}",
         )
 
     @property

--- a/custom_components/givenergy_local/time.py
+++ b/custom_components/givenergy_local/time.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import GivEnergyUpdateCoordinator, InverterModel
+from .sensor import _device_kind
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -238,8 +239,10 @@ class GivEnergyTimeEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], TimeEnt
         self.entity_description = description
         serial = coordinator.data.inverter_serial_number
         self._attr_unique_id = f"{serial}_{description.key}"
+        model = coordinator.data.inverter.model
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy {_device_kind(model)} {serial}",
         )
 
     @property
@@ -275,8 +278,10 @@ class GivEnergyEmsTimeEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], Time
         self.entity_description = description
         serial = coordinator.data.inverter_serial_number
         self._attr_unique_id = f"{serial}_{description.key}"
+        model = coordinator.data.inverter.model
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy {_device_kind(model)} {serial}",
         )
 
     @property

--- a/tests/test_control_entity_device_info.py
+++ b/tests/test_control_entity_device_info.py
@@ -1,0 +1,60 @@
+"""Regression guard: control-platform DeviceInfo carries the device `name`.
+
+The select/switch/number/time entities share the inverter device but each build
+their own ``DeviceInfo``. If that ``DeviceInfo`` omits ``name``, HA cannot derive
+the device-name-prefixed entity_id slug when the platform happens to set up before
+the named device record exists — the entity_id silently falls back to a bare slug
+(e.g. ``select.battery_power_mode`` instead of
+``select.givenergy_inverter_sa1234g123_battery_power_mode``), which breaks the
+dashboard's entity references.
+
+Asserting the name at construction is order-independent, unlike the probabilistic
+full-setup guard in ``test_script_entity_refs`` which only trips when the async
+platform-setup race happens to land the wrong way.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.givenergy_local.number import (
+    EMS_NUMBER_DESCRIPTIONS,
+    NUMBER_DESCRIPTIONS,
+    GivEnergyEmsNumberEntity,
+    GivEnergyNumberEntity,
+)
+from custom_components.givenergy_local.select import (
+    SELECT_DESCRIPTIONS,
+    GivEnergySelectEntity,
+)
+from custom_components.givenergy_local.switch import (
+    EMS_SWITCH_DESCRIPTIONS,
+    SWITCH_DESCRIPTIONS,
+    GivEnergyEmsSwitchEntity,
+    GivEnergySwitchEntity,
+)
+from custom_components.givenergy_local.time import (
+    EMS_TIME_DESCRIPTIONS,
+    TIME_DESCRIPTIONS,
+    GivEnergyEmsTimeEntity,
+    GivEnergyTimeEntity,
+)
+
+
+@pytest.mark.parametrize(
+    ("entity_cls", "description"),
+    [
+        (GivEnergySelectEntity, SELECT_DESCRIPTIONS[0]),
+        (GivEnergySwitchEntity, SWITCH_DESCRIPTIONS[0]),
+        (GivEnergyEmsSwitchEntity, EMS_SWITCH_DESCRIPTIONS[0]),
+        (GivEnergyNumberEntity, NUMBER_DESCRIPTIONS[0]),
+        (GivEnergyEmsNumberEntity, EMS_NUMBER_DESCRIPTIONS[0]),
+        (GivEnergyTimeEntity, TIME_DESCRIPTIONS[0]),
+        (GivEnergyEmsTimeEntity, EMS_TIME_DESCRIPTIONS[0]),
+    ],
+)
+def test_control_entity_device_info_carries_name(mock_plant, entity_cls, description):
+    coordinator = MagicMock()
+    coordinator.data = mock_plant
+    entity = entity_cls(coordinator, description)
+    assert entity.device_info["name"] == "GivEnergy Inverter SA1234G123"


### PR DESCRIPTION
## What this fixes

The `select`, `switch`, `number` and `time` entities all share the inverter device, but each built their `DeviceInfo` with only `identifiers` and no `name`. Because these entities use `has_entity_name = True`, Home Assistant derives the entity_id slug from the **device name**. When one of these platforms registered an entity *before* the `sensor` platform had registered the named device record, the entity_id silently fell back to a bare slug:

- got: `select.battery_power_mode`
- expected: `select.givenergy_inverter_<serial>_battery_power_mode`

`sensor.py` and `binary_sensor.py` already carry the device name in their `DeviceInfo` for exactly this reason — `binary_sensor.py` even has a comment documenting the same race. This just extends the same treatment to the remaining control platforms (including the EMS variants, which share the same device).

## Why it's more than a test fix

On a real first setup, whichever platform happens to register first wins the entity_id. If a control platform races ahead of `sensor`, those entity_ids get persisted as bare slugs — and once written to the registry they stick. So this is a genuine correctness issue in the integration, not just test noise. I don't think it bites often in practice (setup order tends to favour `sensor`), but it's fragile and worth closing off.

## How it surfaced

It turned up as an intermittently failing guard test — `test_dashboard_entity_refs_all_registered` failed roughly 1 in 3 full-suite runs while passing reliably in isolation. The dashboard generator references the device-prefixed entity_ids, so a bare-slug fallback made those references look "missing". The flake predates this branch; the registry-based dashboard work just made it visible.

I initially suspected the mock fixture (some enum sensors raise during state-write because of auto-mocked values), and fixing that did reduce the flake rate — but it didn't eliminate it, which is what pointed at the real `DeviceInfo` race underneath. The mock-side change was backed out; the only production change here is the missing `name`.

## Tests

- Added `tests/test_control_entity_device_info.py` — a deterministic, setup-order-independent guard that constructs each control entity and asserts its `DeviceInfo` carries the device name. Verified it fails without this fix and passes with it.
- Ran the full suite in a loop 20× with the fix: **0 failures** (was ~1 in 3 before).
- `ruff check` / `ruff format` clean; full suite green; `mypy` unchanged (no new errors introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)