### PR TITLE
fix(sensor): gate same-day monotonic resets on a plausible post-reset value

### DIFF
--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1328,6 +1328,8 @@ class GivEnergyInverterSensor(
         self._monotonic_max: float | None = None
         self._monotonic_date: date | None = None
         self._monotonic_last_read: datetime | None = None
+        self._monotonic_reset_pending = False
+        self._monotonic_prior_day_value: float | None = None
         self._source_ir_registers = _source_ir_registers(
             type(coordinator.data.inverter), description.source_field or description.key
         )
@@ -1371,6 +1373,12 @@ class GivEnergyInverterSensor(
             # negative state (#142), which must not re-seed the baseline.
             self._monotonic_max = max(restored, 0.0)
             self._monotonic_date = last_date
+        else:
+            # A prior-day value is no intra-day baseline, but it is the
+            # reference for the first reading of the new day: matching it
+            # means the counter carried over un-reset across a restart
+            # spanning midnight, so the late reset must still be admitted.
+            self._monotonic_prior_day_value = max(restored, 0.0)
 
     @property
     def available(self) -> bool:
@@ -1410,7 +1418,20 @@ class GivEnergyInverterSensor(
                 # negative at any moment, including across the day boundary
                 # (#142). A high carry-over here is normal (inverter clock
                 # lagging HA's midnight); the reset branch below catches the
-                # real reset a poll later.
+                # real reset a poll later. A reset is owed exactly when the
+                # counter did NOT drop at the boundary — judged against the
+                # running max, or after a restart against the restored
+                # prior-day value; only while it is owed may the acceptance
+                # band widen with elapsed time.
+                prior_ref = (
+                    self._monotonic_max
+                    if self._monotonic_max is not None
+                    else self._monotonic_prior_day_value
+                )
+                self._monotonic_reset_pending = (
+                    prior_ref is not None and value >= prior_ref - _MONOTONIC_RESET_THRESHOLD
+                )
+                self._monotonic_prior_day_value = None
                 self._monotonic_max = max(value, 0.0)
                 self._monotonic_date = today
             elif self._monotonic_max is None:
@@ -1424,17 +1445,21 @@ class GivEnergyInverterSensor(
                 # threshold's comment). Anything else is transient register
                 # skew: hold the clamp until the source recovers, so the
                 # recorder never sees a fake reset followed by a
-                # sum-corrupting recovery jump (#142). The ceiling scales
-                # with time since the previous reading so a reset observed
-                # late — long scan interval, or a polling outage spanning
-                # midnight — is not rejected for having accumulated more
-                # than the floor.
+                # sum-corrupting recovery jump (#142). While the midnight
+                # reset is still owed, the ceiling scales with time since
+                # the previous reading so a reset observed late — long scan
+                # interval, or a polling outage after the date flip — is
+                # not rejected for having accumulated more than the floor.
+                # Once it has been observed (or was never owed), the band
+                # stays at the floor: a post-gap daytime sag is skew, not a
+                # reset.
                 ceiling = _MONOTONIC_RESET_THRESHOLD
-                if last_read is not None:
+                if self._monotonic_reset_pending and last_read is not None:
                     elapsed_hours = (now - last_read).total_seconds() / 3600.0
                     ceiling = max(ceiling, _MONOTONIC_RESET_MAX_LOAD_KW * elapsed_hours)
                 if 0.0 <= value <= ceiling:
                     self._monotonic_max = value
+                    self._monotonic_reset_pending = False
             else:
                 self._monotonic_max = max(value, self._monotonic_max)
             return self._monotonic_max

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1442,17 +1442,29 @@ class GivEnergyInverterSensor(
                 self._monotonic_max = max(value, 0.0)
                 self._monotonic_date = today
             elif self._monotonic_reset_pending is None and value >= 0.0:
-                # First plausible reading of a day whose boundary poll was
-                # skew: make the deferred owed-reset call now, then fall
-                # through to the normal same-day handling on the next poll.
+                # Deferred owed-reset call (the boundary poll was skew).
+                # Three outcomes: the carry-over reappearing means the reset
+                # is still owed; a reading inside the (elapsed-scaled) reset
+                # band means it happened during the skew window; anything in
+                # between is an ambiguous still-large sag — exactly the
+                # shape this clamp rejects — so it neither settles the
+                # question nor gets exposed, and a later plausible poll
+                # decides.
                 prior_ref = self._monotonic_prior_day_value
-                self._monotonic_reset_pending = (
-                    prior_ref is not None and value >= prior_ref - _MONOTONIC_RESET_THRESHOLD
-                )
-                self._monotonic_prior_day_value = None
-                self._monotonic_max = max(
-                    value, self._monotonic_max if self._monotonic_max is not None else 0.0
-                )
+                ceiling = _MONOTONIC_RESET_THRESHOLD
+                if last_read is not None:
+                    elapsed_hours = (now - last_read).total_seconds() / 3600.0
+                    ceiling = max(ceiling, _MONOTONIC_RESET_MAX_LOAD_KW * elapsed_hours)
+                held_max = self._monotonic_max if self._monotonic_max is not None else 0.0
+                if prior_ref is not None and value >= prior_ref - _MONOTONIC_RESET_THRESHOLD:
+                    self._monotonic_reset_pending = True
+                    self._monotonic_prior_day_value = None
+                    self._monotonic_max = max(value, held_max)
+                elif prior_ref is None or value <= ceiling:
+                    self._monotonic_reset_pending = False
+                    self._monotonic_prior_day_value = None
+                    self._monotonic_max = max(value, held_max)
+                # else: ambiguous — hold the current max, stay undecided.
             elif self._monotonic_max is None:
                 # Unreachable in practice (date and max are set together),
                 # but keeps the invariant explicit and lets the branches

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1328,7 +1328,7 @@ class GivEnergyInverterSensor(
         self._monotonic_max: float | None = None
         self._monotonic_date: date | None = None
         self._monotonic_last_read: datetime | None = None
-        self._monotonic_reset_pending = False
+        self._monotonic_reset_pending: bool | None = False
         self._monotonic_prior_day_value: float | None = None
         self._source_ir_registers = _source_ir_registers(
             type(coordinator.data.inverter), description.source_field or description.key
@@ -1422,18 +1422,37 @@ class GivEnergyInverterSensor(
                 # counter did NOT drop at the boundary — judged against the
                 # running max, or after a restart against the restored
                 # prior-day value; only while it is owed may the acceptance
-                # band widen with elapsed time.
+                # band widen with elapsed time. An implausible (negative)
+                # boundary reading decides nothing: defer the owed-reset
+                # call to the first plausible reading of the day, or the
+                # carry-over reappearing after the skew would lose it.
                 prior_ref = (
                     self._monotonic_max
                     if self._monotonic_max is not None
                     else self._monotonic_prior_day_value
                 )
+                if value < 0.0:
+                    self._monotonic_reset_pending = None
+                    self._monotonic_prior_day_value = prior_ref
+                else:
+                    self._monotonic_reset_pending = (
+                        prior_ref is not None and value >= prior_ref - _MONOTONIC_RESET_THRESHOLD
+                    )
+                    self._monotonic_prior_day_value = None
+                self._monotonic_max = max(value, 0.0)
+                self._monotonic_date = today
+            elif self._monotonic_reset_pending is None and value >= 0.0:
+                # First plausible reading of a day whose boundary poll was
+                # skew: make the deferred owed-reset call now, then fall
+                # through to the normal same-day handling on the next poll.
+                prior_ref = self._monotonic_prior_day_value
                 self._monotonic_reset_pending = (
                     prior_ref is not None and value >= prior_ref - _MONOTONIC_RESET_THRESHOLD
                 )
                 self._monotonic_prior_day_value = None
-                self._monotonic_max = max(value, 0.0)
-                self._monotonic_date = today
+                self._monotonic_max = max(
+                    value, self._monotonic_max if self._monotonic_max is not None else 0.0
+                )
             elif self._monotonic_max is None:
                 # Unreachable in practice (date and max are set together),
                 # but keeps the invariant explicit and lets the branches

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime
 from typing import Any
 
 from givenergy_modbus.model.aio_battery import AioBatteryModule
@@ -1259,18 +1259,30 @@ def _derive_display_precision(description: SensorEntityDescription, model: Any) 
     return model.precision_of(description.key)
 
 
-# Dual-role bound (in the sensor's native unit) for same-day reset detection:
+# Dual-role floor (in the sensor's native unit) for same-day reset detection:
 # a drop must be larger than this to be considered a reset at all, AND the
-# post-drop value must land within [0, this] to be accepted as one. Covers the
-# case where the inverter clock lags HA's local midnight by one scan interval,
-# so the actual counter reset arrives on a subsequent read after the day
-# boundary has already been committed — a real reset observed within a poll or
-# two has accumulated at most a few Wh, so it lands well inside the band. A
-# drop to anything outside it (a negative excursion, a sag to a still-large
-# value) is transient register skew — e.g. a one-poll zeroed register read
-# sinking the derived consumption (#142) — and must be held at the previous
-# max, or the recorder books a fake reset and double-counts the recovery.
+# post-drop value must land within [0, ceiling] to be accepted as one. Covers
+# the case where the inverter clock lags HA's local midnight by one scan
+# interval, so the actual counter reset arrives on a subsequent read after the
+# day boundary has already been committed. A drop to anything outside the band
+# (a negative excursion, a sag to a still-large value) is transient register
+# skew — e.g. a one-poll zeroed register read sinking the derived consumption
+# (#142) — and must be held at the previous max, or the recorder books a fake
+# reset and double-counts the recovery.
+#
+# The acceptance ceiling scales with time since the previous reading:
+# max(floor, max-load × elapsed). At the default 30 s cadence that stays at
+# the 0.5 kWh floor (tight against skew), while a long scan interval or a
+# polling outage spanning the reset widens it to what a genuine post-reset
+# reading can have legitimately accumulated — otherwise yesterday's max stays
+# clamped and the day's statistics are lost. The trade-off is a wider
+# corruptible band on the first poll after an outage; that is the price of
+# not freezing the sensor for hours.
 _MONOTONIC_RESET_THRESHOLD = 0.5  # kWh (matches e_consumption_today's native unit)
+# Conservative continuous-load bound for the elapsed-scaled ceiling — covers
+# three-phase EV-charging/heat-pump households without admitting daytime
+# totals as "resets".
+_MONOTONIC_RESET_MAX_LOAD_KW = 15.0
 
 # A backing input-register bank that has stopped committing past this ceiling
 # reads as a fault, not polling jitter (#152): stale-but-plausible values
@@ -1315,6 +1327,7 @@ class GivEnergyInverterSensor(
         self.entity_description = description
         self._monotonic_max: float | None = None
         self._monotonic_date: date | None = None
+        self._monotonic_last_read: datetime | None = None
         self._source_ir_registers = _source_ir_registers(
             type(coordinator.data.inverter), description.source_field or description.key
         )
@@ -1386,7 +1399,10 @@ class GivEnergyInverterSensor(
     def native_value(self) -> Any:
         value = self.entity_description.value_fn(self.coordinator.data.inverter)
         if self.entity_description.monotonic and isinstance(value, (int, float)):
-            today = dt_util.now().date()
+            now = dt_util.now()
+            today = now.date()
+            last_read = self._monotonic_last_read
+            self._monotonic_last_read = now
             if self._monotonic_date != today:
                 # New calendar day in HA's timezone: start fresh so the
                 # midnight reset passes through as a real decrease. Floored
@@ -1408,8 +1424,16 @@ class GivEnergyInverterSensor(
                 # threshold's comment). Anything else is transient register
                 # skew: hold the clamp until the source recovers, so the
                 # recorder never sees a fake reset followed by a
-                # sum-corrupting recovery jump (#142).
-                if 0.0 <= value <= _MONOTONIC_RESET_THRESHOLD:
+                # sum-corrupting recovery jump (#142). The ceiling scales
+                # with time since the previous reading so a reset observed
+                # late — long scan interval, or a polling outage spanning
+                # midnight — is not rejected for having accumulated more
+                # than the floor.
+                ceiling = _MONOTONIC_RESET_THRESHOLD
+                if last_read is not None:
+                    elapsed_hours = (now - last_read).total_seconds() / 3600.0
+                    ceiling = max(ceiling, _MONOTONIC_RESET_MAX_LOAD_KW * elapsed_hours)
+                if 0.0 <= value <= ceiling:
                     self._monotonic_max = value
             else:
                 self._monotonic_max = max(value, self._monotonic_max)

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1259,13 +1259,17 @@ def _derive_display_precision(description: SensorEntityDescription, model: Any) 
     return model.precision_of(description.key)
 
 
-# A drop larger than this (in the sensor's native unit) is treated as a
-# genuine source reset rather than a transient polling artefact. Covers the
+# Dual-role bound (in the sensor's native unit) for same-day reset detection:
+# a drop must be larger than this to be considered a reset at all, AND the
+# post-drop value must land within [0, this] to be accepted as one. Covers the
 # case where the inverter clock lags HA's local midnight by one scan interval,
 # so the actual counter reset arrives on a subsequent read after the day
-# boundary has already been committed. The value is intentionally conservative:
-# transient multi-register skew is a few Wh; a 500 Wh floor is far above any
-# realistic polling noise while still detecting any meaningful midnight reset.
+# boundary has already been committed — a real reset observed within a poll or
+# two has accumulated at most a few Wh, so it lands well inside the band. A
+# drop to anything outside it (a negative excursion, a sag to a still-large
+# value) is transient register skew — e.g. a one-poll zeroed register read
+# sinking the derived consumption (#142) — and must be held at the previous
+# max, or the recorder books a fake reset and double-counts the recovery.
 _MONOTONIC_RESET_THRESHOLD = 0.5  # kWh (matches e_consumption_today's native unit)
 
 # A backing input-register bank that has stopped committing past this ceiling
@@ -1349,8 +1353,10 @@ class GivEnergyInverterSensor(
         if last_date == dt_util.now().date():
             # Seed the intra-day max from the last persisted value so a
             # transient dip on the first post-restart reading doesn't become
-            # the new baseline while the recorder still holds the higher value.
-            self._monotonic_max = restored
+            # the new baseline while the recorder still holds the higher
+            # value. Floored at zero: pre-fix versions could persist a
+            # negative state (#142), which must not re-seed the baseline.
+            self._monotonic_max = max(restored, 0.0)
             self._monotonic_date = last_date
 
     @property
@@ -1383,22 +1389,30 @@ class GivEnergyInverterSensor(
             today = dt_util.now().date()
             if self._monotonic_date != today:
                 # New calendar day in HA's timezone: start fresh so the
-                # midnight reset passes through as a real decrease.
-                self._monotonic_max = value
+                # midnight reset passes through as a real decrease. Floored
+                # at zero — register skew on a derived value can read
+                # negative at any moment, including across the day boundary
+                # (#142). A high carry-over here is normal (inverter clock
+                # lagging HA's midnight); the reset branch below catches the
+                # real reset a poll later.
+                self._monotonic_max = max(value, 0.0)
                 self._monotonic_date = today
-            elif (
-                self._monotonic_max is not None
-                and value < self._monotonic_max - _MONOTONIC_RESET_THRESHOLD
-            ):
-                # Large same-day drop: treat as a genuine source reset.
-                # This handles an inverter clock that lags HA's midnight by
-                # one poll cycle — the actual counter reset arrives on a
-                # subsequent read after date tracking has already committed
-                # the new day, so we must detect it by magnitude rather than
-                # date alone.
-                self._monotonic_max = value
+            elif self._monotonic_max is None:
+                # Unreachable in practice (date and max are set together),
+                # but keeps the invariant explicit and lets the branches
+                # below assume a non-None max.
+                self._monotonic_max = max(value, 0.0)
+            elif value < self._monotonic_max - _MONOTONIC_RESET_THRESHOLD:
+                # Large same-day drop: a genuine counter reset, but only when
+                # the new value is a plausible post-reset reading (see the
+                # threshold's comment). Anything else is transient register
+                # skew: hold the clamp until the source recovers, so the
+                # recorder never sees a fake reset followed by a
+                # sum-corrupting recovery jump (#142).
+                if 0.0 <= value <= _MONOTONIC_RESET_THRESHOLD:
+                    self._monotonic_max = value
             else:
-                self._monotonic_max = max(value, self._monotonic_max or value)
+                self._monotonic_max = max(value, self._monotonic_max)
             return self._monotonic_max
         return value
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1054,6 +1054,49 @@ def test_monotonic_midnight_reset_passes(mock_plant, freezer):
     assert _read(entity, mock_plant, 0.1) == 0.1
 
 
+def test_monotonic_reset_accepted_after_poll_gap(mock_plant, freezer):
+    """The post-reset plausibility ceiling scales with time since the previous
+    reading: after a polling outage spanning the counter reset, or on a long
+    scan interval under heavy load, the first reading has legitimately
+    accumulated more than the 0.5 kWh floor and must still be accepted."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    # HA's date flips; the lagging counter still reads yesterday's total.
+    freezer.tick(12 * 3600)
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    # Two hours of failed polls; the counter reset during the gap and has
+    # since accumulated 1.8 kWh — far over the floor, well under 15 kW × 2 h.
+    freezer.tick(2 * 3600)
+    assert _read(entity, mock_plant, 1.8) == 1.8
+    assert _read(entity, mock_plant, 2.0) == 2.0
+
+
+def test_monotonic_reset_accepted_on_long_scan_interval(mock_plant, freezer):
+    """A 5-minute scan interval at high load: the first post-reset reading can
+    exceed the 0.5 kWh floor (e.g. 0.9 kWh at ~11 kW); the elapsed-scaled
+    ceiling (15 kW × 300 s = 1.25 kWh) accepts it."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    freezer.tick(12 * 3600)
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    freezer.tick(300)
+    assert _read(entity, mock_plant, 0.9) == 0.9
+
+
+def test_monotonic_negative_still_rejected_after_poll_gap(mock_plant, freezer):
+    """A widened ceiling never admits a negative excursion."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    freezer.tick(3600)
+    assert _read(entity, mock_plant, -2.2) == 14.3
+
+
 def test_monotonic_clock_lag_reset_after_date_flip(mock_plant, freezer):
     """An inverter clock lagging HA's midnight: the pre-reset value carries over
     as the new-day baseline, and the real reset lands a poll later via the

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1064,7 +1064,7 @@ def test_monotonic_reset_accepted_after_poll_gap(mock_plant, freezer):
 
     assert _read(entity, mock_plant, 14.3) == 14.3
     # HA's date flips; the lagging counter still reads yesterday's total.
-    freezer.tick(12 * 3600)
+    freezer.tick(24 * 3600)
     assert _read(entity, mock_plant, 14.3) == 14.3
     # Two hours of failed polls; the counter reset during the gap and has
     # since accumulated 1.8 kWh — far over the floor, well under 15 kW × 2 h.
@@ -1081,10 +1081,43 @@ def test_monotonic_reset_accepted_on_long_scan_interval(mock_plant, freezer):
     entity = _monotonic_entity(mock_plant)
 
     assert _read(entity, mock_plant, 14.3) == 14.3
-    freezer.tick(12 * 3600)
+    freezer.tick(24 * 3600)
     assert _read(entity, mock_plant, 14.3) == 14.3
     freezer.tick(300)
     assert _read(entity, mock_plant, 0.9) == 0.9
+
+
+def test_monotonic_daytime_gap_does_not_widen_acceptance(mock_plant, freezer):
+    """An ordinary daytime polling gap must not widen the reset band: no reset
+    is owed (the day's reset was already observed), so a still-large sag on
+    the first post-gap poll stays clamped (review on #163)."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    # Two-hour outage, then a skew sag to a still-large value: without the
+    # reset-pending gate, the elapsed-scaled ceiling (30 kWh) would accept
+    # 12.1 as a "reset" and double-count the recovery.
+    freezer.tick(2 * 3600)
+    assert _read(entity, mock_plant, 12.1) == 14.3
+    assert _read(entity, mock_plant, 14.4) == 14.4
+
+
+def test_monotonic_pending_reset_consumed_by_acceptance(mock_plant, freezer):
+    """Once the owed reset has been accepted, later same-day gaps revert to
+    the tight floor — a subsequent dip is skew, not another reset."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    freezer.tick(24 * 3600)
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    freezer.tick(2 * 3600)
+    assert _read(entity, mock_plant, 1.8) == 1.8  # owed reset accepted
+    assert _read(entity, mock_plant, 2.0) == 2.0
+    # Another gap the same day: the band is back at the floor.
+    freezer.tick(3600)
+    assert _read(entity, mock_plant, 0.9) == 2.0
 
 
 def test_monotonic_negative_still_rejected_after_poll_gap(mock_plant, freezer):
@@ -1148,6 +1181,34 @@ async def test_monotonic_restore_seeds_same_day_max(hass, mock_plant):
     # A >threshold drop to a still-large value is rejected by the reset gate.
     assert _read(entity, mock_plant, 12.1) == 13.7
     assert _read(entity, mock_plant, 13.8) == 13.8
+
+
+async def test_monotonic_restore_prior_day_carry_over_allows_late_reset(hass, mock_plant, freezer):
+    """A restart spanning midnight: the persisted state is from yesterday, and
+    the first reading of the new day still matches it (inverter clock lag).
+    The owed reset arriving on a later poll must be admitted."""
+    from datetime import timedelta
+    from unittest.mock import AsyncMock
+
+    from homeassistant.core import State
+    from homeassistant.util import dt as dt_util
+
+    freezer.move_to("2026-06-13 00:02:00+00:00")
+    yesterday = dt_util.utcnow() - timedelta(days=1)
+    entity = _monotonic_entity(mock_plant)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_house_consumption_today"
+    entity.async_get_last_state = AsyncMock(
+        return_value=State(entity.entity_id, "14.3", last_updated=yesterday)
+    )
+    await entity.async_added_to_hass()
+    assert entity._monotonic_max is None  # prior-day state is not a baseline
+
+    # First reading still carries yesterday's total — reset owed.
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    # The real reset lands two polls later, after some accumulation.
+    freezer.tick(120)
+    assert _read(entity, mock_plant, 0.3) == 0.3
 
 
 async def test_monotonic_restore_skips_unusable_states(hass, mock_plant):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1120,6 +1120,25 @@ def test_monotonic_pending_reset_consumed_by_acceptance(mock_plant, freezer):
     assert _read(entity, mock_plant, 0.9) == 2.0
 
 
+def test_monotonic_pending_survives_negative_boundary_reading(mock_plant, freezer):
+    """A transient negative reading exactly at the date flip must not decide
+    the owed-reset question: the carry-over reappears on the next poll, and
+    the genuine reset after a later gap must still be admitted (review on
+    #163)."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    # The boundary poll itself is register skew gone negative.
+    freezer.tick(24 * 3600)
+    assert _read(entity, mock_plant, -1.0) == 0.0
+    # Next poll: yesterday's still-unreset total reappears — reset still owed.
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    # The owed reset lands after a two-hour gap, above the fixed floor.
+    freezer.tick(2 * 3600)
+    assert _read(entity, mock_plant, 1.8) == 1.8
+
+
 def test_monotonic_negative_still_rejected_after_poll_gap(mock_plant, freezer):
     """A widened ceiling never admits a negative excursion."""
     freezer.move_to("2026-06-12 12:00:00+00:00")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -981,3 +981,153 @@ def test_sensor_without_ir_source_keeps_default_availability(mock_plant):
     mock_plant.register_age = MagicMock()
     assert entity.available is True
     mock_plant.register_age.assert_not_called()
+
+
+# --- #142: monotonic clamp must not accept transient dips as counter resets ---
+
+
+def _monotonic_entity(mock_plant):
+    from datetime import timedelta
+
+    from custom_components.givenergy_local.sensor import GivEnergyInverterSensor
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.update_interval = timedelta(seconds=30)
+    coordinator.data = mock_plant
+    return GivEnergyInverterSensor(coordinator, _inverter_desc("e_consumption_today"))
+
+
+def _read(entity, mock_plant, value):
+    mock_plant.inverter.e_consumption_today = value
+    return entity.native_value
+
+
+def test_monotonic_clamp_holds_through_transient_dip(mock_plant, freezer):
+    """A transient register-skew dip — any size, any sign — must be held at the
+    previous max, not adopted as a 'reset' (#142: a one-poll zeroed PV read sank
+    the derived value to -2.2 / 1.4 and the recorder double-counted the
+    recovery as ~20 kWh of new consumption)."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    # The #142 excursion: negative dip held, never exposed.
+    assert _read(entity, mock_plant, -2.2) == 14.3
+    # A sag to a still-large value is no more plausible a reset.
+    assert _read(entity, mock_plant, 12.1) == 14.3
+    # Recovery is a plain increase — no fake reset, no double-count.
+    assert _read(entity, mock_plant, 14.5) == 14.5
+
+
+def test_monotonic_never_exposes_negative_baseline(mock_plant, freezer):
+    """A negative first/new-day reading floors the baseline at zero."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, -2.2) == 0.0
+    assert _read(entity, mock_plant, 0.4) == 0.4
+
+    # Negative skew spanning the day boundary: the new-day baseline is floored.
+    freezer.tick(24 * 3600)
+    assert _read(entity, mock_plant, -1.0) == 0.0
+
+
+def test_monotonic_zero_baseline_small_dip(mock_plant, freezer):
+    """Falsy-zero regression: with a 0.0 baseline, a sub-threshold dip used to
+    slip through `self._monotonic_max or value` and expose a negative."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 0.0) == 0.0
+    assert _read(entity, mock_plant, -0.3) == 0.0
+    assert _read(entity, mock_plant, 0.2) == 0.2
+
+
+def test_monotonic_midnight_reset_passes(mock_plant, freezer):
+    """The genuine midnight reset still passes through as a real decrease."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 21.4) == 21.4
+    freezer.tick(24 * 3600)
+    assert _read(entity, mock_plant, 0.1) == 0.1
+
+
+def test_monotonic_clock_lag_reset_after_date_flip(mock_plant, freezer):
+    """An inverter clock lagging HA's midnight: the pre-reset value carries over
+    as the new-day baseline, and the real reset lands a poll later via the
+    magnitude branch — gated on a plausible post-reset value."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 21.4) == 21.4
+    # HA's date flips first; the counter hasn't reset yet.
+    freezer.tick(24 * 3600)
+    assert _read(entity, mock_plant, 21.4) == 21.4
+    # The actual reset arrives on the next poll.
+    assert _read(entity, mock_plant, 0.05) == 0.05
+    # Counting resumes from the new baseline.
+    assert _read(entity, mock_plant, 0.3) == 0.3
+
+
+async def test_monotonic_restore_floors_negative(hass, mock_plant):
+    """A persisted negative state (recorded by pre-fix versions) must not
+    re-seed a negative baseline after restart."""
+    from unittest.mock import AsyncMock
+
+    from homeassistant.core import State
+
+    entity = _monotonic_entity(mock_plant)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_house_consumption_today"
+    entity.async_get_last_state = AsyncMock(return_value=State(entity.entity_id, "-2.2"))
+    await entity.async_added_to_hass()
+
+    assert entity._monotonic_max == 0.0
+    assert _read(entity, mock_plant, -0.3) == 0.0
+
+
+async def test_monotonic_restore_seeds_same_day_max(hass, mock_plant):
+    """A same-day persisted value seeds the intra-day max, so a transient dip
+    on the first post-restart poll is held rather than adopted."""
+    from unittest.mock import AsyncMock
+
+    from homeassistant.core import State
+
+    entity = _monotonic_entity(mock_plant)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_house_consumption_today"
+    entity.async_get_last_state = AsyncMock(return_value=State(entity.entity_id, "13.7"))
+    await entity.async_added_to_hass()
+
+    assert entity._monotonic_max == 13.7
+    # A >threshold drop to a still-large value is rejected by the reset gate.
+    assert _read(entity, mock_plant, 12.1) == 13.7
+    assert _read(entity, mock_plant, 13.8) == 13.8
+
+
+async def test_monotonic_restore_skips_unusable_states(hass, mock_plant):
+    """Non-numeric or prior-day persisted states must not seed the baseline."""
+    from datetime import timedelta
+    from unittest.mock import AsyncMock
+
+    from homeassistant.core import State
+    from homeassistant.util import dt as dt_util
+
+    entity = _monotonic_entity(mock_plant)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_house_consumption_today"
+    entity.async_get_last_state = AsyncMock(return_value=State(entity.entity_id, "unavailable"))
+    await entity.async_added_to_hass()
+    assert entity._monotonic_max is None
+
+    yesterday = dt_util.utcnow() - timedelta(days=1)
+    entity = _monotonic_entity(mock_plant)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_house_consumption_today"
+    entity.async_get_last_state = AsyncMock(
+        return_value=State(entity.entity_id, "13.7", last_updated=yesterday)
+    )
+    await entity.async_added_to_hass()
+    assert entity._monotonic_max is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1139,6 +1139,40 @@ def test_monotonic_pending_survives_negative_boundary_reading(mock_plant, freeze
     assert _read(entity, mock_plant, 1.8) == 1.8
 
 
+def test_monotonic_deferred_decision_skips_ambiguous_sag(mock_plant, freezer):
+    """While the owed-reset question is deferred past a skewed boundary
+    reading, an ambiguous still-large sag (neither carry-over nor a plausible
+    reset) must not settle it — nor be exposed. A later plausible poll makes
+    the call (review on #163)."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    freezer.tick(24 * 3600)
+    assert _read(entity, mock_plant, -1.0) == 0.0  # boundary skew: undecided
+    assert _read(entity, mock_plant, 12.1) == 0.0  # ambiguous sag: held, still undecided
+    assert _read(entity, mock_plant, 14.3) == 14.3  # carry-over: reset owed
+    freezer.tick(2 * 3600)
+    assert _read(entity, mock_plant, 1.8) == 1.8  # owed reset admitted
+
+
+def test_monotonic_deferred_decision_settles_on_plausible_reset(mock_plant, freezer):
+    """The other arm of the deferred call: after boundary skew, a reading in
+    the (elapsed-scaled) reset band means the reset happened during the skew
+    window — decided as seen, counting resumes."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    freezer.tick(24 * 3600)
+    assert _read(entity, mock_plant, -1.0) == 0.0
+    assert _read(entity, mock_plant, 0.2) == 0.2  # plausible post-reset: decided
+    # The band is now back at the floor: a later still-large sag stays held.
+    freezer.tick(2 * 3600)
+    assert _read(entity, mock_plant, 5.0) == 5.0  # normal accumulation
+    assert _read(entity, mock_plant, 3.0) == 5.0  # still-large sag clamped
+
+
 def test_monotonic_negative_still_rejected_after_poll_gap(mock_plant, freezer):
     """A widened ceiling never admits a negative excursion."""
     freezer.move_to("2026-06-12 12:00:00+00:00")


### PR DESCRIPTION
Follow-up to #142 — @holdestmade reported the recorder warning recurring on v1.3.0, this time with a *negative* state (−2.2).

**What's actually happening**
The monotonic clamp on `House Consumption Today` treats any same-day drop > 0.5 kWh as a genuine counter reset and accepts it verbatim. That branch exists for an inverter clock lagging HA's midnight by a poll cycle, but it also waves through transient register-skew excursions. I reproduced it on my own install the same day as the report: a one-poll zeroed register read sank the derived consumption from 22.1 to 1.4, the clamp accepted it as a "reset", and the recorder double-counted the recovery as ~21 kWh of new consumption in the long-term statistics. When the skew composition pushes the value below zero — as on holdestmade's install — HA's `total_increasing` guard also fires the warning. The warning is the visible symptom; the silent sum corruption is the real damage.

**The fix**
A same-day drop is now accepted as a reset only when the new value lands in [0, 0.5 kWh] — where a real reset observed within a poll or two always lands (even 20 kW for 30 s accumulates ~0.17 kWh). Anything else holds the previous max until the source recovers, so the recorder never sees a fake reset. Negative values can no longer become the baseline on any path: day flip, the max-clamp branch (which had a falsy-zero bug: a sub-threshold dip off a 0.0 baseline was returned unclamped), or restart restore of a state persisted by pre-fix versions.

The upstream cause — implausible zeroed register reads committing into the plant model — is a givenergy-modbus matter, raised with the library separately. This change makes the one sensor with derived-value exposure robust regardless.

**Verification**
Eight new tests: the #142 reproduction (negative and still-large dips held, recovery not double-counted), negative-baseline flooring on first read/day-flip/restore, the falsy-zero regression, and pins on the behaviours that must not break — midnight reset, clock-lag reset via the gated branch, same-day restore seeding. Full suite green (273), mypy strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)