### PR TITLE
fix(deps): adopt givenergy-modbus 2.3.0 — capabilities-cache freshening + public accessor migration

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -499,22 +499,35 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    # Seed the cache on cold start (no prior loaded). Warm-hit doesn't need a
-    # write — the prior we just loaded is what's on the wire. Mismatch is
-    # already covered by _on_topology_changed having saved exc.actual.
+    # Seed the cache on cold start (no prior loaded), and FRESHEN it on a warm
+    # hit whose live capabilities drifted from the cache: detect() rebuilds the
+    # capabilities from the wire, so derived fields can legitimately change
+    # under us — givenergy-modbus 2.3.0's 0x31 read-alias retirement (#249) is
+    # the motivating case, where a persisted inverter_address=0x31 works only
+    # via the hardware facade and is expected to self-heal by the consumer
+    # re-persisting after detect(). The matching warm hit stays write-free.
+    # Mismatch is already covered by _on_topology_changed having saved exc.actual.
     #
-    # Only persist a CLEAN seed: if the seed poll was partial (last_partial_failures
+    # Only persist a CLEAN poll: if the seed poll was partial (last_partial_failures
     # non-empty), the integration still loads (coordinator serves the partial), but
     # we don't commit a possibly-degraded topology to disk — flaky kit could
     # otherwise vanish permanently on the next warm start. A permanently-partial
     # plant re-detects fresh each cold start and self-heals to a clean persist once
     # the read succeeds.
-    if (
-        prior_capabilities is None
-        and coordinator.data.capabilities is not None
-        and not coordinator.last_partial_failures
-    ):
-        await _save_capabilities(hass, entry.entry_id, coordinator.data.capabilities)
+    live_capabilities = coordinator.data.capabilities
+    if live_capabilities is not None and not coordinator.last_partial_failures:
+        if prior_capabilities is None:
+            await _save_capabilities(hass, entry.entry_id, live_capabilities)
+        elif live_capabilities != prior_capabilities and not missing_devices(
+            prior_capabilities, live_capabilities
+        ):
+            # Never freshen with a loss-reduced topology: after a persistent
+            # loss the served capabilities are deliberately reduced for the
+            # tick while the full prior stays cached for the next re-probe.
+            await _save_capabilities(hass, entry.entry_id, live_capabilities)
+            # Reconnect detect() hints should follow the wire too, not the
+            # stale cache we loaded at startup.
+            coordinator._prior_capabilities = live_capabilities
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -111,27 +111,6 @@ def missing_devices(prior: PlantCapabilities | None, actual: PlantCapabilities) 
     return missing
 
 
-def ir_register_age(
-    plant: Plant, device_address: int, register: int, *, now: datetime | None = None
-) -> float | None:
-    """Seconds since the freshest stamped IR window containing ``register`` committed.
-
-    Scans the plant's stamped block windows rather than assuming a fixed
-    60-register layout — which banks exist (and at what width) varies by model
-    and device address. Returns None when no stamped window covers the register:
-    a never-committed bank is not a staleness signal — the Pattern B shape is a
-    bank that committed real data and then stopped (#152).
-    """
-    stamps = [
-        stamped
-        for (dev, reg_type, base, count), stamped in plant.register_block_updated_at.items()
-        if dev == device_address and reg_type == "IR" and base <= register < base + count
-    ]
-    if not stamps:
-        return None
-    return ((now or dt_util.utcnow()) - max(stamps)).total_seconds()
-
-
 class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
     """Wraps a long-lived Modbus Client, polling the inverter on a fixed interval.
 

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.2.0,<3.0.0"
+    "givenergy-modbus>=2.3.0,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -16,6 +16,7 @@ from givenergy_modbus.model.inverter import (
     Status,
     UsbDevice,
 )
+from givenergy_modbus.model.register import Register
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -42,7 +43,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
-from .coordinator import GivEnergyUpdateCoordinator, InverterModel, ir_register_age
+from .coordinator import GivEnergyUpdateCoordinator, InverterModel
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1277,25 +1278,22 @@ _STALE_IR_CEILING_FLOOR = 300.0  # seconds
 _STALE_IR_CEILING_SCANS = 10
 
 
-def _source_ir_registers(model_cls: type, key: str) -> tuple[int, ...]:
-    """The input-register indexes backing ``key`` on ``model_cls``, () if none.
+def _source_ir_registers(model_cls: type, key: str) -> tuple[Register, ...]:
+    """The input registers backing ``key`` on ``model_cls``, () if none.
 
-    Resolved through the model's register LUT, so it tracks whatever layout the
-    concrete model (single/three-phase, …) actually has — never a hardcoded
-    bank list. Computed fields aren't in the LUT and HR-backed fields are
-    filtered out (HR banks are only re-read every few ticks by design, so
-    their age is not a staleness signal); both resolve to () and keep the
-    default coordinator availability. Mock model classes in tests also land
-    here, via the getattr fallbacks.
+    Resolved through the model's public ``registers_of()`` accessor
+    (givenergy-modbus 2.3.0, #248), so it tracks whatever layout the concrete
+    model (single/three-phase, …) actually has — never a hardcoded bank list.
+    Computed fields aren't in the LUT and HR-backed fields are filtered out
+    (HR banks are only re-read every few ticks by design, so their age is not
+    a staleness signal); both resolve to () and keep the default coordinator
+    availability. Mock model classes in tests also land here, via the getattr
+    fallback.
     """
     getter = getattr(model_cls, "REGISTER_GETTER", None)
