### PR TITLE
feat(sensor): split grid power into import/export for the Energy Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ When enabled, the integration connects to the inverter but sends no Modbus read 
 | Battery Charge Today | kWh | |
 | Battery Discharge Today | kWh | |
 | Battery Throughput Total | kWh | |
-| Grid Power | W | Positive = exporting, negative = importing |
+| Grid Power | W | Signed net flow: positive = exporting, negative = importing. Hidden by default (feeds the bundled flow card); for the Energy Dashboard use the split sensors below |
+| Grid Power Import / Export | W | Always-positive single-direction power, for the Energy Dashboard's "Two sensors" grid option — no sign inversion, so long-term statistics aren't lost |
 | Grid Export / Import Today | kWh | |
 | Grid Export / Import Total | kWh | |
 | AC Voltage / Frequency | V / Hz | |

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -127,6 +127,21 @@ class GivEnergyCoordinatorSensorDescription(SensorEntityDescription):
     attributes_fn: Callable[[GivEnergyUpdateCoordinator], dict[str, Any] | None] | None = None
 
 
+# `grid_power` (p_grid_out) is a single signed value, positive = export. HA's
+# Energy Dashboard wants two always-positive power sensors (its "Two sensors"
+# grid option), so split the direction out — mirroring how grid energy is
+# already exposed as separate import/export totals. None passes through so the
+# sensors read `unknown` rather than 0 before the first poll.
+def _grid_export_power(inv: InverterModel) -> float | None:
+    p = inv.p_grid_out
+    return max(p, 0) if p is not None else None
+
+
+def _grid_import_power(inv: InverterModel) -> float | None:
+    p = inv.p_grid_out
+    return max(-p, 0) if p is not None else None
+
+
 INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
     # --- Status ---
     GivEnergyInverterSensorDescription(
@@ -397,6 +412,35 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda inv: inv.p_grid_out,
+        # Signed, positive = export — the right shape for the bundled flow card
+        # (which keys off it), but the opposite of HA's Energy-Dashboard sign and
+        # awkward to read standalone. Hidden by default in favour of the split
+        # import/export power sensors below; still recorded, so the flow card and
+        # any existing user references keep working.
+        entity_registry_visible_default=False,
+    ),
+    # Split, always-positive direction sensors for HA's Energy Dashboard "Two
+    # sensors" grid-power option — no inversion helper (which would start its
+    # long-term statistics from scratch). Named "Grid Power Import/Export" rather
+    # than "Grid Import/Export Power" deliberately: the latter's `grid_export_power`
+    # slug is the legacy entity_id of today's `grid_power` and is actively reclaimed
+    # by the unique_id migration (see _RENAMED_UNIQUE_ID_SUFFIXES), so reusing it
+    # would collide.
+    GivEnergyInverterSensorDescription(
+        key="grid_power_import",
+        name="Grid Power Import",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_grid_import_power,
+    ),
+    GivEnergyInverterSensorDescription(
+        key="grid_power_export",
+        name="Grid Power Export",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_grid_export_power,
     ),
     GivEnergyInverterSensorDescription(
         key="e_grid_out_day",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -766,3 +766,43 @@ def test_aio_module_sensor_descriptions_cover_expected_cells():
     assert len([k for k in keys if k.startswith("v_cell_")]) == 24
     assert len([k for k in keys if k.startswith("t_cell_")]) == 12
     assert len(keys) == len(set(keys))
+
+
+# ---------------------------------------------------------------------------
+# Split grid import/export power sensors (Energy Dashboard "Two sensors")
+# ---------------------------------------------------------------------------
+
+
+def test_grid_split_power_helpers_resolve_both_directions():
+    """Each helper is the always-positive magnitude of its own direction, 0 in
+    the other, and None before the first poll."""
+    from custom_components.givenergy_local.sensor import _grid_export_power, _grid_import_power
+
+    exporting = MagicMock(p_grid_out=1500)
+    importing = MagicMock(p_grid_out=-800)
+    unpolled = MagicMock(p_grid_out=None)
+
+    assert _grid_export_power(exporting) == 1500
+    assert _grid_import_power(exporting) == 0
+    assert _grid_import_power(importing) == 800
+    assert _grid_export_power(importing) == 0
+    assert _grid_export_power(unpolled) is None
+    assert _grid_import_power(unpolled) is None
+
+
+async def test_grid_split_power_sensors_created(hass, setup_integration):
+    """Both split power sensors are created; mock p_grid_out=-800 (importing)."""
+    imp = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_grid_power_import"))
+    exp = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_grid_power_export"))
+    assert float(imp.state) == 800
+    assert float(exp.state) == 0
+    assert imp.attributes["unit_of_measurement"] == "W"
+    assert imp.attributes["device_class"] == "power"
+
+
+async def test_grid_power_hidden_by_default(hass, setup_integration):
+    """The signed bidirectional grid_power stays recorded (the bundled flow card
+    keys off it) but is hidden by default in favour of the split sensors."""
+    registry = er.async_get(hass)
+    entry = registry.async_get(_entity_id(hass, "sensor", "SA1234G123_grid_power"))
+    assert entry.hidden_by is not None


### PR DESCRIPTION
## What this does

Makes the inverter's grid power usable in HA's Energy Dashboard without the sign-inversion that loses long-term statistics.

### The problem

Our `Grid Power` sensor is `p_grid_out` — a single signed value, **positive = export**. HA's Energy Dashboard real-time grid power expects the opposite sign, so users pick its **"Inverted"** option, which spins up a derived helper entity that only accrues statistics from creation — the existing history doesn't carry over.

### The fix

Add two always-positive, single-direction power sensors — **Grid Power Import** and **Grid Power Export** — so the Dashboard's **"Two sensors"** grid option works directly: no inversion helper, no lost history. This mirrors how grid *energy* is already split into separate import/export totals.

The bidirectional `Grid Power` keeps its signed shape (the bundled flow card keys off it) but is now **hidden by default** in favour of the split sensors. Existing installs are unaffected — `entity_registry_visible_default` only applies at first registration, so anyone who already has it keeps it visible with full history.

### Naming note

They're "Grid Power Import/Export", not the more natural "Grid Import/Export Power", on purpose: `grid_export_power` is the *legacy* entity_id slug of today's `grid_power` and is actively reclaimed by the unique_id migration ([`_RENAMED_UNIQUE_ID_SUFFIXES`](custom_components/givenergy_local/__init__.py)). Reusing it would collide and silently swap semantics for a version-skipping user — there's an existing migration test guarding that slug.

## Testing

- Helper unit test covering both directions + the pre-poll None case.
- Integration test: both split sensors created with correct values (mock is importing 800 W → import 800, export 0).
- `grid_power` asserted hidden-by-default; the existing migration test still passes (no slug collision).
- Full suite: 253 passing; ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
