### PR TITLE
fix(ci): stop the release blurb extraction deleting paragraph breaks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,12 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # Require an annotated tag — the message becomes the release blurb.
-          blurb="$(git tag -l --format='%(contents)' "$TAG" | sed '/^-----BEGIN PGP/,/^-----END PGP/d' | sed 's/[[:space:]]*$//' | sed '/^$/d')"
+          # Keep interior blank lines: they are the markdown paragraph breaks
+          # between the blurb's heading+paragraph blocks. Deleting them (the
+          # old `sed '/^$/d'`) flattened multi-paragraph blurbs into one blob
+          # in the HACS update dialog (v1.3.0). Command substitution already
+          # trims trailing newlines, so the emptiness check below still holds.
+          blurb="$(git tag -l --format='%(contents)' "$TAG" | sed '/^-----BEGIN PGP/,/^-----END PGP/d' | sed 's/[[:space:]]*$//')"
           if [ -z "$blurb" ]; then
             echo "::error::Tag '$TAG' has no message. Use 'git tag -a $TAG -m \"...\"' to add a release blurb."
             exit 1


### PR DESCRIPTION
The `sed '/^$/d'` in release.yml's tag-annotation pipeline deleted every blank line from the blurb, flattening multi-paragraph release notes into one unbroken blob in the HACS update dialog — spotted on v1.3.0 (that release body has been repaired in place with `gh release edit`).

Interior blank lines are the markdown paragraph breaks between the blurb's heading+paragraph blocks, so the filter now keeps them. The PGP-signature strip and trailing-whitespace trim stay; command substitution already trims trailing newlines, which is all the non-empty annotation check needs.

Verified locally against the live v1.3.0 tag: the three interior blank lines survive the new pipeline and the emptiness check behaves as before. Real-world verification will be the next release rendering correctly in HACS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)