### PR TITLE
fix(sensor): use TOTAL state class for computed e_consumption_today

### DIFF
--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -504,11 +504,16 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         # register; givenergy-modbus computes it (PV gen + grid-in - grid-out -
         # AC-charge). Three-phase has no such field, so skip_if_none drops it
         # there (and the value_fn getattr keeps it None-safe).
+        # TOTAL (not TOTAL_INCREASING) because the value is computed from several
+        # registers polled at slightly different times; a reading can transiently
+        # dip by a few Wh when one component updates before the others, which
+        # triggers HA's strictly-increasing guard. Direct hardware counters (PV,
+        # grid, battery) stay TOTAL_INCREASING since they never decrease.
         key="e_consumption_today",
         name="House Consumption Today",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.TOTAL,
         value_fn=lambda inv: getattr(inv, "e_consumption_today", None),
         skip_if_none=True,
     ),


### PR DESCRIPTION
## What

Changes `e_consumption_today` from `SensorStateClass.TOTAL_INCREASING` to `SensorStateClass.TOTAL`.

## Why

`e_consumption_today` is a computed field — givenergy-modbus derives it as `PV gen + grid-in - grid-out - AC-charge` from several registers polled at slightly different times. When one component updates before the others, the result can transiently dip by a few Wh, triggering HA's strictly-increasing guard and logging the warning reported in #142.

The other daily energy sensors (`e_pv_day`, `e_grid_in_day`, `e_grid_out_day`, the battery day totals) are direct hardware counters that only increment, so they correctly stay `TOTAL_INCREASING`. Only the computed sensor needs the relaxed class.

Both `TOTAL` and `TOTAL_INCREASING` produce sum-type long-term statistics in HA's recorder, so existing history is unaffected.

Fixes #142