-    lut = getattr(getter, "REGISTER_LUT", None)
-    defn = lut.get(key) if lut is not None else None
-    if defn is None:
+    if getter is None:
         return ()
-    # Register._idx is the library's storage for the numeric index; there's no
-    # public accessor yet (givenergy-modbus is a sister project, tracked there).
-    return tuple(r._idx for r in defn.registers if type(r).__name__ == "IR")
+    return tuple(r for r in getter.registers_of(key) if r.reg_type == "IR")
 
 
 class GivEnergyInverterSensor(
@@ -1359,7 +1357,8 @@ class GivEnergyInverterSensor(
     def available(self) -> bool:
         """Drop to unavailable when a backing IR bank has stopped committing (#152).
 
-        Keyed off the plant's stamped block windows generically — which banks a
+        Freshness comes from the library's Plant.register_age() (2.3.0, #248),
+        which scans the stamped block windows generically — which banks a
         device serves varies by model and address. Sensors with no resolvable
         IR source (computed fields, HR-backed config) keep the default
         coordinator availability, as does a never-committed bank.
@@ -1372,7 +1371,7 @@ class GivEnergyInverterSensor(
         if capabilities is None:
             return True
         for register in self._source_ir_registers:
-            age = ir_register_age(self.coordinator.data, capabilities.inverter_address, register)
+            age = self.coordinator.data.register_age(capabilities.inverter_address, register)
             if age is not None and age > self._stale_ir_ceiling:
                 return False
         return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.2.0,<3.0.0",
+    "givenergy-modbus>=2.3.0,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -520,6 +520,70 @@ async def test_cold_start_skips_capabilities_persist_on_partial_seed(
     save_mock.assert_not_awaited()
 
 
+async def test_warm_start_freshens_persisted_capabilities_on_drift(
+    hass, mock_client, mock_config_entry
+):
+    """A warm start whose live capabilities differ from the loaded cache must
+    re-persist the live ones and update the coordinator's reconnect hint.
+    Motivating case: givenergy-modbus 2.3.0 retired the 0x31 read-alias (#249) —
+    a cache persisted with inverter_address=0x31 keeps working only via the
+    hardware facade and is expected to self-heal via the consumer re-persisting
+    after detect()."""
+    stale_prior = PlantCapabilities(
+        device_type=Model.HYBRID,
+        inverter_address=0x31,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.givenergy_local._load_capabilities",
+            new=AsyncMock(return_value=stale_prior),
+        ),
+        patch("custom_components.givenergy_local._save_capabilities", new=AsyncMock()) as save_mock,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Live capabilities (conftest: inverter_address=0x32) drifted from the
+    # 0x31 cache → re-persisted, and the reconnect hint follows the wire.
+    save_mock.assert_awaited_once_with(
+        hass, mock_config_entry.entry_id, mock_client.plant.capabilities
+    )
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
+    assert coordinator._prior_capabilities is mock_client.plant.capabilities
+
+
+async def test_warm_start_with_matching_cache_does_not_rewrite(
+    hass, mock_client, mock_config_entry
+):
+    """A warm hit whose cache structurally equals the live capabilities must not
+    write — the historic write-avoidance stays for the steady state."""
+    matching_prior = PlantCapabilities(
+        device_type=Model.HYBRID,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.givenergy_local._load_capabilities",
+            new=AsyncMock(return_value=matching_prior),
+        ),
+        patch("custom_components.givenergy_local._save_capabilities", new=AsyncMock()) as save_mock,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    save_mock.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Capabilities Store helper unit tests
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -857,17 +857,28 @@ async def test_grid_power_hidden_by_default(hass, setup_integration):
 # ---------------------------------------------------------------------------
 
 
+def _register_shape(registers):
+    """(reg_type, index) view of a Register tuple, for order-pinned assertions."""
+    return [(r.reg_type, r.index) for r in registers]
+
+
 def test_source_ir_registers_resolves_via_model_lut():
-    """Register-backed keys map to their IR indexes through the model's LUT;
-    computed fields (not in the LUT) and HR-backed config resolve to nothing —
-    HR banks legitimately age between full refreshes, so they're no signal."""
+    """Register-backed keys map to their IR registers through the model's public
+    registers_of() accessor (givenergy-modbus 2.3.0, #248); computed fields (not
+    in the LUT) and HR-backed config resolve to nothing — HR banks legitimately
+    age between full refreshes, so they're no signal."""
     from givenergy_modbus.model.inverter import SinglePhaseInverter
     from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
 
     from custom_components.givenergy_local.sensor import _source_ir_registers
 
-    assert _source_ir_registers(SinglePhaseInverter, "e_grid_out_day") == (25,)
-    assert _source_ir_registers(ThreePhaseInverter, "e_load_today") == (1396, 1397)
+    assert _register_shape(_source_ir_registers(SinglePhaseInverter, "e_grid_out_day")) == [
+        ("IR", 25)
+    ]
+    assert _register_shape(_source_ir_registers(ThreePhaseInverter, "e_load_today")) == [
+        ("IR", 1396),
+        ("IR", 1397),
+    ]
     assert _source_ir_registers(SinglePhaseInverter, "e_consumption_today") == ()
     assert _source_ir_registers(SinglePhaseInverter, "charge_target_soc") == ()
     # Mock model classes (as used across these tests) resolve to nothing.
@@ -907,39 +918,20 @@ def test_renamed_direct_register_sensors_declare_their_source_field():
     # value is the derived field (untracked — e_load_today isn't in that LUT),
     # on three-phase it's the native register the value_fn falls back to.
     assert _source_ir_registers(SinglePhaseInverter, "e_load_today") == ()
-    assert _source_ir_registers(ThreePhaseInverter, "e_load_today") == (1396, 1397)
-
-
-def test_ir_register_age_scans_stamped_windows():
-    """Age comes from the freshest stamped IR window containing the register —
-    no assumed bank layout; other devices, HR stamps and uncovered registers
-    don't count."""
-    from datetime import UTC, datetime, timedelta
-
-    from custom_components.givenergy_local.coordinator import ir_register_age
-
-    now = datetime.now(UTC)
-    plant = MagicMock()
-    plant.register_block_updated_at = {
-        (0x32, "IR", 0, 60): now - timedelta(seconds=40),
-        (0x32, "IR", 0, 1): now - timedelta(seconds=5),  # overlapping narrow window
-        (0x32, "IR", 180, 60): now - timedelta(seconds=700),
-        (0x32, "HR", 0, 60): now - timedelta(seconds=9999),
-        (0x31, "IR", 240, 60): now - timedelta(seconds=10),
-    }
-    # Freshest covering window wins: IR(0,1) covers register 0, IR(0,60) covers 25.
-    assert ir_register_age(plant, 0x32, 0, now=now) == pytest.approx(5)
-    assert ir_register_age(plant, 0x32, 25, now=now) == pytest.approx(40)
-    assert ir_register_age(plant, 0x32, 200, now=now) == pytest.approx(700)
-    # 0x32's IR(240) bank was never stamped — 0x31's doesn't count for it.
-    assert ir_register_age(plant, 0x32, 247, now=now) is None
+    assert _register_shape(_source_ir_registers(ThreePhaseInverter, "e_load_today")) == [
+        ("IR", 1396),
+        ("IR", 1397),
+    ]
 
 
 def test_sensor_unavailable_when_backing_ir_block_stale(mock_plant):
     """A backing IR bank that stopped committing past the ceiling drops the
     sensor to unavailable; a never-committed bank is no signal (the Pattern B
-    shape is 'committed real data, then stopped' — #152)."""
-    from datetime import UTC, datetime, timedelta
+    shape is 'committed real data, then stopped' — #152). Freshness comes from
+    the library's Plant.register_age() (2.3.0, #248)."""
+    from datetime import timedelta
+
+    from givenergy_modbus.model.register import IR
 
     from custom_components.givenergy_local.sensor import GivEnergyInverterSensor
 
@@ -950,20 +942,24 @@ def test_sensor_unavailable_when_backing_ir_block_stale(mock_plant):
     entity = GivEnergyInverterSensor(coordinator, _inverter_desc("e_grid_out_day"))
     # The conftest inverter is a MagicMock with no register LUT, so inject the
     # source registers the resolver would derive from the real model.
-    entity._source_ir_registers = (25,)
+    entity._source_ir_registers = (IR(25),)
+    mock_plant.register_age = MagicMock()
 
-    now = datetime.now(UTC)
     # Fresh bank: available.
-    mock_plant.register_block_updated_at = {(0x32, "IR", 0, 60): now - timedelta(seconds=35)}
+    mock_plant.register_age.return_value = 35.0
     assert entity.available is True
+    # Asked the plant about the right device and register.
+    (addr, reg) = mock_plant.register_age.call_args.args
+    assert addr == 0x32  # conftest capabilities.inverter_address
+    assert (reg.reg_type, reg.index) == ("IR", 25)
     # Bank stopped committing 10 minutes ago (ceiling at 30 s interval = 300 s).
-    mock_plant.register_block_updated_at = {(0x32, "IR", 0, 60): now - timedelta(seconds=600)}
+    mock_plant.register_age.return_value = 600.0
     assert entity.available is False
     # Never committed: stays available (its value reads None/unknown anyway).
-    mock_plant.register_block_updated_at = {}
+    mock_plant.register_age.return_value = None
     assert entity.available is True
     # Coordinator-level failure still wins regardless of bank ages.
-    mock_plant.register_block_updated_at = {(0x32, "IR", 0, 60): now - timedelta(seconds=35)}
+    mock_plant.register_age.return_value = 35.0
     coordinator.last_update_success = False
     assert entity.available is False
 
@@ -981,6 +977,7 @@ def test_sensor_without_ir_source_keeps_default_availability(mock_plant):
     entity = GivEnergyInverterSensor(coordinator, _inverter_desc("e_consumption_today"))
 
     assert entity._source_ir_registers == ()
-    # No stamp data at all — must not even be consulted.
-    mock_plant.register_block_updated_at = {}
+    # Freshness must not even be consulted.
+    mock_plant.register_age = MagicMock()
     assert entity.available is True
+    mock_plant.register_age.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -929,7 +929,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.2.0,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.3.0,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -942,16 +942,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.2.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/17/a6546e0ac03480532b40a5001b132618da15962d96e218068113e00cffe7/givenergy_modbus-2.2.0.tar.gz", hash = "sha256:2b0ede8620c29148a3d8df7a9841b469e89afa6b5433f990d5835d12b6acd967", size = 375297, upload-time = "2026-06-10T21:12:19.12Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/7a/c568b35a1d1cff87e5c4f617c4f6e0fd01eb1280024575180122290ce5b9/givenergy_modbus-2.3.0.tar.gz", hash = "sha256:78fc88146739c92b0df1a06db150daaeaf086f05d813eff45be602e48363b1a0", size = 381348, upload-time = "2026-06-11T23:19:17.913Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/ae/cea45704fe4b82bda56e70981c496425e3f3d4a0ffdba313d7b4ec6de1ed/givenergy_modbus-2.2.0-py3-none-any.whl", hash = "sha256:2c7108d066343e570af9ed3655e4f4f8182c15262fa2bf36a95938e8ee2c14d4", size = 142506, upload-time = "2026-06-10T21:12:17.821Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/04/0025d3f0fdca3e89938b67721486a8aa2124a17f16786baf1a154aafd675/givenergy_modbus-2.3.0-py3-none-any.whl", hash = "sha256:4f2a27e0e26cffe0cd5492263e10f36ca17fed3dc3ff08ec245a8b6def38f71a", size = 144017, upload-time = "2026-06-11T23:19:16.635Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Reactive changes for givenergy-modbus 2.3.0, in two commits.

**1. Pin bump + capabilities-cache freshening** (`fix(deps)`)
2.3.0 retires the 0x31 read-alias ([modbus#249](https://github.com/dewet22/givenergy-modbus/pull/249)). Verified against the release source: `detect()` doesn't compare `inverter_address` between prior and actual, so there's no mismatch/repair noise on upgrade, and the live capabilities self-correct to 0x11 — but the library deliberately leaves an explicit persisted `0x31` untouched at load, expecting the consumer to re-persist after detect. We only persisted on cold start, so our on-disk cache (and the `prior=` hint fed to every reconnect detect) would have stayed 0x31 indefinitely, leaning on the hardware facade forever.

The warm-start seed block now re-persists when the live capabilities drift from the loaded cache (clean polls only) and repoints the coordinator's reconnect hint. Guarded by `missing_devices()` so a loss-reduced topology is never baked in — the persistent-loss behaviour is unchanged and still pinned by its test.

**2. Public accessor migration** (`refactor`)
[modbus#248](https://github.com/dewet22/givenergy-modbus/pull/248) shipped the surface I asked for after #158: `registers_of()`, `Register.index`/`reg_type`, and `Plant.register_age()`. The stale-bank availability check now uses those; the hand-rolled `ir_register_age()` is deleted (the library pins that behaviour with its own tests), and there are no remaining reaches into `Register._idx` or `plant.register_block_updated_at` (grep-verified).

Also checked and deliberately untouched: the meter pf/apparent rescale (modbus#250) doesn't affect us — no meter-model sensors exposed; `ir0_max_age` adoption and a per-pack `i_battery` sensor are noted as separate follow-ups.

**Verification**
Two new tests pin the freshen behaviour (0x31-drift rewrite + matching-cache write-avoidance); the #158 tests are adapted to the object-based API. Full suite green on 2.3.0 (265 passed — also a clean smoke of the rest of the release), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)