### PR TITLE
fix: survive entry unload during the topology loss-retry loop

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -768,6 +768,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         coordinator: GivEnergyUpdateCoordinator = hass.data[DOMAIN].pop(entry.entry_id)
+        # Shut down before discarding the client: no new scheduled refresh can
+        # race the teardown. HA auto-registers async_shutdown via
+        # config_entry.async_on_unload, but those callbacks fire only after this
+        # function returns — too late, the client would already be gone. An
+        # already-in-flight refresh isn't cancelled by either path; the
+        # coordinator's loss-retry loop guards against the discarded client.
+        await coordinator.async_shutdown()
         await coordinator.async_close()
 
     if not hass.data.get(DOMAIN):

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -218,6 +218,13 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
             reconnecting = self._client is None or not self._client.connected
             if reconnecting:
                 await self._connect()
+            if self._client is None:
+                # The entry was unloaded while _connect() was resolving topology
+                # (async_close() discarded the client mid-flight). Serve the
+                # last-known data for this final tick rather than proceeding to
+                # a poll that would fail loudly — the coordinator is being torn
+                # down, and a routine unload should not log an ERROR.
+                return self.data
 
             plant = (
                 await self._passive_update(reconnecting)

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -515,6 +515,15 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                     DETECT_LOSS_RETRY_DELAY,
                 )
                 await asyncio.sleep(DETECT_LOSS_RETRY_DELAY)
