### PR TITLE
feat: add glance mode (mode: glance) for the givenergy dashboard strategy (#131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ To avoid that snapshot problem entirely, there's also a dashboard *strategy* tha
 ```yaml
 strategy:
   type: custom:givenergy
-  mode: classic        # classic (default) | flow — see below
+  mode: classic        # classic (default) | flow | glance — see below
   max_power_kw: 10     # optional; default 10; Overview 24h chart y-axis envelope (kW)
   serial: SA2114G047   # optional; pin one inverter on a multi-plant install
 ```
@@ -255,7 +255,19 @@ strategy:
 
 The Flow view is rendered as a `panel: true` view. If you have the **kiosk-mode** custom integration installed (HACS), the strategy adds hints to hide the header and sidebar for a true full-screen display; without it, the view simply renders inside the normal HA chrome. The card is responsive (container-query based), so it works as a wall-tablet kiosk and reflows for a phone webview.
 
-The remaining directions from [the redesign brief](docs/design/dashboard-redesign-brief.md) — `glance`, `analyst`, and the tariff-aware `coach` — are still to come.
+The remaining directions from [the redesign brief](docs/design/dashboard-redesign-brief.md) — `analyst` and the tariff-aware `coach` — are still to come.
+
+#### `mode: glance`
+
+`mode: glance` leads the dashboard with a calm, full-width **Glance** view: a single-sentence system summary, three large numbers (solar generated today, battery SOC, house consumption today), and a row of health pills showing battery count, import and export totals for the day, and per-string PV generation when active. It's built around a bundled `custom:givenergy-glance` card — nothing extra to install.
+
+```yaml
+strategy:
+  type: custom:givenergy
+  mode: glance
+```
+
+The status sentence is derived from the live signs of grid, battery, and solar power — covering states like self-sufficient, exporting, solar-and-grid importing, battery-only overnight, and so on. The dot to its left pulses green when the system is self-sufficient or exporting, amber when importing from the grid or when battery SOC drops below 20%. The full classic view set follows the Glance panel, so the detailed tabs are still one tap away. Like `flow`, the Glance view is `panel: true` and picks up kiosk-mode hints when the integration is present.
 
 ### Voice assistants & LLM access
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ To avoid that snapshot problem entirely, there's also a dashboard *strategy* tha
 ```yaml
 strategy:
   type: custom:givenergy
-  mode: classic        # classic (default) | flow | glance — see below
+  mode: classic        # classic (default) | flow | glance | analyst | all — see below
   max_power_kw: 10     # optional; default 10; Overview 24h chart y-axis envelope (kW)
   serial: SA2114G047   # optional; pin one inverter on a multi-plant install
 ```
@@ -255,7 +255,7 @@ strategy:
 
 The Flow view is rendered as a `panel: true` view. If you have the **kiosk-mode** custom integration installed (HACS), the strategy adds hints to hide the header and sidebar for a true full-screen display; without it, the view simply renders inside the normal HA chrome. The card is responsive (container-query based), so it works as a wall-tablet kiosk and reflows for a phone webview.
 
-The remaining directions from [the redesign brief](docs/design/dashboard-redesign-brief.md) — `analyst` and the tariff-aware `coach` — are still to come.
+The tariff-aware `coach` direction from [the redesign brief](docs/design/dashboard-redesign-brief.md) is still to come.
 
 #### `mode: glance`
 
@@ -268,6 +268,28 @@ strategy:
 ```
 
 The status sentence is derived from the live signs of grid, battery, and solar power — covering states like self-sufficient, exporting, solar-and-grid importing, battery-only overnight, and so on. The dot to its left pulses green when the system is self-sufficient or exporting, amber when importing from the grid or when battery SOC drops below 20%. The full classic view set follows the Glance panel, so the detailed tabs are still one tap away. Like `flow`, the Glance view is `panel: true` and picks up kiosk-mode hints when the integration is present.
+
+#### `mode: analyst`
+
+`mode: analyst` leads the dashboard with a dense **Analyst** view aimed at optimisation and debugging: a live metrics strip (PV, load, battery, grid), an energy ledger breaking down today's sources and sinks as kWh and percentages, a diagnostics table (temperatures, grid frequency, power factor, work time, consecutive failures), a 24-hour power overlay chart (requires `apexcharts-card`), and per-pack cell heatmaps. Nothing extra to install beyond the apexcharts card for the chart.
+
+```yaml
+strategy:
+  type: custom:givenergy
+  mode: analyst
+```
+
+The Analyst view is a standard (non-panel) multi-card view, so the full classic tab set still follows it.
+
+#### `mode: all`
+
+`mode: all` stacks all four views — Glance, Flow, Analyst, and the classic tab set — into a single dashboard. Useful if you want to switch between display styles without maintaining separate dashboards.
+
+```yaml
+strategy:
+  type: custom:givenergy
+  mode: all
+```
 
 ### Voice assistants & LLM access
 

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -77,7 +77,7 @@ _STRATEGY_URL = f"/{DOMAIN}/{_STRATEGY_FILENAME}"
 # served from the same package dir so they resolve offline without a CDN.
 _FONTS_DIRNAME = "fonts"
 _FONTS_URL = f"/{DOMAIN}/{_FONTS_DIRNAME}"
-_STRATEGY_VERSION = "6"
+_STRATEGY_VERSION = "7"
 
 # Per-config-entry topology cache. PlantCapabilities is persisted as
 # `to_dict()` directly (no envelope) following HA Core's Store convention —

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -77,7 +77,7 @@ _STRATEGY_URL = f"/{DOMAIN}/{_STRATEGY_FILENAME}"
 # served from the same package dir so they resolve offline without a CDN.
 _FONTS_DIRNAME = "fonts"
 _FONTS_URL = f"/{DOMAIN}/{_FONTS_DIRNAME}"
-_STRATEGY_VERSION = "5"
+_STRATEGY_VERSION = "6"
 
 # Per-config-entry topology cache. PlantCapabilities is persisted as
 # `to_dict()` directly (no envelope) following HA Core's Store convention —

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -77,7 +77,7 @@ _STRATEGY_URL = f"/{DOMAIN}/{_STRATEGY_FILENAME}"
 # served from the same package dir so they resolve offline without a CDN.
 _FONTS_DIRNAME = "fonts"
 _FONTS_URL = f"/{DOMAIN}/{_FONTS_DIRNAME}"
-_STRATEGY_VERSION = "7"
+_STRATEGY_VERSION = "8"
 
 # Per-config-entry topology cache. PlantCapabilities is persisted as
 # `to_dict()` directly (no envelope) following HA Core's Store convention —

--- a/custom_components/givenergy_local/www/ge-strategy.js
+++ b/custom_components/givenergy_local/www/ge-strategy.js
@@ -385,6 +385,15 @@
     return view;
   }
 
+  // mode: all -- dev convenience: all mode panels in front of classic tabs.
+  // Not intended as a permanent user-facing mode; remove when modes split into
+  // separate dashboards.
+  function allViews(plant, opts) {
+    var a = makeAccessors(plant);
+    if (plant.target && plant.target.isEms) return classicViews(plant, opts);
+    return [glanceView(plant, a, opts), flowView(plant, a, opts)].concat(classicViews(plant, opts));
+  }
+
   function overviewView(plant, a, opts) {
     var cap = (opts.maxPowerKw || 10) * 1000;
     var cards = [];
@@ -1079,6 +1088,7 @@
     var views =
       opts.mode === "flow"   ? flowViews(plant, opts)   :
       opts.mode === "glance" ? glanceViews(plant, opts) :
+      opts.mode === "all"    ? allViews(plant, opts)    :
                                classicViews(plant, opts);
     return { title: "GivEnergy", views: views };
   }

--- a/custom_components/givenergy_local/www/ge-strategy.js
+++ b/custom_components/givenergy_local/www/ge-strategy.js
@@ -1579,25 +1579,44 @@
           var importing   = grid  != null && grid  < -THRESH;
 
           // Natural-language status sentence (ASCII-only).
+          // Structure: check net grid direction (exporting/importing/idle) first
+          // within the solarOn group so the sentence is correct even when solar
+          // is present but insufficient to cover demand or the source of battery
+          // charge is ambiguous.
           var sentence;
-          if (solarOn && charging && exporting)
-            sentence = "Solar covering the house and charging the battery, exporting the surplus.";
-          else if (solarOn && charging)
-            sentence = "Solar covering the house and charging the battery.";
-          else if (solarOn && exporting)
-            sentence = "Solar ahead of demand - exporting to the grid.";
-          else if (solarOn && discharging)
-            sentence = "Solar and battery covering the house.";
-          else if (solarOn)
-            sentence = "Solar covering the house.";
-          else if (discharging && !importing)
+          if (solarOn) {
+            if (exporting) {
+              if (charging)
+                sentence = "Solar covering the house and charging the battery, exporting the surplus.";
+              else if (discharging)
+                sentence = "Solar and battery exporting to the grid.";
+              else
+                sentence = "Solar ahead of demand - exporting to the grid.";
+            } else if (importing) {
+              if (charging)
+                sentence = "Solar and grid supplying the house and charging the battery.";
+              else if (discharging)
+                sentence = "Solar, battery, and grid supplying the house.";
+              else
+                sentence = "Solar and grid supplying the house.";
+            } else {
+              // Grid approximately idle: solar balanced against load and battery.
+              if (charging)
+                sentence = "Solar covering the house and charging the battery.";
+              else if (discharging)
+                sentence = "Solar and battery covering the house.";
+              else
+                sentence = "Solar covering the house.";
+            }
+          } else if (discharging && !importing) {
             sentence = "Battery powering the house.";
-          else if (discharging && importing)
+          } else if (discharging && importing) {
             sentence = "Battery and grid supplying the house.";
-          else if (importing)
+          } else if (importing) {
             sentence = "Drawing from the grid.";
-          else
+          } else {
             sentence = "System idle.";
+          }
 
           // Status dot: amber when importing or battery low, green otherwise.
           var dotColor = (importing || (soc != null && soc < 20)) ? "#d4a85a" : "#5bbb6a";

--- a/custom_components/givenergy_local/www/ge-strategy.js
+++ b/custom_components/givenergy_local/www/ge-strategy.js
@@ -333,6 +333,58 @@
     return view;
   }
 
+  function glanceViews(plant, opts) {
+    var a = makeAccessors(plant);
+    // Glance is inverter-centric; an EMS plant has no PV/battery/grid data, so
+    // fall back to the classic (EMS) view set with no glance panel.
+    if (plant.target && plant.target.isEms) return classicViews(plant, opts);
+    return [glanceView(plant, a, opts)].concat(classicViews(plant, opts));
+  }
+
+  function glanceView(plant, a, opts) {
+    var cfg = { type: "custom:givenergy-glance" };
+    if (a.inv("p_pv")) cfg.solar = a.inv("p_pv");
+    var strings = [a.inv("p_pv1"), a.inv("p_pv2")].filter(Boolean);
+    if (strings.length) cfg.solar_strings = strings;
+    if (a.inv("grid_power")) cfg.grid = a.inv("grid_power");
+    if (a.inv("p_load_demand")) cfg.load = a.inv("p_load_demand");
+    if (a.inv("p_battery")) cfg.battery_power = a.inv("p_battery");
+    if (a.inv("battery_soc")) cfg.battery_soc = a.inv("battery_soc");
+
+    var packs = plant.batteries
+      .map(function (b) {
+        return { name: String(b.serial).toUpperCase(), soc: a.bat(b, "soc") };
+      })
+      .filter(function (p) { return p.soc; });
+    if (packs.length) cfg.packs = packs;
+
+    // Totals: subset of the flow card's slots (no charge/discharge here).
+    var totalKeys = {
+      pv_today: "e_pv_day",
+      import_today: "e_grid_in_day",
+      export_today: "e_grid_out_day",
+      house_today: "e_consumption_today",
+    };
+    var totals = {};
+    Object.keys(totalKeys).forEach(function (slot) {
+      var eid = a.inv(totalKeys[slot]);
+      if (eid) totals[slot] = eid;
+    });
+    if (Object.keys(totals).length) cfg.totals = totals;
+
+    var view = {
+      title: "Glance",
+      path: "glance",
+      icon: "mdi:eye-outline",
+      panel: true,
+      cards: [cfg],
+    };
+    if (haveCard("kiosk-mode")) {
+      view.kiosk_mode = { hide_header: true, hide_sidebar: true };
+    }
+    return view;
+  }
+
   function overviewView(plant, a, opts) {
     var cap = (opts.maxPowerKw || 10) * 1000;
     var cards = [];
@@ -1024,7 +1076,10 @@
       };
     }
     // Mode dispatch. Unknown/absent mode falls back to classic.
-    var views = opts.mode === "flow" ? flowViews(plant, opts) : classicViews(plant, opts);
+    var views =
+      opts.mode === "flow"   ? flowViews(plant, opts)   :
+      opts.mode === "glance" ? glanceViews(plant, opts) :
+                               classicViews(plant, opts);
     return { title: "GivEnergy", views: views };
   }
 
@@ -1455,6 +1510,223 @@
       });
     }
 
+    // custom:givenergy-glance - the Glance mode centrepiece. Calm-tech ambient
+    // panel: a natural-language status sentence, three large numbers (solar today /
+    // battery SOC / house today), and health pills. Entity_ids arrive pre-resolved
+    // from the strategy; the card only reads hass.states.
+    if (!customElements.get("givenergy-glance")) {
+      customElements.define("givenergy-glance", class extends HTMLElement {
+        setConfig(cfg) {
+          this._cfg = cfg || {};
+        }
+        set hass(hass) {
+          this._hass = hass;
+          this._render();
+        }
+        getCardSize() {
+          return 5;
+        }
+
+        _render() {
+          var cfg = this._cfg, hass = this._hass;
+          if (!cfg || !hass || !hass.states) return;
+
+          var num = function (eid) {
+            var st = eid && hass.states[eid];
+            var v = st ? parseFloat(st.state) : NaN;
+            return isFinite(v) ? v : null;
+          };
+          var esc = function (s) {
+            return String(s).replace(/[&<>"']/g, function (c) {
+              return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+            });
+          };
+          var fmtKw = function (w) {
+            if (w == null) return "&mdash;";
+            var k = w / 1000;
+            return Math.abs(k) < 10 ? k.toFixed(2) : k.toFixed(1);
+          };
+          var fmtKwh = function (v) {
+            if (v == null) return "&mdash;";
+            return Math.abs(v) < 10 ? v.toFixed(1) : Math.round(v).toString();
+          };
+
+          var solar = num(cfg.solar);
+          var grid  = num(cfg.grid);   // + = export, - = import
+          var batt  = num(cfg.battery_power); // + = discharge, - = charge
+          var soc   = num(cfg.battery_soc);
+          var load  = num(cfg.load);
+          var strings = (cfg.solar_strings || []).map(num);
+          var packs = (cfg.packs || []).map(function (p) {
+            return { name: p.name, soc: num(p.soc) };
+          });
+          var totals = cfg.totals || {};
+
+          // Signature guard: skip DOM rebuild if nothing changed.
+          var sig = [solar, grid, batt, soc, load].join(",") +
+            "|" + strings.join(",") +
+            "|" + packs.map(function (p) { return p.name + ":" + p.soc; }).join(",") +
+            "|" + Object.keys(totals).map(function (k) { return k + "=" + num(totals[k]); }).join(",");
+          if (sig === this._sig) return;
+          this._sig = sig;
+
+          // Flow booleans (100 W threshold - higher than flow's 20 W to avoid sentence flicker).
+          var THRESH = 100;
+          var solarOn     = solar != null && solar >  THRESH;
+          var charging    = batt  != null && batt  < -THRESH;
+          var discharging = batt  != null && batt  >  THRESH;
+          var exporting   = grid  != null && grid  >  THRESH;
+          var importing   = grid  != null && grid  < -THRESH;
+
+          // Natural-language status sentence (ASCII-only).
+          var sentence;
+          if (solarOn && charging && exporting)
+            sentence = "Solar covering the house and charging the battery, exporting the surplus.";
+          else if (solarOn && charging)
+            sentence = "Solar covering the house and charging the battery.";
+          else if (solarOn && exporting)
+            sentence = "Solar ahead of demand - exporting to the grid.";
+          else if (solarOn && discharging)
+            sentence = "Solar and battery covering the house.";
+          else if (solarOn)
+            sentence = "Solar covering the house.";
+          else if (discharging && !importing)
+            sentence = "Battery powering the house.";
+          else if (discharging && importing)
+            sentence = "Battery and grid supplying the house.";
+          else if (importing)
+            sentence = "Drawing from the grid.";
+          else
+            sentence = "System idle.";
+
+          // Status dot: amber when importing or battery low, green otherwise.
+          var dotColor = (importing || (soc != null && soc < 20)) ? "#d4a85a" : "#5bbb6a";
+
+          // ---- Big-3 sub-lines ----
+          var solarSub;
+          if (strings.length) {
+            solarSub = strings.map(function (w, i) {
+              return "String " + (i + 1) + ": " + (w == null ? "&mdash;" : fmtKw(w)) + " kW";
+            }).join(" &middot; ");
+          } else if (solar != null) {
+            solarSub = fmtKw(solar) + " kW now";
+          } else {
+            solarSub = "&mdash;";
+          }
+
+          var battSub;
+          if (packs.length > 1) {
+            battSub = packs.map(function (p) {
+              return esc(p.name) + ": " + (p.soc == null ? "&mdash;" : Math.round(p.soc) + "%");
+            }).join(" &middot; ");
+          } else if (charging) {
+            battSub = "Charging &middot; " + fmtKw(-batt) + " kW";
+          } else if (discharging) {
+            battSub = "Discharging &middot; " + fmtKw(batt) + " kW";
+          } else {
+            battSub = "Idle";
+          }
+
+          var houseSub;
+          if (exporting) {
+            houseSub = "Exporting " + fmtKw(grid) + " kW";
+          } else if (importing) {
+            houseSub = "Importing " + fmtKw(-grid) + " kW";
+          } else if (solar != null || batt != null) {
+            houseSub = "Self-sufficient";
+          } else {
+            houseSub = "&mdash;";
+          }
+
+          // ---- Health pills ----
+          var GREEN = "#5bbb6a", AMBER = "#d4a85a", BLUE = "#4a9fd4";
+          var pills = [];
+          // Battery count.
+          if (packs.length > 0) {
+            var battWord = packs.length === 1 ? "battery" : "batteries";
+            pills.push({ label: packs.length + " " + battWord + " online", color: GREEN });
+            // Per-pack SOC if more than one.
+            if (packs.length > 1) {
+              packs.forEach(function (p) {
+                var pc = (p.soc != null && p.soc < 20) ? AMBER : GREEN;
+                pills.push({ label: esc(p.name) + ": " + (p.soc == null ? "&mdash;" : Math.round(p.soc)) + "%", color: pc });
+              });
+            }
+          } else if (soc != null) {
+            pills.push({ label: "1 battery online", color: GREEN });
+          }
+          // Import / export today.
+          var importKwh = num(totals.import_today);
+          if (importKwh != null && importKwh >= 0.05) {
+            pills.push({ label: fmtKwh(importKwh) + " kWh imported today", color: importKwh > 1 ? AMBER : BLUE });
+          }
+          var exportKwh = num(totals.export_today);
+          if (exportKwh != null && exportKwh >= 0.05) {
+            pills.push({ label: fmtKwh(exportKwh) + " kWh exported today", color: GREEN });
+          }
+          // Per-string generation pills (only when solar is active).
+          if (solarOn && strings.length > 0) {
+            strings.forEach(function (w, i) {
+              if (w != null) {
+                pills.push({ label: "String " + (i + 1) + ": " + fmtKw(w) + " kW", color: BLUE });
+              }
+            });
+          }
+
+          var pillsHtml = pills.map(function (p) {
+            return '<span class="gl-pill"><span class="gl-dot" style="background:' + p.color + '"></span>' + p.label + '</span>';
+          }).join("");
+
+          // ---- Render ----
+          var MONO = "'GE Geist Mono',ui-monospace,monospace";
+          var SERIF = "'GE Fraunces',Georgia,serif";
+          var SANS = "'Roboto',system-ui,sans-serif";
+
+          this.innerHTML =
+            '<ha-card><div class="gegl">' +
+            "<style>" +
+            "@font-face{font-family:'GE Fraunces';src:url('/givenergy_local/fonts/fraunces-subset.woff2') format('woff2');font-weight:300 500;font-display:swap}" +
+            "@font-face{font-family:'GE Geist Mono';src:url('/givenergy_local/fonts/geist-mono-subset.woff2') format('woff2');font-weight:400 600;font-display:swap}" +
+            ".gegl{container-type:inline-size;padding:28px 24px 20px;color:var(--primary-text-color)}" +
+            ".gl-status{display:flex;align-items:flex-start;gap:12px;margin-bottom:32px}" +
+            ".gl-dot-wrap{flex-shrink:0;padding-top:6px}" +
+            ".gl-pulse{width:12px;height:12px;border-radius:50%;animation:gl-pulse 2.4s ease-in-out infinite}" +
+            "@keyframes gl-pulse{0%,100%{opacity:1}50%{opacity:.3}}" +
+            ".gl-sentence{font-family:" + SERIF + ";font-size:28px;font-weight:300;line-height:1.25;letter-spacing:-.01em;max-width:680px}" +
+            ".gl-big3{display:grid;grid-template-columns:repeat(3,1fr);gap:32px;margin-bottom:28px}" +
+            ".gl-num{border-top:1px solid var(--divider-color,#444);padding-top:16px}" +
+            ".gl-lbl{font-family:" + MONO + ";font-size:11px;letter-spacing:.06em;color:var(--secondary-text-color);margin-bottom:6px}" +
+            ".gl-val{font-family:" + SERIF + ";font-size:80px;font-weight:200;line-height:1;letter-spacing:-.03em}" +
+            ".gl-unit{font-family:" + SANS + ";font-size:22px;font-weight:300;color:var(--secondary-text-color);margin-left:4px}" +
+            ".gl-sub{font-family:" + MONO + ";font-size:12px;color:var(--secondary-text-color);margin-top:6px}" +
+            ".gl-pills{display:flex;flex-wrap:wrap;gap:8px}" +
+            ".gl-pill{display:inline-flex;align-items:center;gap:7px;padding:7px 13px;" +
+              "border:1px solid var(--divider-color,#444);border-radius:999px;" +
+              "font-family:" + MONO + ";font-size:12px;color:var(--primary-text-color)}" +
+            ".gl-dot{width:6px;height:6px;border-radius:50%;flex-shrink:0}" +
+            "@container (max-width:500px){.gl-sentence{font-size:20px}.gl-big3{grid-template-columns:1fr;gap:20px}.gl-val{font-size:56px}.gl-unit{font-size:16px}}" +
+            "</style>" +
+            '<div class="gl-status">' +
+            '<div class="gl-dot-wrap"><div class="gl-pulse" style="background:' + dotColor + '"></div></div>' +
+            '<div class="gl-sentence">' + sentence + '</div>' +
+            '</div>' +
+            '<div class="gl-big3">' +
+            '<div class="gl-num"><div class="gl-lbl">SOLAR TODAY</div>' +
+            '<div class="gl-val">' + fmtKwh(num(totals.pv_today)) + '<span class="gl-unit">kWh</span></div>' +
+            '<div class="gl-sub">' + solarSub + '</div></div>' +
+            '<div class="gl-num"><div class="gl-lbl">BATTERY</div>' +
+            '<div class="gl-val">' + (soc == null ? "&mdash;" : Math.round(soc)) + '<span class="gl-unit">%</span></div>' +
+            '<div class="gl-sub">' + battSub + '</div></div>' +
+            '<div class="gl-num"><div class="gl-lbl">HOUSE TODAY</div>' +
+            '<div class="gl-val">' + fmtKwh(num(totals.house_today)) + '<span class="gl-unit">kWh</span></div>' +
+            '<div class="gl-sub">' + houseSub + '</div></div>' +
+            '</div>' +
+            '<div class="gl-pills">' + pillsHtml + '</div>' +
+            '</div></ha-card>';
+        }
+      });
+    }
+
     // Discoverability in the "Community dashboards" picker (HA 2026.5+). Harmless
     // where unsupported.
     try {
@@ -1463,7 +1735,7 @@
         type: "givenergy",
         strategyType: "dashboard",
         name: "GivEnergy",
-        description: "Registry-driven GivEnergy dashboard (classic / flow modes).",
+        description: "Registry-driven GivEnergy dashboard (classic / flow / glance modes).",
       });
     } catch (e) {
       /* non-fatal */

--- a/custom_components/givenergy_local/www/ge-strategy.js
+++ b/custom_components/givenergy_local/www/ge-strategy.js
@@ -1570,13 +1570,20 @@
           if (sig === this._sig) return;
           this._sig = sig;
 
-          // Flow booleans (100 W threshold - higher than flow's 20 W to avoid sentence flicker).
-          var THRESH = 100;
-          var solarOn     = solar != null && solar >  THRESH;
-          var charging    = batt  != null && batt  < -THRESH;
-          var discharging = batt  != null && batt  >  THRESH;
-          var exporting   = grid  != null && grid  >  THRESH;
-          var importing   = grid  != null && grid  < -THRESH;
+          // Flow booleans with hysteresis (Schmitt-trigger style): THRESH_ON to
+          // enter a state, THRESH_OFF to leave it. Prevents the sentence from
+          // flipping between adjacent states when readings are near a threshold
+          // (sensor timing skew, end-of-day grazing, etc.).
+          var THRESH_ON  = 200; // W -- must exceed this to enter a new state
+          var THRESH_OFF =  80; // W -- must drop below this to leave a state
+          var prev = this._flowState || {};
+          var solarOn     = solar != null && (solar >  THRESH_ON || (prev.solarOn     && solar >  THRESH_OFF));
+          var exporting   = grid  != null && (grid  >  THRESH_ON || (prev.exporting   && grid  >  THRESH_OFF));
+          var importing   = grid  != null && (grid  < -THRESH_ON || (prev.importing   && grid  < -THRESH_OFF));
+          var charging    = batt  != null && (batt  < -THRESH_ON || (prev.charging    && batt  < -THRESH_OFF));
+          var discharging = batt  != null && (batt  >  THRESH_ON || (prev.discharging && batt  >  THRESH_OFF));
+          this._flowState = { solarOn: solarOn, exporting: exporting, importing: importing,
+                              charging: charging, discharging: discharging };
 
           // Natural-language status sentence (ASCII-only).
           // Structure: check net grid direction (exporting/importing/idle) first

--- a/custom_components/givenergy_local/www/ge-strategy.js
+++ b/custom_components/givenergy_local/www/ge-strategy.js
@@ -391,7 +391,102 @@
   function allViews(plant, opts) {
     var a = makeAccessors(plant);
     if (plant.target && plant.target.isEms) return classicViews(plant, opts);
-    return [glanceView(plant, a, opts), flowView(plant, a, opts)].concat(classicViews(plant, opts));
+    return [glanceView(plant, a, opts), flowView(plant, a, opts), analystView(plant, a, opts)].concat(classicViews(plant, opts));
+  }
+
+  // mode: analyst -- dense terminal-aesthetic view for diagnostics / debugging /
+  // optimisation. Non-panel multi-card view: givenergy-analyst card (live metrics +
+  // energy ledger + diagnostics table), apexcharts 24h power overlay, and one
+  // ge-cell-heatmap per battery pack. Analyst is inverter-centric; falls back
+  // to classic for EMS plants.
+  function analystViews(plant, opts) {
+    var a = makeAccessors(plant);
+    if (plant.target && plant.target.isEms) return classicViews(plant, opts);
+    return [analystView(plant, a, opts)].concat(classicViews(plant, opts));
+  }
+
+  function analystView(plant, a, opts) {
+    var cards = [];
+
+    // Card 1: custom element handles live metrics, energy ledger, diagnostics.
+    var cfg = { type: "custom:givenergy-analyst" };
+    if (a.inv("p_pv"))          cfg.solar        = a.inv("p_pv");
+    var strings = [a.inv("p_pv1"), a.inv("p_pv2")].filter(Boolean);
+    if (strings.length)         cfg.solar_strings = strings;
+    if (a.inv("grid_power"))    cfg.grid          = a.inv("grid_power");
+    if (a.inv("p_load_demand")) cfg.load          = a.inv("p_load_demand");
+    if (a.inv("p_battery"))     cfg.battery_power = a.inv("p_battery");
+    if (a.inv("battery_soc"))   cfg.battery_soc   = a.inv("battery_soc");
+
+    var totalKeyMap = {
+      pv_today:        "e_pv_day",
+      discharge_today: "e_battery_discharge_day",
+      import_today:    "e_grid_in_day",
+      house_today:     "e_consumption_today",
+      charge_today:    "e_battery_charge_day",
+      export_today:    "e_grid_out_day",
+    };
+    var totals = {};
+    Object.keys(totalKeyMap).forEach(function (slot) {
+      var eid = a.inv(totalKeyMap[slot]);
+      if (eid) totals[slot] = eid;
+    });
+    if (Object.keys(totals).length) cfg.totals = totals;
+
+    var diagKeyMap = {
+      t_inverter_heatsink:  "t_inverter_heatsink",
+      t_charger:            "t_charger",
+      f_ac1:                "f_ac1",
+      pf_inverter:          "pf_inverter_output_now",
+      work_time_total:      "work_time_total",
+      consecutive_failures: "consecutive_failures",
+      last_refresh:         "last_successful_refresh",
+    };
+    var diag = {};
+    Object.keys(diagKeyMap).forEach(function (slot) {
+      var eid = a.inv(diagKeyMap[slot]);
+      if (eid) diag[slot] = eid;
+    });
+    if (Object.keys(diag).length) cfg.diag = diag;
+
+    cards.push(cfg);
+
+    // Card 2: 24h power overlay.
+    var powerSeries = [
+      { entity: a.inv("p_pv"),          name: "PV",      color: "#d4a85a" },
+      { entity: a.inv("p_load_demand"), name: "Load",    color: "#cfcfca" },
+      { entity: a.inv("p_battery"),     name: "Battery", color: "#5bbb6a" },
+      { entity: a.inv("grid_power"),    name: "Grid",    color: "#4a9fd4" },
+    ].filter(function (s) { return s.entity; });
+
+    if (haveCard("apexcharts-card") && powerSeries.length) {
+      var cap = (opts.maxPowerKw || 10) * 1000;
+      cards.push({
+        type: "custom:apexcharts-card",
+        header: { show: true, title: "Power - last 24 h" },
+        graph_span: "24h",
+        yaxis: [{ min: -cap, max: cap }],
+        series: powerSeries,
+      });
+    } else if (powerSeries.length) {
+      cards.push(placeholder("apexcharts-card"));
+    }
+
+    // Card 3+: ge-cell-heatmap per battery pack.
+    plant.batteries.forEach(function (b) {
+      cards.push({
+        type: "custom:ge-cell-heatmap",
+        title: "Cell balance - " + String(b.serial).toUpperCase(),
+        batteries: [b.serial],
+      });
+    });
+
+    return {
+      title: "Analyst",
+      path: "analyst",
+      icon: "mdi:chart-line",
+      cards: cards,
+    };
   }
 
   function overviewView(plant, a, opts) {
@@ -1086,10 +1181,11 @@
     }
     // Mode dispatch. Unknown/absent mode falls back to classic.
     var views =
-      opts.mode === "flow"   ? flowViews(plant, opts)   :
-      opts.mode === "glance" ? glanceViews(plant, opts) :
-      opts.mode === "all"    ? allViews(plant, opts)    :
-                               classicViews(plant, opts);
+      opts.mode === "flow"    ? flowViews(plant, opts)    :
+      opts.mode === "glance"  ? glanceViews(plant, opts)  :
+      opts.mode === "analyst" ? analystViews(plant, opts) :
+      opts.mode === "all"     ? allViews(plant, opts)     :
+                                classicViews(plant, opts);
     return { title: "GivEnergy", views: views };
   }
 
@@ -1763,6 +1859,222 @@
       });
     }
 
+    // custom:givenergy-analyst - the Analyst mode centrepiece. Dense terminal-
+    // aesthetic card: live power metrics strip, energy ledger (sources vs sinks
+    // with kWh and percentages), and an inverter diagnostics table.
+    // Entity_ids arrive pre-resolved from the strategy; the card only reads hass.states.
+    if (!customElements.get("givenergy-analyst")) {
+      customElements.define("givenergy-analyst", class extends HTMLElement {
+        setConfig(cfg) {
+          this._cfg = cfg || {};
+        }
+        set hass(hass) {
+          this._hass = hass;
+          this._render();
+        }
+        getCardSize() {
+          return 8;
+        }
+
+        _render() {
+          var cfg = this._cfg, hass = this._hass;
+          if (!cfg || !hass || !hass.states) return;
+
+          var num = function (eid) {
+            var st = eid && hass.states[eid];
+            var v = st ? parseFloat(st.state) : NaN;
+            return isFinite(v) ? v : null;
+          };
+          var str = function (eid) {
+            var st = eid && hass.states[eid];
+            return st ? st.state : null;
+          };
+          var esc = function (s) {
+            return String(s).replace(/[&<>"']/g, function (c) {
+              return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+            });
+          };
+          // fmtW: integer watts for |w| < 1000, else kW to 2dp.
+          var fmtW = function (w) {
+            if (w == null) return "&mdash;";
+            var abs = Math.abs(w);
+            if (abs < 1000) return Math.round(w) + " W";
+            return (w / 1000).toFixed(2) + " kW";
+          };
+          var fmtKwh = function (v) {
+            if (v == null) return "&mdash;";
+            return Math.abs(v) < 10 ? v.toFixed(1) : Math.round(v).toString();
+          };
+
+          var solar = num(cfg.solar);
+          var grid  = num(cfg.grid);          // + = export, - = import
+          var batt  = num(cfg.battery_power); // + = discharge, - = charge
+          var soc   = num(cfg.battery_soc);
+          var load  = num(cfg.load);
+          var totals = cfg.totals || {};
+          var diag   = cfg.diag   || {};
+
+          // Signature guard: skip full re-render when nothing changed.
+          var totVals = Object.keys(totals).map(function (k) { return num(totals[k]); }).join(",");
+          var diagVals = Object.keys(diag).map(function (k) { return str(diag[k]); }).join(",");
+          var sig = [solar, grid, batt, soc, load].join(",") + "|" + totVals + "|" + diagVals;
+          if (sig === this._sig) return;
+          this._sig = sig;
+
+          // ---- live metrics strip ----
+          var metricCell = function (label, value, sub, borderColor) {
+            return '<div class="an-metric" style="border-left-color:' + borderColor + '">' +
+              '<div class="an-m-lbl">' + label + '</div>' +
+              '<div class="an-m-val">' + value + '</div>' +
+              '<div class="an-m-sub">' + sub + '</div>' +
+              '</div>';
+          };
+
+          // PV cell
+          var pvVal = fmtW(solar);
+          var pvSub = "";
+          if (cfg.solar_strings && cfg.solar_strings.length) {
+            pvSub = cfg.solar_strings.map(function (eid, i) {
+              var v = num(eid);
+              return "S" + (i + 1) + " " + (v == null ? "---" : Math.round(v) + " W");
+            }).join(" / ");
+          }
+
+          // Battery cell
+          var battAbs = batt == null ? null : Math.abs(batt);
+          var battDir = batt == null ? "idle" :
+            (batt < -10 ? "charging" : (batt > 10 ? "discharging" : "idle"));
+          var battSub = battDir + (soc != null ? " | " + Math.round(soc) + "%" : "");
+          var battColor = battDir === "charging"    ? "#4a9fd4" :
+                          battDir === "discharging" ? "#5bbb6a" :
+                                                      "var(--divider-color)";
+
+          // Grid cell
+          var gridAbs = grid == null ? null : Math.abs(grid);
+          var gridDir = grid == null ? "idle" :
+            (grid < -10 ? "importing" : (grid > 10 ? "exporting" : "idle"));
+          var gridColor = gridDir === "exporting" ? "#5bbb6a" :
+                          gridDir === "importing" ? "#e55555" :
+                                                    "var(--divider-color)";
+
+          var metricsHtml =
+            metricCell("PV",      fmtW(solar),   pvSub,   "#d4a85a") +
+            metricCell("LOAD",    fmtW(load),    "",      "var(--divider-color)") +
+            metricCell("BATTERY", fmtW(battAbs), battSub, battColor) +
+            metricCell("GRID",    fmtW(gridAbs), gridDir, gridColor);
+
+          // ---- energy ledger ----
+          var pvToday        = num(totals.pv_today);
+          var dischargeToday = num(totals.discharge_today);
+          var importToday    = num(totals.import_today);
+          var houseToday     = num(totals.house_today);
+          var chargeToday    = num(totals.charge_today);
+          var exportToday    = num(totals.export_today);
+
+          var sumSources = (pvToday || 0) + (dischargeToday || 0) + (importToday || 0);
+          var sumSinks   = (houseToday || 0) + (chargeToday || 0) + (exportToday || 0);
+
+          var pct = function (v, total) {
+            if (v == null || !total) return "&mdash;";
+            return Math.round(v / total * 100) + "%";
+          };
+
+          var ledgerRow = function (label, val, total) {
+            return '<tr><td>' + label + '</td>' +
+              '<td class="an-r">' + fmtKwh(val) + '</td>' +
+              '<td class="an-r">' + pct(val, total) + '</td></tr>';
+          };
+          var ledgerTotalRow = function (label, val, color) {
+            return '<tr class="an-tot" style="color:' + color + '">' +
+              '<td>' + label + '</td>' +
+              '<td class="an-r">' + fmtKwh(val || null) + '</td>' +
+              '<td class="an-r">' + (val ? "100%" : "&mdash;") + '</td></tr>';
+          };
+
+          var ledgerHtml =
+            '<table class="an-tbl">' +
+            '<thead><tr><th>Source</th><th class="an-r">kWh</th><th class="an-r">%</th></tr></thead>' +
+            '<tbody>' +
+            ledgerRow("PV generation",     pvToday,        sumSources) +
+            ledgerRow("Battery discharge", dischargeToday, sumSources) +
+            ledgerRow("Grid import",       importToday,    sumSources) +
+            ledgerTotalRow("Sources total", sumSources, "#d4a85a") +
+            '</tbody></table>' +
+            '<table class="an-tbl an-tbl-mt">' +
+            '<thead><tr><th>Sink</th><th class="an-r">kWh</th><th class="an-r">%</th></tr></thead>' +
+            '<tbody>' +
+            ledgerRow("House consumption", houseToday,  sumSinks) +
+            ledgerRow("Battery charge",    chargeToday, sumSinks) +
+            ledgerRow("Grid export",       exportToday, sumSinks) +
+            ledgerTotalRow("Sinks total", sumSinks, "#5bbb6a") +
+            '</tbody></table>';
+
+          // ---- diagnostics table ----
+          var diagDefs = [
+            { slot: "t_inverter_heatsink",  label: "Heatsink",        unit: " deg C", isNum: true  },
+            { slot: "t_charger",            label: "Charger",          unit: " deg C", isNum: true  },
+            { slot: "f_ac1",                label: "Grid freq",        unit: " Hz",    isNum: true  },
+            // scale: 0.0001 is a stopgap (/10,000 only; correct formula is /10,000 - 1).
+            // Tracked at dewet22/givenergy-modbus#209.
+            { slot: "pf_inverter",          label: "Power factor",     unit: "",       isNum: true, scale: 0.0001 },
+            { slot: "work_time_total",      label: "Work time",        unit: " h",     isNum: true  },
+            { slot: "last_refresh",         label: "Last refresh",     unit: "",       isNum: false },
+            { slot: "consecutive_failures", label: "Consec. failures", unit: "",       isNum: true  },
+          ];
+          var diagRowsHtml = diagDefs.map(function (d) {
+            var eid = diag[d.slot];
+            if (!eid) return "";
+            var raw = d.isNum ? num(eid) : str(eid);
+            if (raw != null && d.scale) raw = parseFloat((raw * d.scale).toFixed(4));
+            var display = raw == null ? "&mdash;" : esc(String(raw)) + esc(d.unit);
+            return '<tr><td>' + d.label + '</td><td class="an-r">' + display + '</td></tr>';
+          }).join("");
+          var diagHtml = diagRowsHtml
+            ? '<table class="an-tbl an-diag">' +
+              '<thead><tr><th>Diagnostic</th><th class="an-r">Value</th></tr></thead>' +
+              '<tbody>' + diagRowsHtml + '</tbody></table>'
+            : "";
+
+          // ---- compose ----
+          this.innerHTML =
+            '<ha-card>' +
+            '<style>' +
+            ':host { display: block; }' +
+            '.an-wrap { padding: 12px 16px; font-family: "GE Geist Mono", ui-monospace, monospace;' +
+            '  container-type: inline-size; }' +
+            '.an-metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; margin-bottom: 16px; }' +
+            '@container (max-width: 600px) { .an-metrics { grid-template-columns: repeat(2, 1fr); } }' +
+            '@container (max-width: 300px) { .an-metrics { grid-template-columns: 1fr; } }' +
+            '.an-metric { border-left: 3px solid var(--divider-color); padding: 6px 10px;' +
+            '  background: var(--secondary-background-color); border-radius: 4px; }' +
+            '.an-m-lbl { font-size: 10px; color: var(--secondary-text-color); letter-spacing: 0.08em; }' +
+            '.an-m-val { font-size: 20px; font-weight: 600; color: var(--primary-text-color); line-height: 1.2; }' +
+            '.an-m-sub { font-size: 11px; color: var(--secondary-text-color); }' +
+            '.an-body { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }' +
+            '@container (max-width: 600px) { .an-body { grid-template-columns: 1fr; } }' +
+            '.an-tbl { width: 100%; border-collapse: collapse; font-size: 13px; }' +
+            '.an-tbl th { font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em;' +
+            '  color: var(--secondary-text-color); padding: 0 4px 4px;' +
+            '  border-bottom: 1px solid var(--divider-color); font-weight: 500; text-align: left; }' +
+            '.an-tbl td { padding: 3px 4px; color: var(--primary-text-color); }' +
+            '.an-tbl tbody tr:hover { background: var(--secondary-background-color); }' +
+            '.an-r { text-align: right; }' +
+            '.an-tot { font-weight: 600; border-top: 1px solid var(--divider-color); }' +
+            '.an-tbl-mt { margin-top: 8px; }' +
+            '.an-diag th { text-align: left; }' +
+            '</style>' +
+            '<div class="an-wrap">' +
+            '<div class="an-metrics">' + metricsHtml + '</div>' +
+            '<div class="an-body">' +
+            '<div>' + ledgerHtml + '</div>' +
+            (diagHtml ? '<div>' + diagHtml + '</div>' : '') +
+            '</div>' +
+            '</div>' +
+            '</ha-card>';
+        }
+      });
+    }
+
     // Discoverability in the "Community dashboards" picker (HA 2026.5+). Harmless
     // where unsupported.
     try {
@@ -1771,7 +2083,7 @@
         type: "givenergy",
         strategyType: "dashboard",
         name: "GivEnergy",
-        description: "Registry-driven GivEnergy dashboard (classic / flow / glance modes).",
+        description: "Registry-driven GivEnergy dashboard (classic / flow / glance / analyst modes).",
       });
     } catch (e) {
       /* non-fatal */

--- a/custom_components/givenergy_local/www/ge-strategy.js
+++ b/custom_components/givenergy_local/www/ge-strategy.js
@@ -385,7 +385,7 @@
     return view;
   }
 
-  // mode: all -- dev convenience: all mode panels in front of classic tabs.
+  // mode: all -- Glance + Flow + Analyst panels followed by the classic tab set.
   // Not intended as a permanent user-facing mode; remove when modes split into
   // separate dashboards.
   function allViews(plant, opts) {
@@ -2083,7 +2083,7 @@
         type: "givenergy",
         strategyType: "dashboard",
         name: "GivEnergy",
-        description: "Registry-driven GivEnergy dashboard (classic / flow / glance / analyst modes).",
+        description: "Registry-driven GivEnergy dashboard (classic / flow / glance / analyst / all modes).",
       });
     } catch (e) {
       /* non-fatal */

--- a/tests/js/ge-strategy.test.js
+++ b/tests/js/ge-strategy.test.js
@@ -394,3 +394,28 @@ describe("glance mode", () => {
     expect(titles(dash)).toEqual(["EMS Controls", "Diagnostics"]);
   });
 });
+
+describe("all mode", () => {
+  it("leads with Glance then Flow then the full classic view set", async () => {
+    const hass = makeHass({ batterySerials: ["BAT1"], acCoupled: true });
+    const dash = await GE.generateDashboard({ mode: "all" }, hass);
+    expect(titles(dash)).toEqual([
+      "Glance",
+      "Flow",
+      "Overview",
+      "Energy",
+      "Batteries",
+      "Battery Health",
+      "Controls",
+      "Diagnostics",
+    ]);
+    expect(view(dash, "Glance").cards[0].type).toBe("custom:givenergy-glance");
+    expect(view(dash, "Flow").cards[0].type).toBe("custom:givenergy-flow");
+  });
+
+  it("falls back to classic for an EMS plant", async () => {
+    const hass = makeHass({ ems: true });
+    const dash = await GE.generateDashboard({ mode: "all" }, hass);
+    expect(titles(dash)).toEqual(["EMS Controls", "Diagnostics"]);
+  });
+});

--- a/tests/js/ge-strategy.test.js
+++ b/tests/js/ge-strategy.test.js
@@ -396,12 +396,13 @@ describe("glance mode", () => {
 });
 
 describe("all mode", () => {
-  it("leads with Glance then Flow then the full classic view set", async () => {
+  it("leads with Glance then Flow then Analyst then the full classic view set", async () => {
     const hass = makeHass({ batterySerials: ["BAT1"], acCoupled: true });
     const dash = await GE.generateDashboard({ mode: "all" }, hass);
     expect(titles(dash)).toEqual([
       "Glance",
       "Flow",
+      "Analyst",
       "Overview",
       "Energy",
       "Batteries",
@@ -411,11 +412,83 @@ describe("all mode", () => {
     ]);
     expect(view(dash, "Glance").cards[0].type).toBe("custom:givenergy-glance");
     expect(view(dash, "Flow").cards[0].type).toBe("custom:givenergy-flow");
+    expect(view(dash, "Analyst").cards[0].type).toBe("custom:givenergy-analyst");
   });
 
   it("falls back to classic for an EMS plant", async () => {
     const hass = makeHass({ ems: true });
     const dash = await GE.generateDashboard({ mode: "all" }, hass);
+    expect(titles(dash)).toEqual(["EMS Controls", "Diagnostics"]);
+  });
+});
+
+describe("analyst mode", () => {
+  const analystCard = (dash) => view(dash, "Analyst").cards[0];
+
+  it("leads with a non-panel Analyst view with givenergy-analyst, apexcharts placeholder, and heatmaps", async () => {
+    const hass = makeHass({ batterySerials: ["BAT1", "BAT2"], acCoupled: true });
+    const dash = await GE.generateDashboard({ mode: "analyst" }, hass);
+    expect(titles(dash)).toEqual([
+      "Analyst",
+      "Overview",
+      "Energy",
+      "Batteries",
+      "Battery Health",
+      "Controls",
+      "Diagnostics",
+    ]);
+    const av = view(dash, "Analyst");
+    expect(av.panel).toBeUndefined(); // non-panel
+    expect(av.cards[0].type).toBe("custom:givenergy-analyst");
+    // apexcharts not registered -> placeholder
+    expect(av.cards[1].type).toBe("markdown");
+    expect(av.cards[1].content).toContain("apexcharts-card");
+    // one heatmap per battery pack
+    expect(av.cards[2].type).toBe("custom:ge-cell-heatmap");
+    expect(av.cards[3].type).toBe("custom:ge-cell-heatmap");
+  });
+
+  it("resolves all analyst entity slots from the registry and survives the loft_ prefix", async () => {
+    const hass = makeHass({ batterySerials: ["BAT1"], areaPrefix: "loft_" });
+    const dash = await GE.generateDashboard({ mode: "analyst" }, hass);
+    const c = analystCard(dash);
+    const registry = await regSet(hass);
+
+    const liveSlots = [c.solar, c.grid, c.load, c.battery_power, c.battery_soc]
+      .concat(c.solar_strings || [])
+      .filter(Boolean);
+    const totalSlots = Object.values(c.totals || {});
+    const diagSlots  = Object.values(c.diag   || {});
+    const allSlots   = liveSlots.concat(totalSlots).concat(diagSlots);
+
+    expect(liveSlots.length).toBeGreaterThan(4);
+    expect(totalSlots.length).toBe(6); // all 6 energy totals
+    expect(diagSlots.length).toBeGreaterThan(4);
+
+    for (const eid of allSlots) {
+      expect(registry.has(eid)).toBe(true);
+      expect(eid).toContain("loft_");
+    }
+    expect(hasNullEntity(c)).toBe(false);
+  });
+
+  it("omits missing totals and diag entities gracefully rather than emitting null", async () => {
+    const hass = makeHass({
+      batterySerials: ["BAT1"],
+      omitKeys: ["e_grid_out_day", "e_grid_in_day", "consecutive_failures"],
+    });
+    const c = analystCard(await GE.generateDashboard({ mode: "analyst" }, hass));
+    expect(c.totals.export_today).toBeUndefined();
+    expect(c.totals.import_today).toBeUndefined();
+    expect(c.totals.pv_today).toBeTruthy();
+    expect(c.diag.consecutive_failures).toBeUndefined();
+    expect(c.diag.t_inverter_heatsink).toBeTruthy();
+    expect(hasNullEntity(c)).toBe(false);
+  });
+
+  it("does not emit an Analyst view for an EMS plant", async () => {
+    const hass = makeHass({ ems: true });
+    const dash = await GE.generateDashboard({ mode: "analyst" }, hass);
     expect(titles(dash)).toEqual(["EMS Controls", "Diagnostics"]);
   });
 });

--- a/tests/js/ge-strategy.test.js
+++ b/tests/js/ge-strategy.test.js
@@ -338,3 +338,59 @@ describe("flow mode", () => {
     expect(titles(dash)).toEqual(["EMS Controls", "Diagnostics"]);
   });
 });
+
+describe("glance mode", () => {
+  const glanceCard = (dash) => view(dash, "Glance").cards[0];
+
+  it("leads with a panel Glance view, then the full classic view set", async () => {
+    const hass = makeHass({ batterySerials: ["BAT1"], acCoupled: true });
+    const dash = await GE.generateDashboard({ mode: "glance" }, hass);
+    expect(titles(dash)).toEqual([
+      "Glance",
+      "Overview",
+      "Energy",
+      "Batteries",
+      "Battery Health",
+      "Controls",
+      "Diagnostics",
+    ]);
+    const gl = view(dash, "Glance");
+    expect(gl.panel).toBe(true);
+    expect(gl.cards.length).toBe(1);
+    expect(gl.cards[0].type).toBe("custom:givenergy-glance");
+  });
+
+  it("resolves every glance slot from the registry and survives the loft_ prefix", async () => {
+    const hass = makeHass({ batterySerials: ["BAT1", "BAT2"], areaPrefix: "loft_" });
+    const dash = await GE.generateDashboard({ mode: "glance" }, hass);
+    const c = glanceCard(dash);
+    const registry = await regSet(hass);
+
+    const slots = [c.solar, c.grid, c.load, c.battery_power, c.battery_soc]
+      .concat(c.solar_strings || [])
+      .concat(Object.values(c.totals || {}))
+      .concat((c.packs || []).map((p) => p.soc));
+
+    expect(slots.length).toBeGreaterThan(8);
+    for (const eid of slots) {
+      expect(registry.has(eid)).toBe(true);
+      expect(eid).toContain("loft_");
+    }
+    expect((c.packs || []).map((p) => p.name)).toEqual(["BAT1", "BAT2"]);
+  });
+
+  it("omits totals whose entities are missing rather than emitting null", async () => {
+    const hass = makeHass({ batterySerials: ["BAT1"], omitKeys: ["e_grid_out_day", "e_grid_in_day"] });
+    const c = glanceCard(await GE.generateDashboard({ mode: "glance" }, hass));
+    expect(c.totals.export_today).toBeUndefined();
+    expect(c.totals.import_today).toBeUndefined();
+    expect(c.totals.pv_today).toBeTruthy();
+    expect(hasNullEntity(c)).toBe(false);
+  });
+
+  it("does not emit a Glance panel for an EMS plant", async () => {
+    const hass = makeHass({ ems: true });
+    const dash = await GE.generateDashboard({ mode: "glance" }, hass);
+    expect(titles(dash)).toEqual(["EMS Controls", "Diagnostics"]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes part of #131 — introduces `mode: glance` as a third selectable mode for the `custom:givenergy` dashboard strategy.

**What's new**

- `mode: glance` prepends a full-viewport Glance panel (`panel: true`) to the existing classic view set.
- `custom:givenergy-glance` — a new vanilla custom element (no build step) that renders:
  - A natural-language status sentence with a pulsing amber/green indicator dot. Eight states are derived from live sign-combinations of grid/battery/solar (e.g. "Solar covering the house and charging the battery, exporting the surplus." / "Battery powering the house." / "Drawing from the grid."). The dot turns amber when importing from the grid or when battery SOC drops below 20%.
  - Three large Fraunces numerals: Solar today (kWh), Battery SOC (%), House today (kWh). Each has a contextual sub-line: string breakdown or current kW for solar, per-pack SOC or charge/discharge direction for battery, import/export direction for house.
  - Health pills: battery count, per-pack SOC when multiple packs are present (amber at < 20%), imported/exported kWh today, active per-string generation.
- EMS plants fall back to the classic view set (no glance panel), matching the `flow` mode behaviour.
- Kiosk-mode hints (`hide_header`, `hide_sidebar`) are feature-detected and omitted when the integration is absent.
- Container-query responsive layout; signature guard skips DOM rebuilds when no referenced state has changed.
- `_STRATEGY_VERSION` bumped to `6` for cache-busting.

**Tests**

Four new JS tests (29 total): view set shape, EMS fallback, registry resolution under the `loft_` area prefix, and missing-entity omission.

## Test plan

- [ ] Add `strategy: { type: custom:givenergy, mode: glance }` to a dashboard.
- [ ] Confirm Glance panel is the first view; classic tabs follow.
- [ ] Status sentence matches the current system state (solar generating, battery charging/discharging, grid import/export).
- [ ] Dot is green when self-sufficient/exporting, amber when importing or SOC < 20%.
- [ ] Three big numbers populated (Solar today / Battery % / House today).
- [ ] Health pills show battery count, import/export today, and per-string when active.
- [ ] On a narrow viewport, the three numbers stack to a single column.
- [ ] EMS plant: `mode: glance` falls back to the classic EMS view set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "glance" dashboard mode with an at-a-glance view displaying solar generation, battery state-of-charge, and household usage.
  * Includes visual indicators for battery availability, import/export totals, and per-string solar generation.

* **Chores**
  * Updated dashboard version to ensure clients fetch the latest configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->