### PR TITLE
Surface a missing device instead of silently baking in the loss

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -52,7 +52,7 @@ from .const import (
     SERVICE_REDETECT_PLANT,
     SERVICE_SET_SYSTEM_DATETIME,
 )
-from .coordinator import GivEnergyUpdateCoordinator
+from .coordinator import GivEnergyUpdateCoordinator, missing_devices
 from .dashboard import DASHBOARD_VERSION
 from .http import (
     CaptureDownloadView,
@@ -498,6 +498,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         hass.config_entries.async_schedule_reload(entry.entry_id)
 
+    async def _on_devices_missing(prior: PlantCapabilities, actual: PlantCapabilities) -> None:
+        # A previously-known device stopped responding and the loss persisted
+        # across retries. Do NOT persist the reduced topology and do NOT reload —
+        # the full prior stays cached so the next reconnect re-probes it and can
+        # self-heal. Raise a loud, fixable repair so a human decides whether this
+        # is transient or a genuine removal.
+        devices = ", ".join(missing_devices(prior, actual)) or "a device"
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"expected_devices_missing_{entry.entry_id}",
+            is_fixable=True,
+            is_persistent=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="expected_devices_missing",
+            translation_placeholders={"devices": devices},
+            data={"entry_id": entry.entry_id, "devices": devices},
+        )
+
+    async def _on_topology_healed() -> None:
+        # Full expected topology confirmed — clear any standing "device missing"
+        # repair the moment the device answers again (idempotent: a no-op when
+        # no such issue exists).
+        ir.async_delete_issue(hass, DOMAIN, f"expected_devices_missing_{entry.entry_id}")
+
     coordinator = GivEnergyUpdateCoordinator(
         hass=hass,
         host=entry.data[CONF_HOST],
@@ -506,6 +531,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         passive=entry.data.get(CONF_PASSIVE, DEFAULT_PASSIVE),
         prior_capabilities=prior_capabilities,
         on_topology_changed=_on_topology_changed,
+        on_devices_missing=_on_devices_missing,
+        on_topology_healed=_on_topology_healed,
     )
 
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
@@ -28,6 +29,17 @@ InverterModel = SinglePhaseInverter | ThreePhaseInverter
 # the coordinator itself stays free of HA UI / config-entry concerns.
 TopologyChangedCallback = Callable[[PlantCapabilities], Awaitable[None]]
 
+# Invoked when detect() reports that a previously-known device did NOT respond
+# (a loss) and the loss persisted across retries. Receives (prior, actual) so
+# the caller can raise a loud, fixable repair WITHOUT persisting the reduced
+# topology — the full prior stays cached so the next reconnect re-probes it.
+DevicesMissingCallback = Callable[[PlantCapabilities, PlantCapabilities], Awaitable[None]]
+
+# Invoked whenever a (re)connect confirms the full expected topology (detect
+# succeeded with no mismatch, or a loss healed on retry). Lets the caller clear
+# a stale "device missing" repair the moment the device answers again.
+TopologyHealedCallback = Callable[[], Awaitable[None]]
+
 _LOGGER = logging.getLogger(__name__)
 
 # Target interval between full holding-register refreshes in active mode.
@@ -48,6 +60,48 @@ _PARTIAL_LOG_EVERY = 20
 # so the extra latency is bounded to ~one slow probe per detect.
 PROBE_TIMEOUT_SECONDS = 1.0
 PROBE_RETRIES = 3
