### PR TITLE
chore(claude): add coordination-inbox Stop hook (#224 H3)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_CONFIG_DIR/scripts/check-inbox.sh",
+            "statusMessage": "Checking coordination inbox..."
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash $CLAUDE_CONFIG_DIR/scripts/check-inbox.sh",
+            "command": "bash \"$CLAUDE_CONFIG_DIR/scripts/check-inbox.sh\"",
             "statusMessage": "Checking coordination inbox..."
           }
         ]


### PR DESCRIPTION
Part of the givenergy-modbus security audit (#224, H3). Brings this repo into the same cross-agent coordination convention as the modbus/cli sister repos: it adds the shared `check-inbox.sh` Stop hook so the agent reads the ephemeral coordination inbox.

The inbox has been relocated off the world-writable `/tmp` path into the maintainer's user-owned (`0700`) config dir and hardened (treat-as-untrusted content + UID-scoped scan) as part of the audit. Durable cross-repo API contracts still go via GitHub issues per the existing **Repo boundaries** section.

Config-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)