+                if self._client is None:
+                    # The entry was unloaded during the retry sleep and
+                    # async_close() discarded the client — abandon the
+                    # resolution quietly; no callbacks for a dead entry.
+                    _LOGGER.debug(
+                        "Client discarded during loss-retry sleep (entry unloading); "
+                        "abandoning topology resolution"
+                    )
+                    return False
                 try:
                     await self._client.detect(
                         prior=self._prior_capabilities,
@@ -534,6 +543,14 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                     # the full prior. Nothing to bake in, no callback, prior kept.
                     _LOGGER.info("Missing device(s) reappeared on retry; full topology restored")
                     return True
+
+        if self._client is None:
+            # Unloaded while the final detect() retry was in flight — same
+            # bail-out as above, just past the loop rather than inside it.
+            _LOGGER.debug(
+                "Client discarded during topology resolution (entry unloading); abandoning"
+            )
+            return False
 
         if missing:
             # Persistent loss. Do NOT touch self._prior_capabilities — keep the

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1101,6 +1101,52 @@ async def test_persistent_loss_invokes_on_devices_missing(hass, mock_plant):
     assert coordinator._schedule_reconnect  # forces a reconnect on the next poll
 
 
+async def test_unload_mid_loss_retry_does_not_crash(hass, mock_plant):
+    """An unload during the loss-retry sleeps discards the client (async_close);
+    when the retry loop resumes it must bail out quietly — no AttributeError on
+    the None client, and no topology callbacks for a resolution that was
+    abandoned mid-flight."""
+    prior = _caps(lv_battery_addresses=[0x32, 0x33])
+    actual = _caps(lv_battery_addresses=[0x32])
+    mismatch = PlantTopologyMismatch("battery missing", prior=prior, actual=actual)
+    on_missing, on_changed, on_healed = AsyncMock(), AsyncMock(), AsyncMock()
+    coordinator = GivEnergyUpdateCoordinator(
+        hass,
+        "192.168.1.1",
+        8899,
+        30,
+        prior_capabilities=prior,
+        on_topology_changed=on_changed,
+        on_devices_missing=on_missing,
+        on_topology_healed=on_healed,
+    )
+
+    async def _unload_during_sleep(_delay):
+        # Simulates async_unload_entry running while this refresh sleeps.
+        await coordinator.async_close()
+
+    with (
+        patch("custom_components.givenergy_local.coordinator.Client") as mock_cls,
+        patch(
+            "custom_components.givenergy_local.coordinator.asyncio.sleep",
+            AsyncMock(side_effect=_unload_during_sleep),
+        ),
+    ):
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.detect = AsyncMock(side_effect=mismatch)  # loss on the initial detect
+        mock_cls.return_value = client
+
+        await coordinator._connect()  # must NOT raise
+
+    assert coordinator._client is None  # closed stays closed
+    on_missing.assert_not_awaited()
+    on_changed.assert_not_awaited()
+    on_healed.assert_not_awaited()
+    assert coordinator._prior_capabilities is prior  # nothing baked in
+
+
 async def test_loss_reconnect_respects_cooldown(hass, mock_plant):
     """_schedule_reconnect within cooldown: no reset, normal poll continues."""
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1103,9 +1103,11 @@ async def test_persistent_loss_invokes_on_devices_missing(hass, mock_plant):
 
 async def test_unload_mid_loss_retry_does_not_crash(hass, mock_plant):
     """An unload during the loss-retry sleeps discards the client (async_close);
-    when the retry loop resumes it must bail out quietly — no AttributeError on
-    the None client, and no topology callbacks for a resolution that was
-    abandoned mid-flight."""
+    when the retry loop resumes the whole refresh must bail out quietly — no
+    AttributeError on the None client, no topology callbacks for a resolution
+    that was abandoned mid-flight, and no UpdateFailed (a scary ERROR in the HA
+    log) for what is a routine teardown: the tick serves last-known data
+    instead (Gemini review on #159)."""
     prior = _caps(lv_battery_addresses=[0x32, 0x33])
     actual = _caps(lv_battery_addresses=[0x32])
     mismatch = PlantTopologyMismatch("battery missing", prior=prior, actual=actual)
@@ -1138,9 +1140,13 @@ async def test_unload_mid_loss_retry_does_not_crash(hass, mock_plant):
         client.detect = AsyncMock(side_effect=mismatch)  # loss on the initial detect
         mock_cls.return_value = client
 
-        await coordinator._connect()  # must NOT raise
+        # The full refresh path: must neither raise UpdateFailed nor crash —
+        # the post-_connect guard serves last-known data (None here) quietly.
+        result = await coordinator._async_update_data()
 
+    assert result is coordinator.data
     assert coordinator._client is None  # closed stays closed
+    assert coordinator.consecutive_failures == 0  # teardown is not a failure
     on_missing.assert_not_awaited()
     on_changed.assert_not_awaited()
     on_healed.assert_not_awaited()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -386,6 +386,39 @@ async def test_heal_matching_setup_topology_does_not_reload(hass, mock_client, m
     reload_mock.assert_not_called()
 
 
+async def test_unload_entry_shuts_down_coordinator_before_closing(
+    hass, mock_client, mock_config_entry
+):
+    """Unload must shut the coordinator down (no new scheduled refresh can race
+    teardown) before discarding the client. HA's auto-registered shutdown (via
+    config_entry.async_on_unload) fires only after async_unload_entry returns —
+    too late, the client is already gone by then."""
+    from unittest.mock import Mock
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
+
+    order = Mock()
+    with (
+        patch.object(
+            coordinator, "async_shutdown", wraps=coordinator.async_shutdown
+        ) as shutdown_spy,
+        patch.object(coordinator, "async_close", wraps=coordinator.async_close) as close_spy,
+    ):
+        order.attach_mock(shutdown_spy, "shutdown")
+        order.attach_mock(close_spy, "close")
+        assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+    shutdown_spy.assert_awaited()
+    close_spy.assert_awaited_once()
+    spy_calls = [c[0] for c in order.mock_calls if c[0] in ("shutdown", "close")]
+    assert spy_calls.index("shutdown") < spy_calls.index("close")
+
+
 async def test_missing_device_fix_flow_clears_cache_and_reloads(hass):
     """The repair's Fix step clears the entry's cached topology and reloads it."""
     from custom_components.givenergy_local.repairs import (


### PR DESCRIPTION
Follow-up to the Gemini finding on #157, which guarded one access point — this covers the underlying race.

**The race:** `async_unload_entry` calls `coordinator.async_close()`, nulling `coordinator._client`, but nothing stops an in-flight refresh. A refresh sleeping in `_handle_topology_mismatch`'s loss-retry loop (2 × 5 s `DETECT_LOSS_RETRY_DELAY`) resumes after the unload and dereferences the discarded client (`await self._client.detect(...)`) → `AttributeError` on None.

**The fix:**
- The retry loop bails out quietly when the client has been discarded — checked after each sleep and once past the final retry. Returns "not confirmed", so `_connect`'s existing #157 guard exits cleanly with no topology callbacks fired for a dead entry.
- `async_unload_entry` calls `coordinator.async_shutdown()` before `async_close()`, so no *new* scheduled refresh can race the teardown. HA auto-registers shutdown via `config_entry.async_on_unload`, but those callbacks fire only after `async_unload_entry` returns — by which point the client is already gone.

One detail worth recording: `DataUpdateCoordinator.async_shutdown()` does **not** cancel an in-flight update (verified against the HA 2026.6 source — it only sets `_shutdown_requested`, unschedules future refreshes and shuts the debouncer), which is why the in-loop guards are the load-bearing part rather than the shutdown call.

**Verification**
- New test reproducing the crash: persistent-loss mismatch with `async_close()` invoked from inside the retry sleep — previously `AttributeError: 'NoneType' object has no attribute 'detect'`, now a clean bail-out with no callbacks.
- New test pinning unload ordering: `async_shutdown` awaited before `async_close`, entry reaches `NOT_LOADED`.
- Full suite green (264 passed), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)