### PR TITLE
fix: resolve blocking importlib.metadata call in the capture header

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -271,6 +271,17 @@ async def _async_register_frontend_card(hass: HomeAssistant) -> None:
         _LOGGER.warning("Could not register the bundled frontend module: %s", exc)
 
 
+def _givenergy_modbus_version() -> str:
+    """Installed givenergy-modbus version, "unknown" if unresolvable.
+
+    Blocking (reads dist-info from disk) — call via the executor.
+    """
+    try:
+        return importlib.metadata.version("givenergy-modbus")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
 async def _build_capture_header(
     hass: HomeAssistant, *, generated: datetime, duration: float, frame_count: int
 ) -> str:
@@ -282,10 +293,9 @@ async def _build_capture_header(
     shared diagnostics (those are recoverable from the wire frames by anyone with
     a parser anyway).
     """
-    try:
-        library_version = importlib.metadata.version("givenergy-modbus")
-    except importlib.metadata.PackageNotFoundError:
-        library_version = "unknown"
+    # Package-metadata lookup reads dist-info off disk — executor, not loop
+    # (HA's blocking-call detector flags it otherwise).
+    library_version = await hass.async_add_executor_job(_givenergy_modbus_version)
     integration = await async_get_integration(hass, DOMAIN)
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     lines = [

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -82,6 +82,29 @@ async def test_build_capture_header_contains_env_and_no_serial(hass):
     assert "SA1234G123" not in header
 
 
+async def test_build_capture_header_version_lookup_off_loop(hass):
+    """The package-metadata lookup does blocking filesystem I/O and must run
+    in the executor, not on the event loop — HA's blocking-call detector
+    flags it (three warnings per capture) and asks users to file a bug."""
+    import threading
+    from unittest.mock import patch
+
+    loop_thread = threading.get_ident()
+    seen: dict[str, int] = {}
+
+    def _fake_version(_name: str) -> str:
+        seen["thread"] = threading.get_ident()
+        return "9.9.9"
+
+    with patch("importlib.metadata.version", _fake_version):
+        header = await _build_capture_header(
+            hass, generated=dt_util.now(), duration=1.0, frame_count=0
+        )
+
+    assert "givenergy-modbus 9.9.9" in header
+    assert seen["thread"] != loop_thread
+
+
 def test_split_header_separates_env_block_from_body():
     content = "# GivEnergy\n# Generated: x\n#\nTX: 0102\nRX: 0304\n"
     header, body = _split_header(content)

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -86,13 +86,20 @@ async def test_build_capture_header_version_lookup_off_loop(hass):
     """The package-metadata lookup does blocking filesystem I/O and must run
     in the executor, not on the event loop — HA's blocking-call detector
     flags it (three warnings per capture) and asks users to file a bug."""
+    import importlib.metadata
     import threading
     from unittest.mock import patch
 
     loop_thread = threading.get_ident()
     seen: dict[str, int] = {}
+    orig_version = importlib.metadata.version
 
-    def _fake_version(_name: str) -> str:
+    def _fake_version(name: str) -> str:
+        # Delegate other packages to the real lookup — the patch is global
+        # for the duration of the block, and unrelated metadata lookups
+        # (e.g. from the integration loader) must not see the fake.
+        if name != "givenergy-modbus":
+            return orig_version(name)
         seen["thread"] = threading.get_ident()
         return "9.9.9"
 


### PR DESCRIPTION
The capture-header builder looked up the installed givenergy-modbus version with `importlib.metadata.version()` directly on the event loop. The lookup reads dist-info off disk, so HA's blocking-call detector logged three warnings per `capture_frames` invocation (listdir/read_text/open) and asked users to file a bug — spotted in the wild during last night's capture session.

The lookup now runs via `hass.async_add_executor_job`, with a regression test asserting it executes off the loop thread. No behaviour change otherwise; the "unknown" fallback for an unresolvable package is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)