### PR TITLE
feat(sensor): three-phase House Consumption via native e_load_today/e_load_total

### DIFF
--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -45,6 +45,7 @@ EXPOSE_RECOMMENDED_ENTITY_KEYS = (
     # Load / Consumption
     "p_load_demand",
     "e_consumption_today",
+    "e_load_total",  # three-phase only — silently skipped elsewhere
     # PV generation total (was e_inverter_out_total / "Inverter Output Total")
     "e_pv_generation_total",
     # Health — entity description's `key` is "status"; `inverter_status` is

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -565,22 +565,40 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         value_fn=lambda inv: inv.p_load_demand,
     ),
     GivEnergyInverterSensorDescription(
-        # Derived house consumption (single-phase only) — matches the GE app's
-        # "Consumption today". Single-phase inverters expose no consumption
-        # register; givenergy-modbus computes it (PV gen + grid-in - grid-out -
-        # AC-charge). Three-phase has no such field, so skip_if_none drops it
-        # there (and the value_fn getattr keeps it None-safe).
-        # monotonic=True because the value is computed from several registers
-        # polled at slightly different times; a reading can transiently dip by
-        # a few Wh when one component updates before the others, tripping
-        # TOTAL_INCREASING's strictly-increasing guard (#142).
+        # House consumption, sourced per model (#154). Single-phase inverters
+        # expose no consumption register; givenergy-modbus derives it (PV gen +
+        # grid-in - grid-out - AC-charge) to match the GE app's "Consumption
+        # today". Three-phase units meter it natively instead (e_load_today,
+        # IR 1396-1397 — modelled in givenergy-modbus 2.2 but not yet validated
+        # on real 3-phase hardware), so the value_fn falls back to that there.
+        # Same key on both topologies keeps the dashboard strategy and
+        # recommended-entity list working unchanged.
+        # monotonic=True because the derived value is computed from several
+        # registers polled at slightly different times; a reading can
+        # transiently dip by a few Wh when one component updates before the
+        # others, tripping TOTAL_INCREASING's strictly-increasing guard (#142).
         key="e_consumption_today",
         name="House Consumption Today",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         monotonic=True,
-        value_fn=lambda inv: getattr(inv, "e_consumption_today", None),
+        value_fn=lambda inv: getattr(
+            inv, "e_consumption_today", getattr(inv, "e_load_today", None)
+        ),
+        skip_if_none=True,
+    ),
+    GivEnergyInverterSensorDescription(
+        # Native lifetime consumption counter (IR 1398-1399) — three-phase
+        # only; single-phase models lack the field, so skip_if_none drops it
+        # there. No monotonic clamp: this is a single metered register, not a
+        # multi-register derivation.
+        key="e_load_total",
+        name="House Consumption Total",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda inv: getattr(inv, "e_load_total", None),
         skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,12 @@ def mock_inverter() -> MagicMock:
     # are PV generation. Consumption is derived. All entity keys renamed in 2.1.1/2.
     inv.e_ac_charge_today = 3.8
     inv.e_consumption_today = 21.4
+    # Native load registers (IR 1396-1399) exist only on three-phase models —
+    # mirror the real model so the mock can't fabricate fields the sensors
+    # then break on. Three-phase tests set these (and delete the derived
+    # e_consumption_today) explicitly.
+    del inv.e_load_today
+    del inv.e_load_total
     inv.e_pv_generation_today = 11.2
     inv.e_pv_generation_total = 5100.2
     inv.t_inverter_heatsink = 45.3

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -145,8 +145,9 @@ async def test_expected_sensor_count(hass, setup_integration):
     registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(registry, setup_integration.entry_id)
     sensors = [e for e in entries if e.domain == "sensor"]
-    # 1 battery → inverter sensors + battery sensors + coordinator diagnostics
-    expected = len(INVERTER_SENSORS) + len(BATTERY_SENSORS) + len(COORDINATOR_SENSORS)
+    # 1 battery → inverter sensors + battery sensors + coordinator diagnostics,
+    # minus e_load_total which only exists on three-phase models (#154).
+    expected = len(INVERTER_SENSORS) + len(BATTERY_SENSORS) + len(COORDINATOR_SENSORS) - 1
     assert len(sensors) == expected
 
 
@@ -459,6 +460,45 @@ async def test_house_consumption_today_sensor(hass, setup_integration):
     """The new derived consumption sensor (the dashboard's real 'Consumed')."""
     state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_e_consumption_today"))
     assert state.state == "21.4"
+
+
+async def test_house_consumption_today_uses_native_register_on_three_phase(
+    hass, mock_client, mock_config_entry
+):
+    """Three-phase inverters meter consumption directly (e_load_today, IR 1396-1397),
+    so the same entity key reads the native register there instead of the derived
+    single-phase field — dashboards keyed on e_consumption_today keep working (#154).
+    The native lifetime counter surfaces alongside it as e_load_total."""
+    from givenergy_modbus.model.inverter import Model
+    from givenergy_modbus.model.plant import PlantCapabilities
+
+    inv = mock_client.plant.inverter
+    del inv.e_consumption_today  # derived field exists only on single-phase models
+    inv.e_load_today = 6.2
+    inv.e_load_total = 1234.5
+    mock_client.plant.capabilities = PlantCapabilities(
+        device_type=Model.HYBRID_3PH,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_e_consumption_today"))
+    assert state.state == "6.2"
+    total = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_e_load_total"))
+    assert total.state == "1234.5"
+
+
+async def test_house_consumption_total_absent_on_single_phase(hass, setup_integration):
+    """Single-phase units expose no native lifetime consumption register, so the
+    e_load_total sensor must not be created there."""
+    registry = er.async_get(hass)
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_e_load_total") is None
 
 
 async def test_ac_charge_today_sensor_replaces_load_energy(hass, setup_integration):


### PR DESCRIPTION
Closes #154.

On single-phase inverters, **House Consumption Today** is the library-derived `e_consumption_today` (PV + grid-in − grid-out − AC-charge). Three-phase inverters deliberately lack that computed field — givenergy-modbus 2.2 models the native registers instead: `e_load_today` (IR 1396–1397) and `e_load_total` (IR 1398–1399). Until now the integration silently skipped the sensor on three-phase.

**Changes**
- The existing `e_consumption_today` descriptor's `value_fn` falls back to the native `e_load_today` register when the derived field is absent (i.e. on three-phase). The entity key is unchanged on both topologies, so the dashboard strategy (which resolves entities by unique_id key suffix) and the recommended-entities service work untouched, and there are no entity-ID changes for existing installs.
- New three-phase-only **House Consumption Total** sensor backed by `e_load_total`; `skip_if_none` drops it on single-phase. Added to `EXPOSE_RECOMMENDED_ENTITY_KEYS` (silently skipped where absent, like the battery keys on PV-only installs).
- Test fixtures now mirror the real model: the single-phase mock deletes the native load attributes so MagicMock can't fabricate them; a new three-phase test asserts the native-register routing.

**Verification**
- Full suite green (255 passed), ruff clean.
- The client's three-phase `refresh()` polls IR 1000–1414 in 60-register windows, covering 1396–1399.
- Caveat: the register mapping is modelled in givenergy-modbus 2.2 but hasn't been validated on real three-phase hardware yet — no 3-phase unit on the supported-devices list so far. Something to revisit when a tester with three-phase kit turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)