### PR TITLE
fix(deps): bump givenergy-modbus to 2.3.1

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.3.0,<3.0.0"
+    "givenergy-modbus>=2.3.1,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.3.0,<3.0.0",
+    "givenergy-modbus>=2.3.1,<3.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -929,7 +929,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.3.0,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.3.1,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -942,16 +942,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.3.0"
+version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/7a/c568b35a1d1cff87e5c4f617c4f6e0fd01eb1280024575180122290ce5b9/givenergy_modbus-2.3.0.tar.gz", hash = "sha256:78fc88146739c92b0df1a06db150daaeaf086f05d813eff45be602e48363b1a0", size = 381348, upload-time = "2026-06-11T23:19:17.913Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/0f/417da42f403947e6de66b29a8dd6d8f83c3838441ad19a595e12a16b269d/givenergy_modbus-2.3.1.tar.gz", hash = "sha256:dae2873cb37c1537f2e737dc56ae9bebf3a1303fe53b38e4bb0504b1cf758b89", size = 390018, upload-time = "2026-06-12T20:37:48.595Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/04/0025d3f0fdca3e89938b67721486a8aa2124a17f16786baf1a154aafd675/givenergy_modbus-2.3.0-py3-none-any.whl", hash = "sha256:4f2a27e0e26cffe0cd5492263e10f36ca17fed3dc3ff08ec245a8b6def38f71a", size = 144017, upload-time = "2026-06-11T23:19:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8d/dae19b6753554ed278f523cd46f4d1a5cf90c9094a8fd6519b0d3633d822/givenergy_modbus-2.3.1-py3-none-any.whl", hash = "sha256:079a6de969452032a9551853c7a759c27659266f4792dc58e0b4c5cbb8a33ee3", size = 148691, upload-time = "2026-06-12T20:37:47.267Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated bump triggered by [givenergy-modbus@2.3.1](https://github.com/dewet22/givenergy-modbus/releases/tag/v2.3.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying dependencies to maintain stability and ensure optimal performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->