+
+# When detect() reports a DEVICE LOSS (a previously-known battery/meter/stack
+# stopped answering), re-probe a few times before believing it — a slow BMS
+# often answers on the next sweep. Kept small: this blocks _connect(), which
+# runs under HA's coordinator lock, so total added latency on a persistent loss
+# is bounded to DETECT_LOSS_RETRIES * (one detect sweep + DETECT_LOSS_RETRY_DELAY).
+DETECT_LOSS_RETRIES = 2
+DETECT_LOSS_RETRY_DELAY = 5.0  # seconds
+
+
+def missing_devices(prior: PlantCapabilities, actual: PlantCapabilities) -> list[str]:
+    """Describe devices present in ``prior`` but absent from ``actual``.
+
+    An empty list means this is *not* a device loss — a pure add or a
+    ``device_type`` change returns ``[]`` so the routine accept-persist-reload
+    path handles it. A non-empty list means a previously-known device is gone
+    (the descriptors double as the repair message), which the caller should
+    retry and, if persistent, surface loudly rather than silently bake in.
+
+    Membership comparison (not positional) — the library may reorder addresses;
+    only an *absence* (or a shrunk HV module count) counts as a loss.
+    """
+    if prior.device_type != actual.device_type:
+        return []
+    missing: list[str] = []
+    for addr in prior.lv_battery_addresses:
+        if addr not in actual.lv_battery_addresses:
+            missing.append(f"battery at 0x{addr:02x}")
+    for addr in prior.meter_addresses:
+        if addr not in actual.meter_addresses:
+            missing.append(f"meter at 0x{addr:02x}")
+    # bcu_stacks entries are (bcu_offset, num_modules); device addr = 0x70+offset.
+    actual_modules_by_offset = {off: mods for off, mods in actual.bcu_stacks}
+    for off, mods in prior.bcu_stacks:
+        if off not in actual_modules_by_offset:
+            missing.append(f"HV stack at 0x{0x70 + off:02x}")
+        elif actual_modules_by_offset[off] < mods:
+            missing.append(
+                f"HV stack at 0x{0x70 + off:02x} "
+                f"({actual_modules_by_offset[off]} of {mods} modules)"
+            )
+    return missing
 
 
 class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
@@ -76,6 +130,8 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         retries: int = 1,
         prior_capabilities: PlantCapabilities | None = None,
         on_topology_changed: TopologyChangedCallback | None = None,
