### PR TITLE
fix: reload entry when a healed topology reveals devices that missed setup

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -459,11 +459,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             data={"entry_id": entry.entry_id, "devices": devices},
         )
 
-    async def _on_topology_healed() -> None:
+    # Capabilities snapshot the platforms built their entities from — captured
+    # after async_forward_entry_setups below. None until then, so the heal that
+    # fires during the initial connect (before any entities exist) is a no-op.
+    setup_capabilities: PlantCapabilities | None = None
+
+    async def _on_topology_healed(confirmed: PlantCapabilities) -> None:
         # Full expected topology confirmed — clear any standing "device missing"
         # repair the moment the device answers again (idempotent: a no-op when
         # no such issue exists).
         ir.async_delete_issue(hass, DOMAIN, f"expected_devices_missing_{entry.entry_id}")
+        # Entity sets are frozen at platform setup: a device that answered late
+        # (slow BMS during a warm-start detect) got no entities, and nothing
+        # creates them when it recovers. missing_devices(confirmed, setup)
+        # lists exactly those — present in the confirmed topology, absent from
+        # the snapshot entities were built from — so reload to pick them up (#148).
+        if setup_capabilities is None:
+            return
+        appeared = missing_devices(confirmed, setup_capabilities)
+        if appeared:
+            _LOGGER.info(
+                "Recovered device(s) %s had no entities created at setup; "
+                "reloading the entry to create them",
+                ", ".join(appeared),
+            )
+            hass.config_entries.async_schedule_reload(entry.entry_id)
 
     coordinator = GivEnergyUpdateCoordinator(
         hass=hass,
@@ -503,6 +523,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _migrate_unique_ids(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # The platforms have now enumerated their entities from coordinator.data —
+    # snapshot the topology that enumeration saw for the heal-path diff (#148).
+    setup_capabilities = coordinator.data.capabilities
 
     # EMS entity-id realignment prompt. An EMS controller's entities are now named
     # `givenergy_ems_…` (sensor._device_kind); existing installs still carry the old

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -36,9 +36,12 @@ TopologyChangedCallback = Callable[[PlantCapabilities], Awaitable[None]]
 DevicesMissingCallback = Callable[[PlantCapabilities, PlantCapabilities], Awaitable[None]]
 
 # Invoked whenever a (re)connect confirms the full expected topology (detect
-# succeeded with no mismatch, or a loss healed on retry). Lets the caller clear
-# a stale "device missing" repair the moment the device answers again.
-TopologyHealedCallback = Callable[[], Awaitable[None]]
+# succeeded with no mismatch, or a loss healed on retry), with the confirmed
+# capabilities. Lets the caller clear a stale "device missing" repair the
+# moment the device answers again, and reconcile entities against what is now
+# confirmed — a device that answered late never got entities at platform
+# setup, so the caller reloads the entry when the heal reveals one (#148).
+TopologyHealedCallback = Callable[[PlantCapabilities], Awaitable[None]]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,6 +95,9 @@ def missing_devices(prior: PlantCapabilities | None, actual: PlantCapabilities) 
     for addr in prior.meter_addresses:
         if addr not in actual.meter_addresses:
             missing.append(f"meter at 0x{addr:02x}")
+    for addr in prior.aio_battery_module_addresses:
+        if addr not in actual.aio_battery_module_addresses:
+            missing.append(f"AIO battery module at 0x{addr:02x}")
     # bcu_stacks entries are (bcu_offset, num_modules); device addr = 0x70+offset.
     actual_modules_by_offset = {off: mods for off, mods in actual.bcu_stacks}
     for off, mods in prior.bcu_stacks:
@@ -447,10 +453,12 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
             )
         except PlantTopologyMismatch as exc:
             topology_confirmed = await self._handle_topology_mismatch(exc)
-        if topology_confirmed and self._on_topology_healed is not None:
-            # Full expected topology is present — clear any stale "device
-            # missing" repair (covers both restart and mid-session recovery).
-            await self._on_topology_healed()
+        confirmed = self._client.plant.capabilities
+        if topology_confirmed and self._on_topology_healed is not None and confirmed is not None:
+            # Full expected topology is present — let the caller clear any
+            # stale "device missing" repair and reconcile entities against the
+            # confirmed topology (covers both restart and mid-session recovery).
+            await self._on_topology_healed(confirmed)
         self._last_inverter_time = None
         self._unchanged_ticks = 0
         self._active_tick = 0

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -453,6 +453,11 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
             )
         except PlantTopologyMismatch as exc:
             topology_confirmed = await self._handle_topology_mismatch(exc)
+        if self._client is None:
+            # The entry was unloaded/reloaded while _handle_topology_mismatch
+            # yielded (retry sleeps) and async_close() discarded the client —
+            # nothing to confirm against, we're shutting down.
+            return
         confirmed = self._client.plant.capabilities
         if topology_confirmed and self._on_topology_healed is not None and confirmed is not None:
             # Full expected topology is present — let the caller clear any

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1003,8 +1003,21 @@ def test_missing_devices_classification():
     assert missing_devices(_caps(bcu_stacks=[(0, 4)]), _caps(bcu_stacks=[(0, 2)])) == [
         "HV stack at 0x70 (2 of 4 modules)"
     ]
