### PR TITLE
feat(sensor): expose per-module AIO battery devices (#192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Uses [`givenergy-modbus`](https://github.com/dewet22/givenergy-modbus) for all i
 
 ## Supported inverters
 
-The integration uses [`givenergy-modbus`](https://github.com/dewet22/givenergy-modbus) v2.1, which models the following device families: single-phase hybrid, three-phase hybrid, AC-coupled, EMS, Gateway, and All-in-One. Register maps for all of these shipped in v2.0, but empirical verification is still in progress for most — the mappings were brought in from the GivTCP fork, which ran across a wide range of hardware, so the coverage is broad but not all of it has been confirmed against wire data.
+The integration uses [`givenergy-modbus`](https://github.com/dewet22/givenergy-modbus) v2.2, which models the following device families: single-phase hybrid, three-phase hybrid, AC-coupled, EMS, Gateway, and All-in-One. Register maps for all of these shipped in v2.0, but empirical verification is still in progress for most — the mappings were brought in from the GivTCP fork, which ran across a wide range of hardware, so the coverage is broad but not all of it has been confirmed against wire data.
 
 Confirmed working:
 
@@ -187,7 +187,7 @@ When enabled, the integration connects to the inverter but sends no Modbus read 
 
 ### Battery device(s)
 
-Each connected battery pack appears as a separate device linked to the inverter. On All-in-One (AIO) hardware, devices are surfaced at pack level only — the individual module sub-devices that some other tools expose are not yet represented ([#95](https://github.com/dewet22/givenergy-hass/issues/95)).
+Each connected battery pack appears as a separate device linked to the inverter. On All-in-One (AIO) hardware, each removable battery module is also surfaced as its own device (linked to the AIO inverter), exposing its `HX…` serial and per-cell voltages and temperatures — see [AIO battery modules](#aio-battery-modules) below ([#192](https://github.com/dewet22/givenergy-hass/issues/192)).
 
 | Entity | Unit | Notes |
 |---|---|---|
@@ -204,6 +204,10 @@ Each connected battery pack appears as a separate device linked to the inverter.
 | Cells 1-4 / 5-8 / 9-12 / 13-16 Temperature | °C | Diagnostic; the BMS samples one thermistor per 4-cell group |
 
 Cell-level entities are tagged as diagnostic, so they're hidden from the default device view but available for dashboards and pack-health monitoring (cell voltage spread, temperature deltas, etc.).
+
+#### AIO battery modules
+
+All-in-One systems expose each removable battery module separately, so on AIO hardware you'll see one extra device per module (parented to the AIO inverter) alongside the pack-level battery device. Each module device carries its `HX…` serial plus 24 per-cell voltages and 12 per-cell temperatures, all diagnostic. These mirror the LV per-cell entities, so the cell-heatmap card and the same pack-health views work at module granularity. Module data needs `givenergy-modbus` 2.2 or newer.
 
 ### Services
 

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.1.6,<3.0.0"
+    "givenergy-modbus>=2.2.0rc3,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import date
 from typing import Any
 
+from givenergy_modbus.model.aio_battery import AioBatteryModule
 from givenergy_modbus.model.battery import Battery, BatteryMaintenance
 from givenergy_modbus.model.inverter import (
     BatteryCalibrationStage,
@@ -74,6 +75,20 @@ def _battery_attr(name: str) -> Callable[[Battery], Any]:
     of the resulting Callable).
     """
     return lambda bat: getattr(bat, name)
+
+
+@dataclass(frozen=True, kw_only=True)
+class GivEnergyAioModuleSensorDescription(SensorEntityDescription):
+    value_fn: Callable[[AioBatteryModule], Any] = field(default=lambda _: None)
+
+
+def _module_attr(name: str) -> Callable[[AioBatteryModule], Any]:
+    """Return a value_fn that reads `name` off an AIO battery module.
+
+    Per-module counterpart of `_battery_attr`; each closure captures its own
+    attribute name so the bulk-defined per-cell entities don't share one.
+    """
+    return lambda module: getattr(module, name)
 
 
 def _battery_hex(name: str, width: int) -> Callable[[Battery], Any]:
@@ -947,6 +962,40 @@ BATTERY_SENSORS: tuple[GivEnergyBatterySensorDescription, ...] = (
 )
 
 
+# All-in-One per-module battery sensors (#192). Each removable module reports
+# its own 24 cell voltages and per-cell temperatures. Mirrors the LV per-cell
+# entities above: DIAGNOSTIC, enabled by default. Cell temps 13-24 read zero on
+# known AIO hardware, so only 01-12 are exposed (matching what the module BMS
+# actually populates); voltages cover all 24 cells.
+AIO_MODULE_SENSORS: tuple[GivEnergyAioModuleSensorDescription, ...] = (
+    *(
+        GivEnergyAioModuleSensorDescription(
+            key=f"v_cell_{i:02d}",
+            name=f"Cell {i} Voltage",
+            native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+            device_class=SensorDeviceClass.VOLTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
+            suggested_display_precision=3,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            value_fn=_module_attr(f"v_cell_{i:02d}"),
+        )
+        for i in range(1, 25)
+    ),
+    *(
+        GivEnergyAioModuleSensorDescription(
+            key=f"t_cell_{i:02d}",
+            name=f"Cell {i} Temperature",
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            value_fn=_module_attr(f"t_cell_{i:02d}"),
+        )
+        for i in range(1, 13)
+    ),
+)
+
+
 def _partial_failure_attributes(
     coordinator: GivEnergyUpdateCoordinator,
 ) -> dict[str, Any] | None:
@@ -1063,6 +1112,17 @@ async def async_setup_entry(
         entities.extend(
             GivEnergyBatterySensor(coordinator, description, battery_index)
             for description in BATTERY_SENSORS
+        )
+
+    # AIO per-module battery devices (#192) — empty on non-AIO plants. A module
+    # with a blank/invalid serial can't anchor a device, so skip it; the index
+    # still aligns with `aio_battery_modules` for the entities we do create.
+    for module_index, module in enumerate(coordinator.data.aio_battery_modules):
+        if not module.is_valid():
+            continue
+        entities.extend(
+            GivEnergyAioModuleSensor(coordinator, description, module_index)
+            for description in AIO_MODULE_SENSORS
         )
 
     entities.extend(
@@ -1239,6 +1299,45 @@ class GivEnergyBatterySensor(CoordinatorEntity[GivEnergyUpdateCoordinator], Sens
         if self._battery_index >= len(batteries):
             return None
         return self.entity_description.value_fn(batteries[self._battery_index])
+
+
+class GivEnergyAioModuleSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity):
+    """Per-cell sensor for one All-in-One removable battery module (#192).
+
+    Each module is its own HA device, linked to the AIO inverter as parent via
+    `via_device`, identified by the module's `HX…` serial.
+    """
+
+    _attr_has_entity_name = True
+    entity_description: GivEnergyAioModuleSensorDescription
+
+    def __init__(
+        self,
+        coordinator: GivEnergyUpdateCoordinator,
+        description: GivEnergyAioModuleSensorDescription,
+        module_index: int,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._module_index = module_index
+        module = coordinator.data.aio_battery_modules[module_index]
+        serial = module.serial_number
+        self._attr_unique_id = f"{serial}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy Battery Module {serial}",
+            manufacturer="GivEnergy",
+            model="AIO Battery Module",
+            serial_number=serial,
+            via_device=(DOMAIN, coordinator.data.inverter_serial_number),
+        )
+
+    @property
+    def native_value(self) -> Any:
+        modules = self.coordinator.data.aio_battery_modules
+        if self._module_index >= len(modules):
+            return None
+        return self.entity_description.value_fn(modules[self._module_index])
 
 
 class GivEnergyCoordinatorSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity):

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1319,9 +1319,12 @@ class GivEnergyAioModuleSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], Se
     ) -> None:
         super().__init__(coordinator)
         self.entity_description = description
-        self._module_index = module_index
-        module = coordinator.data.aio_battery_modules[module_index]
-        serial = module.serial_number
+        # Bind to the module's serial, not its list position. aio_battery_modules
+        # is rebuilt every refresh from whichever module caches decoded, so indices
+        # shift when a module drops out — resolving by serial keeps each entity tied
+        # to its own module instead of cross-wiring to a neighbour's cell data.
+        serial = coordinator.data.aio_battery_modules[module_index].serial_number
+        self._module_serial = serial
         self._attr_unique_id = f"{serial}_{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
@@ -1332,12 +1335,27 @@ class GivEnergyAioModuleSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], Se
             via_device=(DOMAIN, coordinator.data.inverter_serial_number),
         )
 
+    def _module(self) -> AioBatteryModule | None:
+        """Resolve this entity's module by serial in the latest coordinator data."""
+        data = self.coordinator.data
+        if data is None:
+            return None
+        return next(
+            (m for m in data.aio_battery_modules if m.serial_number == self._module_serial),
+            None,
+        )
+
+    @property
+    def available(self) -> bool:
+        # Unavailable (not cross-wired) when this module is absent from the poll.
+        return super().available and self._module() is not None
+
     @property
     def native_value(self) -> Any:
-        modules = self.coordinator.data.aio_battery_modules
-        if self._module_index >= len(modules):
+        module = self._module()
+        if module is None:
             return None
-        return self.entity_description.value_fn(modules[self._module_index])
+        return self.entity_description.value_fn(module)
 
 
 class GivEnergyCoordinatorSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity):

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1117,6 +1117,9 @@ async def async_setup_entry(
     # AIO per-module battery devices (#192) — empty on non-AIO plants. A module
     # with a blank/invalid serial can't anchor a device, so skip it; the index
     # still aligns with `aio_battery_modules` for the entities we do create.
+    # Like the battery entities, this set is fixed at setup: a module absent
+    # during the initial probe gets no entities until a reload (tracked in #148,
+    # to be fixed uniformly for all device types).
     for module_index, module in enumerate(coordinator.data.aio_battery_modules):
         if not module.is_valid():
             continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.1.6,<3.0.0",
+    "givenergy-modbus>=2.2.0rc3,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,6 +172,8 @@ def mock_plant(mock_inverter, mock_battery) -> MagicMock:
     plant.inverter = mock_inverter
     plant.batteries = [mock_battery]
     plant.number_batteries = 1
+    # Non-AIO by default — AIO per-module tests override this with mock modules.
+    plant.aio_battery_modules = []
     # No EMS by default; the EMS-specific tests override this with a mock Ems so
     # the EMS scheduling entities are only created for EMS plants.
     plant.ems = None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,10 +2,13 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.givenergy_local.const import DOMAIN
 from custom_components.givenergy_local.sensor import (
+    AIO_MODULE_SENSORS,
     BATTERY_SENSORS,
     COORDINATOR_SENSORS,
     INVERTER_SENSORS,
@@ -205,7 +208,6 @@ async def test_inverter_device_info(hass, setup_integration):
     registry = er.async_get(hass)
     entry = registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_p_pv")
     entity_entry = registry.async_get(entry)
-    from homeassistant.helpers import device_registry as dr
 
     dev_registry = dr.async_get(hass)
     device = dev_registry.async_get(entity_entry.device_id)
@@ -224,7 +226,6 @@ async def test_battery_device_linked_to_inverter(hass, setup_integration):
     registry = er.async_get(hass)
     entry = registry.async_get_entity_id("sensor", DOMAIN, "BT1234A001_soc")
     entity_entry = registry.async_get(entry)
-    from homeassistant.helpers import device_registry as dr
 
     dev_registry = dr.async_get(hass)
     battery_device = dev_registry.async_get(entity_entry.device_id)
@@ -301,7 +302,6 @@ async def test_bms_status_warning_rendered_as_hex(hass, setup_integration):
 
 async def test_cell_voltages_attached_to_battery_device(hass, setup_integration):
     """Per-cell sensors live on the battery device, not the inverter device."""
-    from homeassistant.helpers import device_registry as dr
 
     registry = er.async_get(hass)
     dev_registry = dr.async_get(hass)
@@ -616,3 +616,131 @@ async def test_entity_id_rename_fires_when_unique_id_already_migrated(
     migrated = registry.async_get(new_entity_id)
     assert migrated is not None, f"entity_id {new_entity_id!r} not found after migration"
     assert migrated.unique_id == "SA1234G123_grid_power"
+
+
+# ---------------------------------------------------------------------------
+# All-in-One per-module battery devices (#192)
+# ---------------------------------------------------------------------------
+
+
+def _mock_aio_module(serial: str, address: int, *, valid: bool = True) -> MagicMock:
+    """A stand-in AioBatteryModule: 24 cell voltages, 12 populated temps."""
+    module = MagicMock()
+    module.serial_number = serial
+    module.module_address = address
+    module.is_valid.return_value = valid
+    for i in range(1, 25):
+        setattr(module, f"v_cell_{i:02d}", 3.30 + i * 0.001)
+    for i in range(1, 13):
+        setattr(module, f"t_cell_{i:02d}", 20.0 + i * 0.1)
+    for i in range(13, 25):
+        setattr(module, f"t_cell_{i:02d}", 0.0)  # unpopulated on real hardware
+    return module
+
+
+def _setup_aio_plant(mock_client, modules: list[MagicMock]) -> None:
+    """Reshape the mock plant into an All-in-One exposing `modules`."""
+    from givenergy_modbus.model.inverter import Model
+    from givenergy_modbus.model.plant import PlantCapabilities
+
+    addresses = [m.module_address for m in modules]
+    mock_client.plant.aio_battery_modules = modules
+    mock_client.plant.capabilities = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x31,
+        meter_addresses=[],
+        lv_battery_addresses=[],
+        bcu_stacks=[],
+        aio_battery_module_addresses=addresses,
+    )
+
+
+@pytest.fixture
+async def aio_setup(hass, mock_client, mock_config_entry):
+    """Set up the integration as an All-in-One with two valid battery modules."""
+    _setup_aio_plant(
+        mock_client,
+        [_mock_aio_module("HX2414G831", 0x50), _mock_aio_module("HX2414G832", 0x51)],
+    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
+
+
+async def test_aio_modules_create_one_device_each(hass, aio_setup):
+    """Each module is its own device, keyed by serial and linked to the inverter."""
+    registry = er.async_get(hass)
+    dev_registry = dr.async_get(hass)
+    for serial in ("HX2414G831", "HX2414G832"):
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_v_cell_01")
+        assert entity_id is not None, f"module {serial} has no cell sensor"
+        device = dev_registry.async_get(registry.async_get(entity_id).device_id)
+        assert device is not None
+        assert (DOMAIN, serial) in device.identifiers
+        assert device.serial_number == serial
+        assert device.model == "AIO Battery Module"
+        assert device.via_device_id is not None  # parented to the AIO inverter
+
+
+async def test_aio_module_all_24_voltage_cells(hass, aio_setup):
+    registry = er.async_get(hass)
+    for i in range(1, 25):
+        assert (
+            registry.async_get_entity_id("sensor", DOMAIN, f"HX2414G831_v_cell_{i:02d}") is not None
+        ), f"v_cell_{i:02d} missing"
+    state = hass.states.get(_entity_id(hass, "sensor", "HX2414G831_v_cell_01"))
+    assert float(state.state) == 3.301  # 3.30 + 1*0.001
+    assert state.attributes["unit_of_measurement"] == "V"
+
+
+async def test_aio_module_exposes_only_first_twelve_temps(hass, aio_setup):
+    """Cells 1-12 get temperature sensors; 13-24 (zero on hardware) are omitted."""
+    registry = er.async_get(hass)
+    for i in range(1, 13):
+        assert (
+            registry.async_get_entity_id("sensor", DOMAIN, f"HX2414G831_t_cell_{i:02d}") is not None
+        ), f"t_cell_{i:02d} should exist"
+    for i in range(13, 25):
+        assert (
+            registry.async_get_entity_id("sensor", DOMAIN, f"HX2414G831_t_cell_{i:02d}") is None
+        ), f"t_cell_{i:02d} should not be exposed"
+
+
+async def test_aio_module_with_invalid_serial_is_skipped(hass, mock_client, mock_config_entry):
+    """A module with a blank/invalid serial can't anchor a device, so it's skipped."""
+    _setup_aio_plant(
+        mock_client,
+        [_mock_aio_module("HX2414G831", 0x50), _mock_aio_module("", 0x51, valid=False)],
+    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    dev_registry = dr.async_get(hass)
+    modules = [
+        d
+        for d in dr.async_entries_for_config_entry(dev_registry, mock_config_entry.entry_id)
+        if d.model == "AIO Battery Module"
+    ]
+    assert len(modules) == 1
+    assert modules[0].serial_number == "HX2414G831"
+
+
+async def test_non_aio_plant_creates_no_module_entities(hass, setup_integration):
+    """The default (non-AIO) fixture must not create any per-module entities."""
+    dev_registry = dr.async_get(hass)
+    modules = [
+        d
+        for d in dr.async_entries_for_config_entry(dev_registry, setup_integration.entry_id)
+        if d.model == "AIO Battery Module"
+    ]
+    assert modules == []
+
+
+def test_aio_module_sensor_descriptions_cover_expected_cells():
+    """24 voltage + 12 temperature descriptions, no duplicate keys."""
+    keys = [d.key for d in AIO_MODULE_SENSORS]
+    assert len([k for k in keys if k.startswith("v_cell_")]) == 24
+    assert len([k for k in keys if k.startswith("t_cell_")]) == 12
+    assert len(keys) == len(set(keys))

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -694,6 +694,28 @@ async def test_aio_module_all_24_voltage_cells(hass, aio_setup):
     assert state.attributes["unit_of_measurement"] == "V"
 
 
+async def test_aio_module_entity_tracks_serial_not_list_index(hass, aio_setup):
+    """If a module drops out and the list reindexes, each entity must keep
+    reporting its own module — never cross-wire to a neighbour, and go
+    unavailable when its module is absent (#192 review)."""
+    coordinator = hass.data[DOMAIN][aio_setup.entry_id]
+    # The first module (HX2414G831) drops out of the poll; only the second
+    # (HX2414G832) remains, now at list index 0 with a distinctive cell value.
+    surviving = _mock_aio_module("HX2414G832", 0x51)
+    surviving.v_cell_01 = 3.500
+    coordinator.data.aio_battery_modules = [surviving]
+    coordinator.async_set_updated_data(coordinator.data)
+    await hass.async_block_till_done()
+
+    # The survivor reports its own value under its own serial — not the dropped
+    # module's (which would be the bug if entities indexed by position).
+    survivor_state = hass.states.get(_entity_id(hass, "sensor", "HX2414G832_v_cell_01"))
+    assert float(survivor_state.state) == 3.500
+    # The dropped module's entity goes unavailable rather than borrowing index 0.
+    dropped_state = hass.states.get(_entity_id(hass, "sensor", "HX2414G831_v_cell_01"))
+    assert dropped_state.state == "unavailable"
+
+
 async def test_aio_module_exposes_only_first_twelve_temps(hass, aio_setup):
     """Cells 1-12 get temperature sensors; 13-24 (zero on hardware) are omitted."""
     registry = er.async_get(hass)

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.1.6,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.2.0rc3,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -960,16 +960,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.1.6"
+version = "2.2.0rc3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/80/452c7ed2ae2450d230fef62c4dd3ca5c481440edf2bf2c7b2295b8689710/givenergy_modbus-2.1.6.tar.gz", hash = "sha256:f3520af0ea1b788f7e43e20bf615771f41332df029f6edbc00b940b088f515c6", size = 339845, upload-time = "2026-06-09T18:38:40.655Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/a3/fb76da826248fcd37872a019836583f47a3023a884afb688841e5d62cb0e/givenergy_modbus-2.2.0rc3.tar.gz", hash = "sha256:cefff8768ee795bc1b1b06198cbb63effa830fa9ce08994292f0a1762acbb71b", size = 357991, upload-time = "2026-06-09T21:00:19.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/c9/2523f2c225694692031580895f33d31aec84de3839d87cf34544c06730db/givenergy_modbus-2.1.6-py3-none-any.whl", hash = "sha256:19058a86b36b3877c00678cc9d2142b7c5c2e5cfaabdc92cde30c739016da8b5", size = 128266, upload-time = "2026-06-09T18:38:39.111Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/b80b282ce1b230f5609c5b84b6b075c3f430bb58e5afd63d3af0dec81a73/givenergy_modbus-2.2.0rc3-py3-none-any.whl", hash = "sha256:f1c037de06e4981855dc6eb01cc405858bba960d81b9a34ad3fbdbf884973752", size = 136184, upload-time = "2026-06-09T21:00:17.921Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does

Surfaces each removable **All-in-One battery module** as its own Home Assistant device — closing the gap where AIO data was only available at pack level (the original ask in #95, now tracked as #192).

On AIO hardware, each module (device addresses `0x50–0x53`) becomes a device parented to the AIO inverter, keyed by its `HX…` serial, exposing:

- **24 per-cell voltages** (`v_cell_01…24`)
- **12 per-cell temperatures** (`t_cell_01…12` — cells 13–24 read zero on known hardware, so they're omitted)

These mirror the existing LV per-cell entities exactly: `DIAGNOSTIC`, enabled by default, so the cell-heatmap card and the same pack-health views work at module granularity.

## How it's gated

- Driven off `PlantCapabilities.aio_battery_module_addresses` via `Plant.aio_battery_modules`, so **non-AIO plants create nothing**.
- A module with a blank/invalid serial can't anchor a device, so it's skipped (the index still aligns for the modules we do create).

## Dependency

Requires the per-module API from **givenergy-modbus 2.2** (`AioBatteryModule`, `Plant.aio_battery_modules`, `DeviceType.BATTERY_MODULE`). The floor is pinned to `>=2.2.0rc3` across manifest, pyproject, and the lockfile — only givenergy-modbus resolves to a pre-release. This is intended for a **feature RC** to validate against real AIO hardware (AberDino's 4-module unit, #95) before 2.2 final.

## Testing

- 6 new tests: per-module devices created and parented to the inverter, all 24 voltage + 12 temp sensors present, temps 13–24 absent, invalid-serial module skipped, non-AIO plants create no module entities, description coverage.
- Full suite: 242 passing against 2.2.0rc3. ruff/format/mypy clean.

Not yet validated on real AIO hardware — that's the point of the RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for monitoring individual battery modules in All-in-One systems with per-cell voltage and temperature diagnostics.

* **Documentation**
  * Updated to reflect v2.2 compatibility and clarified battery module representation on All-in-One hardware.

* **Dependencies**
  * Updated minimum required version to givenergy-modbus v2.2.0rc3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->