+        on_devices_missing: DevicesMissingCallback | None = None,
+        on_topology_healed: TopologyHealedCallback | None = None,
     ) -> None:
         super().__init__(
             hass,
@@ -94,6 +150,8 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         # this attribute at async_setup_entry time.
         self._prior_capabilities = prior_capabilities
         self._on_topology_changed = on_topology_changed
+        self._on_devices_missing = on_devices_missing
+        self._on_topology_healed = on_topology_healed
         self._client: Client | None = None
         self.last_successful_refresh: datetime | None = None
         self.consecutive_failures: int = 0
@@ -362,6 +420,7 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         """
         self._client = Client(host=self.host, port=self.port)
         await self._client.connect()
+        topology_confirmed = True
         try:
             # The library's battery sweep probes additional packs (0x33+) with a
             # stingy default budget (probe_timeout=0.5s, probe_retries=1) and
@@ -378,24 +437,94 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                 probe_retries=PROBE_RETRIES,
             )
         except PlantTopologyMismatch as exc:
-            _LOGGER.warning(
-                "Plant topology has changed since last seen — accepting new layout "
-                "(prior=%r, actual=%r); a reload will refresh entity counts",
-                exc.prior,
-                exc.actual,
-            )
-            # Library leaves plant.capabilities=None on mismatch; assign so this
-            # tick's refresh_plant() still dispatches correctly using the new
-            # topology before the reload tears things down.
-            assert self._client is not None  # set two lines above
-            self._client.plant.capabilities = exc.actual
-            self._prior_capabilities = exc.actual
-            if self._on_topology_changed is not None:
-                await self._on_topology_changed(exc.actual)
+            topology_confirmed = await self._handle_topology_mismatch(exc)
+        if topology_confirmed and self._on_topology_healed is not None:
+            # Full expected topology is present — clear any stale "device
+            # missing" repair (covers both restart and mid-session recovery).
+            await self._on_topology_healed()
         self._last_inverter_time = None
         self._unchanged_ticks = 0
         self._active_tick = 0
         _LOGGER.info("Connected to inverter at %s:%s", self.host, self.port)
+
+    async def _handle_topology_mismatch(self, exc: PlantTopologyMismatch) -> bool:
+        """Resolve a detect() topology mismatch.
+
+        Returns True only when the full expected topology is confirmed (a loss
+        that healed on retry) so the caller can clear a stale repair. Returns
+        False for a persistent loss (surfaced via on_devices_missing, prior kept)
+        and for a routine add / device_type change (accepted, persisted, reloaded
+        via on_topology_changed).
+        """
+        assert self._client is not None  # _connect set it before calling
+
+        missing = missing_devices(exc.prior, exc.actual)
+        if missing:
+            # A previously-known device didn't answer. Re-probe a few times — a
+            # slow BMS often responds on the next sweep — before believing it.
+            for attempt in range(1, DETECT_LOSS_RETRIES + 1):
+                _LOGGER.warning(
+                    "detect() reports missing device(s) %s (attempt %d/%d); "
+                    "re-probing in %.0fs before accepting the loss",
+                    missing,
+                    attempt,
+                    DETECT_LOSS_RETRIES,
+                    DETECT_LOSS_RETRY_DELAY,
+                )
+                await asyncio.sleep(DETECT_LOSS_RETRY_DELAY)
+                try:
+                    await self._client.detect(
+                        prior=self._prior_capabilities,
+                        probe_timeout=PROBE_TIMEOUT_SECONDS,
+                        probe_retries=PROBE_RETRIES,
+                    )
+                except PlantTopologyMismatch as retry_exc:
+                    # A retry can surface a *different* mismatch (e.g. an add now);
+                    # re-classify against this retry's prior/actual.
+                    exc = retry_exc
+                    missing = missing_devices(retry_exc.prior, retry_exc.actual)
+                    if not missing:
+                        break  # no longer a loss → routine add/device_type path
+                    continue
+                else:
+                    # Retry succeeded: detect() repopulated plant.capabilities with
+                    # the full prior. Nothing to bake in, no callback, prior kept.
+                    _LOGGER.info("Missing device(s) reappeared on retry; full topology restored")
+                    return True
+
+        if missing:
+            # Persistent loss. Do NOT touch self._prior_capabilities — keep the
+            # full prior so the next reconnect re-probes it and self-heals. Serve
+            # the reduced topology for this tick only so the live poll dispatches
+            # for what responded; the missing device's entities read unavailable.
+            _LOGGER.error(
+                "Expected device(s) %s did not respond after %d retries; serving the "
+                "reduced topology for this poll but NOT persisting it — affected "
+                "entities will read unavailable until they reappear or you re-detect",
+                missing,
+                DETECT_LOSS_RETRIES,
+            )
+            self._client.plant.capabilities = exc.actual
+            if self._on_devices_missing is not None:
+                await self._on_devices_missing(exc.prior, exc.actual)
+            return False
+
+        # Not (or no longer) a loss: routine add / device_type change. Preserve
+        # the existing behaviour — accept, persist, and reload via the callback.
+        _LOGGER.warning(
+            "Plant topology has changed since last seen — accepting new layout "
+            "(prior=%r, actual=%r); a reload will refresh entity counts",
+            exc.prior,
+            exc.actual,
+        )
+        # Library leaves plant.capabilities=None on mismatch; assign so this
+        # tick's refresh_plant() still dispatches correctly using the new
+        # topology before the reload tears things down.
+        self._client.plant.capabilities = exc.actual
+        self._prior_capabilities = exc.actual
+        if self._on_topology_changed is not None:
+            await self._on_topology_changed(exc.actual)
+        return False
 
     async def _reset_client(self) -> None:
         """Close and discard the client so the next tick triggers a reconnect."""

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -70,7 +70,7 @@ DETECT_LOSS_RETRIES = 2
 DETECT_LOSS_RETRY_DELAY = 5.0  # seconds
 
 
-def missing_devices(prior: PlantCapabilities, actual: PlantCapabilities) -> list[str]:
+def missing_devices(prior: PlantCapabilities | None, actual: PlantCapabilities) -> list[str]:
     """Describe devices present in ``prior`` but absent from ``actual``.
 
     An empty list means this is *not* a device loss — a pure add or a
@@ -82,7 +82,7 @@ def missing_devices(prior: PlantCapabilities, actual: PlantCapabilities) -> list
     Membership comparison (not positional) — the library may reorder addresses;
     only an *absence* (or a shrunk HV module count) counts as a loss.
     """
-    if prior.device_type != actual.device_type:
+    if prior is None or prior.device_type != actual.device_type:
         return []
     missing: list[str] = []
     for addr in prior.lv_battery_addresses:
@@ -153,6 +153,7 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         self._on_devices_missing = on_devices_missing
         self._on_topology_healed = on_topology_healed
         self._client: Client | None = None
+        self._schedule_reconnect: bool = False
         self.last_successful_refresh: datetime | None = None
         self.consecutive_failures: int = 0
         self.total_failures: int = 0
@@ -179,6 +180,9 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
 
     async def _async_update_data(self) -> Plant:
         try:
+            if self._schedule_reconnect:
+                self._schedule_reconnect = False
+                await self._reset_client()
             reconnecting = self._client is None or not self._client.connected
             if reconnecting:
                 await self._connect()
@@ -505,6 +509,7 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                 DETECT_LOSS_RETRIES,
             )
             self._client.plant.capabilities = exc.actual
+            self._schedule_reconnect = True
             if self._on_devices_missing is not None:
                 await self._on_devices_missing(exc.prior, exc.actual)
             return False

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -68,6 +68,7 @@ PROBE_RETRIES = 3
 # is bounded to DETECT_LOSS_RETRIES * (one detect sweep + DETECT_LOSS_RETRY_DELAY).
 DETECT_LOSS_RETRIES = 2
 DETECT_LOSS_RETRY_DELAY = 5.0  # seconds
+LOSS_REDETECT_INTERVAL = 300.0  # seconds between loss-driven reconnect-and-detect attempts
 
 
 def missing_devices(prior: PlantCapabilities | None, actual: PlantCapabilities) -> list[str]:
@@ -154,6 +155,7 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         self._on_topology_healed = on_topology_healed
         self._client: Client | None = None
         self._schedule_reconnect: bool = False
+        self._loss_redetect_after: float = 0.0
         self.last_successful_refresh: datetime | None = None
         self.consecutive_failures: int = 0
         self.total_failures: int = 0
@@ -180,9 +182,12 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
 
     async def _async_update_data(self) -> Plant:
         try:
-            if self._schedule_reconnect:
+            loop = asyncio.get_running_loop()
+            if self._schedule_reconnect and loop.time() >= self._loss_redetect_after:
                 self._schedule_reconnect = False
                 await self._reset_client()
+                loop = asyncio.get_running_loop()
+                self._loss_redetect_after = loop.time() + LOSS_REDETECT_INTERVAL
             reconnecting = self._client is None or not self._client.connected
             if reconnecting:
                 await self._connect()

--- a/custom_components/givenergy_local/repairs.py
+++ b/custom_components/givenergy_local/repairs.py
@@ -15,6 +15,8 @@ async def async_create_fix_flow(
     issue_id: str,
     data: dict | None,
 ) -> RepairsFlow:
+    if issue_id.startswith("expected_devices_missing_"):
+        return ExpectedDevicesMissingRepairFlow(data)
     return DashboardOutdatedRepairFlow(data)
 
 
@@ -37,5 +39,36 @@ class DashboardOutdatedRepairFlow(RepairsFlow):
             description_placeholders={
                 "old_version": str(self._data.get("old_version", "?")),
                 "new_version": str(self._data.get("new_version", "?")),
+            },
+        )
+
+
+class ExpectedDevicesMissingRepairFlow(RepairsFlow):
+    """Fix flow for a previously-known device that stopped responding.
+
+    Confirming clears the cached plant topology for the entry and reloads it —
+    a fresh cold detect() then commits whatever hardware is actually present
+    (the same effect as the redetect_plant service, but targeted directly by
+    the entry_id we already hold).
+    """
+
+    def __init__(self, data: dict | None) -> None:
+        self._data = data or {}
+
+    async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
+        if user_input is not None:
+            # Lazy import to avoid any import cycle with the package __init__.
+            from . import _capabilities_store
+
+            entry_id = self._data.get("entry_id")
+            if entry_id:
+                await _capabilities_store(self.hass, entry_id).async_remove()
+                self.hass.config_entries.async_schedule_reload(entry_id)
+            return self.async_create_entry(data={})
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "devices": str(self._data.get("devices", "a device")),
             },
         )

--- a/custom_components/givenergy_local/strings.json
+++ b/custom_components/givenergy_local/strings.json
@@ -45,6 +45,17 @@
         }
       }
     },
+    "expected_devices_missing": {
+      "title": "GivEnergy device not responding",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "A known GivEnergy device stopped responding",
+            "description": "These device(s) were part of your system last time but did not respond on the latest connection: {devices}.\n\nThe integration has NOT removed them — it is still serving the rest of your system, and the affected entities show as unavailable. This is usually a transient comms issue (for example a slow battery BMS); the previous layout is kept and retried, so it normally clears on its own.\n\nIf the device has come back, or if you have genuinely removed it, click Fix to clear the cached layout and run a fresh hardware detection. Otherwise you can dismiss this — the integration picks the device back up automatically on its next successful detection."
+          }
+        }
+      }
+    },
     "plant_topology_changed": {
       "title": "GivEnergy plant topology has changed",
       "description": "The hardware layout of your GivEnergy system has changed since the last start — typically a battery was added or removed, or the inverter device type changed.\n\nThe integration has already accepted the new topology and reloaded itself; this notice is purely advisory and can be dismissed."

--- a/custom_components/givenergy_local/translations/en.json
+++ b/custom_components/givenergy_local/translations/en.json
@@ -43,6 +43,17 @@
         }
       }
     },
+    "expected_devices_missing": {
+      "title": "GivEnergy device not responding",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "A known GivEnergy device stopped responding",
+            "description": "These device(s) were part of your system last time but did not respond on the latest connection: {devices}.\n\nThe integration has NOT removed them — it is still serving the rest of your system, and the affected entities show as unavailable. This is usually a transient comms issue (for example a slow battery BMS); the previous layout is kept and retried, so it normally clears on its own.\n\nIf the device has come back, or if you have genuinely removed it, click Fix to clear the cached layout and run a fresh hardware detection. Otherwise you can dismiss this — the integration picks the device back up automatically on its next successful detection."
+          }
+        }
+      }
+    },
     "plant_topology_changed": {
       "title": "GivEnergy plant topology has changed",
       "description": "The hardware layout of your GivEnergy system has changed since the last start — typically a battery was added or removed, or the inverter device type changed.\n\nThe integration has already accepted the new topology and reloaded itself; this notice is purely advisory and can be dismissed."

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1007,6 +1007,8 @@ def test_missing_devices_classification():
     assert missing_devices(_caps(lv_battery_addresses=[0x32]), base) == []
     # A device_type change is not a loss (the routine reload path handles it).
     assert missing_devices(_caps(), _caps(device_type=Model.AC)) == []
+    # No prior (cold start) is not a loss.
+    assert missing_devices(None, base) == []
 
 
 async def test_loss_retried_then_heals(hass, mock_plant):
@@ -1083,6 +1085,7 @@ async def test_persistent_loss_invokes_on_devices_missing(hass, mock_plant):
     on_healed.assert_not_awaited()
     assert coordinator._prior_capabilities is prior  # loss NOT baked in
     assert client.plant.capabilities is actual  # reduced topology served this tick
+    assert coordinator._schedule_reconnect  # forces a reconnect on the next poll
 
 
 async def test_device_type_change_uses_topology_changed_path(hass, mock_plant):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1088,6 +1088,28 @@ async def test_persistent_loss_invokes_on_devices_missing(hass, mock_plant):
     assert coordinator._schedule_reconnect  # forces a reconnect on the next poll
 
 
+async def test_loss_reconnect_respects_cooldown(hass, mock_plant):
+    """_schedule_reconnect within cooldown: no reset, normal poll continues."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        mock_cls.return_value = client
+        coordinator._client = client
+        coordinator._schedule_reconnect = True
+        coordinator._loss_redetect_after = float("inf")  # cooldown not yet expired
+
+        await coordinator._async_update_data()
+
+    # Client must NOT have been reset — reconnect was deferred by cooldown.
+    client.close.assert_not_awaited()
+    assert coordinator._client is client
+    # Flag remains set so the reconnect fires once the cooldown expires.
+    assert coordinator._schedule_reconnect
+
+
 async def test_device_type_change_uses_topology_changed_path(hass, mock_plant):
     """A device_type change is routine (not a loss): accept, update prior, reload."""
     prior = _caps()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -17,9 +17,12 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.givenergy_local.coordinator import (
     _PARTIAL_LOG_EVERY,
+    DETECT_LOSS_RETRIES,
+    DETECT_LOSS_RETRY_DELAY,
     PROBE_RETRIES,
     PROBE_TIMEOUT_SECONDS,
     GivEnergyUpdateCoordinator,
+    missing_devices,
 )
 
 
@@ -983,3 +986,170 @@ async def test_topology_mismatch_without_callback_still_accepts_actual(hass, moc
 
     assert client.plant.capabilities is actual
     assert coordinator._prior_capabilities is actual
+
+
+def test_missing_devices_classification():
+    """missing_devices() flags losses (battery/meter/HV) but not adds or type changes."""
+    base = _caps(lv_battery_addresses=[0x32, 0x33])
+    # Battery dropped.
+    assert missing_devices(base, _caps(lv_battery_addresses=[0x32])) == ["battery at 0x33"]
+    # Meter dropped.
+    assert missing_devices(_caps(meter_addresses=[0x01]), _caps(meter_addresses=[])) == [
+        "meter at 0x01"
+    ]
+    # HV stack offset removed.
+    assert missing_devices(_caps(bcu_stacks=[(0, 4)]), _caps(bcu_stacks=[])) == ["HV stack at 0x70"]
+    # HV stack module count shrank.
+    assert missing_devices(_caps(bcu_stacks=[(0, 4)]), _caps(bcu_stacks=[(0, 2)])) == [
+        "HV stack at 0x70 (2 of 4 modules)"
+    ]
+    # An add is not a loss.
+    assert missing_devices(_caps(lv_battery_addresses=[0x32]), base) == []
+    # A device_type change is not a loss (the routine reload path handles it).
+    assert missing_devices(_caps(), _caps(device_type=Model.AC)) == []
+
+
+async def test_loss_retried_then_heals(hass, mock_plant):
+    """A loss that clears on retry: full prior kept, healed callback, no loss callback."""
+    prior = _caps(lv_battery_addresses=[0x32, 0x33])
+    actual = _caps(lv_battery_addresses=[0x32])
+    mismatch = PlantTopologyMismatch("battery missing", prior=prior, actual=actual)
+    on_missing, on_changed, on_healed = AsyncMock(), AsyncMock(), AsyncMock()
+    coordinator = GivEnergyUpdateCoordinator(
+        hass,
+        "192.168.1.1",
+        8899,
+        30,
+        prior_capabilities=prior,
+        on_topology_changed=on_changed,
+        on_devices_missing=on_missing,
+        on_topology_healed=on_healed,
+    )
+
+    with (
+        patch("custom_components.givenergy_local.coordinator.Client") as mock_cls,
+        patch(
+            "custom_components.givenergy_local.coordinator.asyncio.sleep", AsyncMock()
+        ) as mock_sleep,
+    ):
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.detect = AsyncMock(side_effect=[mismatch, None])  # heals on retry
+        mock_cls.return_value = client
+
+        await coordinator._connect()  # must NOT raise
+
+    assert client.detect.await_count == 2  # initial + one healing retry
+    mock_sleep.assert_awaited_once_with(DETECT_LOSS_RETRY_DELAY)
+    on_missing.assert_not_awaited()
+    on_changed.assert_not_awaited()
+    on_healed.assert_awaited_once()
+    assert coordinator._prior_capabilities is prior  # full prior never overwritten
+
+
+async def test_persistent_loss_invokes_on_devices_missing(hass, mock_plant):
+    """A loss surviving retries: loss callback, prior kept, reduced caps for the tick."""
+    prior = _caps(lv_battery_addresses=[0x32, 0x33])
+    actual = _caps(lv_battery_addresses=[0x32])
+    mismatch = PlantTopologyMismatch("battery missing", prior=prior, actual=actual)
+    on_missing, on_changed, on_healed = AsyncMock(), AsyncMock(), AsyncMock()
+    coordinator = GivEnergyUpdateCoordinator(
+        hass,
+        "192.168.1.1",
+        8899,
+        30,
+        prior_capabilities=prior,
+        on_topology_changed=on_changed,
+        on_devices_missing=on_missing,
+        on_topology_healed=on_healed,
+    )
+
+    with (
+        patch("custom_components.givenergy_local.coordinator.Client") as mock_cls,
+        patch("custom_components.givenergy_local.coordinator.asyncio.sleep", AsyncMock()),
+    ):
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.detect = AsyncMock(side_effect=mismatch)  # never recovers
+        mock_cls.return_value = client
+
+        await coordinator._connect()  # must NOT raise
+
+    assert client.detect.await_count == 1 + DETECT_LOSS_RETRIES
+    on_missing.assert_awaited_once_with(prior, actual)
+    on_changed.assert_not_awaited()  # not a routine change → no persist/reload
+    on_healed.assert_not_awaited()
+    assert coordinator._prior_capabilities is prior  # loss NOT baked in
+    assert client.plant.capabilities is actual  # reduced topology served this tick
+
+
+async def test_device_type_change_uses_topology_changed_path(hass, mock_plant):
+    """A device_type change is routine (not a loss): accept, update prior, reload."""
+    prior = _caps()
+    actual = _caps(device_type=Model.AC)
+    mismatch = PlantTopologyMismatch("type changed", prior=prior, actual=actual)
+    on_missing, on_changed = AsyncMock(), AsyncMock()
+    coordinator = GivEnergyUpdateCoordinator(
+        hass,
+        "192.168.1.1",
+        8899,
+        30,
+        prior_capabilities=prior,
+        on_topology_changed=on_changed,
+        on_devices_missing=on_missing,
+    )
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.detect = AsyncMock(side_effect=mismatch)
+        mock_cls.return_value = client
+
+        await coordinator._connect()
+
+    client.detect.assert_awaited_once()  # no retries for a non-loss
+    on_changed.assert_awaited_once_with(actual)
+    on_missing.assert_not_awaited()
+    assert coordinator._prior_capabilities is actual
+    assert client.plant.capabilities is actual
+
+
+async def test_loss_retry_surfacing_add_falls_through(hass, mock_plant):
+    """A loss whose retry reveals a non-loss change (an add) takes the routine path."""
+    prior = _caps(lv_battery_addresses=[0x32, 0x33])
+    loss_actual = _caps(lv_battery_addresses=[0x32])
+    add_actual = _caps(lv_battery_addresses=[0x32, 0x33, 0x34])
+    loss = PlantTopologyMismatch("battery missing", prior=prior, actual=loss_actual)
+    add = PlantTopologyMismatch("battery added", prior=prior, actual=add_actual)
+    on_missing, on_changed, on_healed = AsyncMock(), AsyncMock(), AsyncMock()
+    coordinator = GivEnergyUpdateCoordinator(
+        hass,
+        "192.168.1.1",
+        8899,
+        30,
+        prior_capabilities=prior,
+        on_topology_changed=on_changed,
+        on_devices_missing=on_missing,
+        on_topology_healed=on_healed,
+    )
+
+    with (
+        patch("custom_components.givenergy_local.coordinator.Client") as mock_cls,
+        patch("custom_components.givenergy_local.coordinator.asyncio.sleep", AsyncMock()),
+    ):
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.detect = AsyncMock(side_effect=[loss, add])
+        mock_cls.return_value = client
+
+        await coordinator._connect()
+
+    assert client.detect.await_count == 2
+    on_changed.assert_awaited_once_with(add_actual)  # routine path with the retry's actual
+    on_missing.assert_not_awaited()
+    on_healed.assert_not_awaited()
+    assert coordinator._prior_capabilities is add_actual

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,6 +6,7 @@ from givenergy_modbus.exceptions import PlantTopologyMismatch
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
@@ -298,6 +299,124 @@ async def test_topology_mismatch_persists_actual_and_raises_repairs_issue(
     assert (DOMAIN, f"plant_topology_changed_{mock_config_entry.entry_id}") in issues
     # And a reload was queued.
     reload_mock.assert_called_with(mock_config_entry.entry_id)
+
+
+async def test_persistent_loss_raises_error_repair_and_keeps_cache(
+    hass, mock_client, mock_config_entry
+):
+    """A persistent device loss raises a loud fixable ERROR repair and does NOT
+    persist the reduced topology or reload — the full prior stays cached."""
+    prior = PlantCapabilities(
+        device_type=Model.HYBRID,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32, 0x33],
+        bcu_stacks=[],
+    )
+    actual = PlantCapabilities(
+        device_type=Model.HYBRID,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    mismatch = PlantTopologyMismatch("battery missing", prior=prior, actual=actual)
+    mock_client.detect = AsyncMock(side_effect=mismatch)
+
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.givenergy_local._load_capabilities",
+            new=AsyncMock(return_value=prior),
+        ),
+        patch("custom_components.givenergy_local._save_capabilities", new=AsyncMock()) as save_mock,
+        patch.object(
+            hass.config_entries, "async_reload", new=AsyncMock(return_value=True)
+        ) as reload_mock,
+        patch("custom_components.givenergy_local.coordinator.asyncio.sleep", AsyncMock()),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Reduced topology NOT persisted, integration NOT reloaded.
+    save_mock.assert_not_awaited()
+    reload_mock.assert_not_called()
+    # A loud, fixable ERROR repair names the missing battery.
+    issue = ir.async_get(hass).issues.get(
+        (DOMAIN, f"expected_devices_missing_{mock_config_entry.entry_id}")
+    )
+    assert issue is not None
+    assert issue.severity is ir.IssueSeverity.ERROR
+    assert issue.is_fixable is True
+    assert "battery at 0x33" in issue.translation_placeholders["devices"]
+
+
+async def test_full_topology_detect_clears_stale_missing_repair(
+    hass, mock_client, mock_config_entry
+):
+    """A successful detect (full topology) clears any standing device-missing repair."""
+    mock_config_entry.add_to_hass(hass)
+    # Pre-seed a stale repair as if a prior run had flagged a missing device.
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"expected_devices_missing_{mock_config_entry.entry_id}",
+        is_fixable=True,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="expected_devices_missing",
+        translation_placeholders={"devices": "battery at 0x33"},
+        data={"entry_id": mock_config_entry.entry_id},
+    )
+
+    # Default mock_client.detect succeeds (no mismatch) → healed callback fires.
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        DOMAIN,
+        f"expected_devices_missing_{mock_config_entry.entry_id}",
+    ) not in ir.async_get(hass).issues
+
+
+async def test_missing_device_fix_flow_clears_cache_and_reloads(hass):
+    """The repair's Fix step clears the entry's cached topology and reloads it."""
+    from custom_components.givenergy_local.repairs import (
+        ExpectedDevicesMissingRepairFlow,
+    )
+
+    flow = ExpectedDevicesMissingRepairFlow({"entry_id": "entry-xyz", "devices": "battery at 0x33"})
+    flow.hass = hass
+
+    fake_store = AsyncMock()
+    with (
+        patch(
+            "custom_components.givenergy_local._capabilities_store",
+            return_value=fake_store,
+        ) as store_factory,
+        patch.object(hass.config_entries, "async_schedule_reload") as reload_mock,
+    ):
+        result = await flow.async_step_init({})
+
+    store_factory.assert_called_once_with(hass, "entry-xyz")
+    fake_store.async_remove.assert_awaited_once()
+    reload_mock.assert_called_once_with("entry-xyz")
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_missing_device_fix_flow_form_names_devices(hass):
+    """Before confirming, the Fix form surfaces which device(s) went missing."""
+    from custom_components.givenergy_local.repairs import (
+        ExpectedDevicesMissingRepairFlow,
+    )
+
+    flow = ExpectedDevicesMissingRepairFlow({"entry_id": "e", "devices": "battery at 0x33"})
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["description_placeholders"]["devices"] == "battery at 0x33"
 
 
 async def test_cold_start_saves_capabilities_on_first_successful_refresh(


### PR DESCRIPTION
## What

When `detect(prior=…)` finds a previously-known device missing, the coordinator no longer silently bakes in the reduced topology. It now:

- **Classifies** the mismatch — a *device loss* (a known battery/meter/HV stack absent, `device_type` unchanged) versus a routine add / `device_type` change.
- **Retries** a loss a couple of times (5s apart) before believing it — a slow BMS often answers on the next sweep.
- On a **persistent loss**, serves the reduced topology for that poll only but keeps the full prior cached (no persist, no reload), so the next reconnect re-probes the full set and self-heals. The missing device's entities read unavailable rather than vanishing.
- Raises a **loud, fixable ERROR repair** naming the missing device(s). It clears automatically once the device returns, or you click Fix to clear the cache and re-detect (committing a genuine removal).

Adds and `device_type` changes keep the existing persist-and-reload path unchanged.

## Why

This came out of a real incident: a restart triggered a detect that transiently missed a battery (its BMS was slow to answer one probe window). The integration dropped the pack, its entities went unavailable, and nothing was recorded for it until I spotted it on a dashboard — `redetect_plant` recovered it, since the pack had been responding the whole time. The worst case is a restart where none of a known device's data is recorded until a human notices.

## Scope

This is the hass-side resilience change. The dashboard Redetect button and serial-targeted services already shipped. A follow-up modbus change (a placeholder so a device missed at cold setup stays present-but-unavailable within the same session, rather than absent until the next restart) isn't needed for this to be safe — today a missing device just reads unavailable, never crashes — so I've deferred it to a separate handoff.

## Testing

`uv run pytest` (266 pass, 9 new), ruff and mypy clean. New tests cover the classifier, retry-then-heal, persistent loss (callback fires, prior kept, nothing persisted/reloaded), adds and `device_type` changes (unchanged path), a retry that surfaces an add, the ERROR repair creation, live self-heal, and the fix flow. I haven't validated against the real hardware yet — I'll do that via the HA MCP once merged (reproduce a transient miss; confirm the ERROR repair appears and clears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for missing GivEnergy devices with user-friendly repair guidance to clear cached layout and rerun device discovery.
  * Integration now creates fixable repair issues when expected devices stop responding.
  * Automatically clears repair issues when device connectivity is restored.

* **Bug Fixes**
  * Improved distinction between temporary and persistent device loss to prevent unnecessary configuration reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->