+    # AIO battery module dropped (#148).
+    assert missing_devices(
+        _caps(aio_battery_module_addresses=[0x50, 0x51]),
+        _caps(aio_battery_module_addresses=[0x50]),
+    ) == ["AIO battery module at 0x51"]
     # An add is not a loss.
     assert missing_devices(_caps(lv_battery_addresses=[0x32]), base) == []
+    # An AIO module add is not a loss either.
+    assert (
+        missing_devices(
+            _caps(aio_battery_module_addresses=[0x50]),
+            _caps(aio_battery_module_addresses=[0x50, 0x51]),
+        )
+        == []
+    )
     # A device_type change is not a loss (the routine reload path handles it).
     assert missing_devices(_caps(), _caps(device_type=Model.AC)) == []
     # No prior (cold start) is not a loss.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -341,6 +341,51 @@ async def test_full_topology_detect_clears_stale_missing_repair(
     ) not in ir.async_get(hass).issues
 
 
+async def test_heal_reloads_when_recovered_device_missed_setup(
+    hass, mock_client, mock_config_entry
+):
+    """A device absent when entities were created gets them via an entry reload once
+    the topology heals (#148): the healed callback diffs the confirmed topology
+    against the setup-time snapshot and schedules a reload on any gap."""
+    # Default fixture topology: one battery at 0x32.
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
+
+    # Mid-session heal confirms a battery (0x33) that wasn't there at setup.
+    confirmed = PlantCapabilities(
+        device_type=Model.HYBRID,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32, 0x33],
+        bcu_stacks=[],
+    )
+    with patch.object(hass.config_entries, "async_schedule_reload") as reload_mock:
+        await coordinator._on_topology_healed(confirmed)
+    reload_mock.assert_called_once_with(mock_config_entry.entry_id)
+
+
+async def test_heal_matching_setup_topology_does_not_reload(hass, mock_client, mock_config_entry):
+    """The routine heal — confirmed topology identical to what setup instantiated —
+    must not reload (it fires on every clean reconnect)."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
+
+    confirmed = PlantCapabilities(
+        device_type=Model.HYBRID,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    with patch.object(hass.config_entries, "async_schedule_reload") as reload_mock:
+        await coordinator._on_topology_healed(confirmed)
+    reload_mock.assert_not_called()
+
+
 async def test_missing_device_fix_flow_clears_cache_and_reloads(hass):
     """The repair's Fix step clears the entry's cached topology and reloads it."""
     from custom_components.givenergy_local.repairs import (

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -680,7 +680,10 @@ async def test_aio_modules_create_one_device_each(hass, aio_setup):
         assert (DOMAIN, serial) in device.identifiers
         assert device.serial_number == serial
         assert device.model == "AIO Battery Module"
-        assert device.via_device_id is not None  # parented to the AIO inverter
+        # Parented to the AIO inverter device specifically, not just any parent.
+        inverter_device = dev_registry.async_get_device(identifiers={(DOMAIN, "SA1234G123")})
+        assert inverter_device is not None
+        assert device.via_device_id == inverter_device.id
 
 
 async def test_aio_module_all_24_voltage_cells(hass, aio_setup):
@@ -761,11 +764,12 @@ async def test_non_aio_plant_creates_no_module_entities(hass, setup_integration)
 
 
 def test_aio_module_sensor_descriptions_cover_expected_cells():
-    """24 voltage + 12 temperature descriptions, no duplicate keys."""
+    """Exactly v_cell_01..24 and t_cell_01..12 — exact sets, so a shifted or
+    missing index is caught, not just a matching count."""
     keys = [d.key for d in AIO_MODULE_SENSORS]
-    assert len([k for k in keys if k.startswith("v_cell_")]) == 24
-    assert len([k for k in keys if k.startswith("t_cell_")]) == 12
     assert len(keys) == len(set(keys))
+    assert {k for k in keys if k.startswith("v_cell_")} == {f"v_cell_{i:02d}" for i in range(1, 25)}
+    assert {k for k in keys if k.startswith("t_cell_")} == {f"t_cell_{i:02d}" for i in range(1, 13)}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #148.

Entity sets are frozen at platform setup: a device that's slow to answer during a warm-start detect — an LV battery, or (since #192) an AIO battery module — gets no entities, and the topology state machine's healed path only cleared the repair. The recovered device stayed entity-less until a manual reload.

**Changes**
- `_on_topology_healed` now receives the confirmed `PlantCapabilities`. The `__init__.py` callback diffs it against a snapshot of the topology the platforms actually built entities from (captured right after `async_forward_entry_setups`), reusing `missing_devices()` with the arguments swapped — devices present in the confirmed topology but absent from the setup snapshot. Any gap schedules an entry reload. Uniform across batteries, meters, HV stacks and AIO modules.
- `missing_devices()` gains `aio_battery_module_addresses` tracking, so module loss/heal raises and clears the repair the same way a battery's does.
- The snapshot starts as `None`, so the heal that fires during the initial connect (before entities exist) is a no-op, and the routine heal on every clean reconnect compares equal and doesn't reload — no reload loops.
- Folds in the two test-tightenings from the #147 review (per the issue comment): exact expected cell-key sets for AIO module descriptors, and `via_device_id` asserted against the actual inverter device rather than non-null.

**Verification**
- New tests: AIO module loss/add classification, heal-with-gap schedules reload, heal-matching-setup doesn't.
- Full suite green (255 passed), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)