### PR TITLE
fix: adopt givenergy-modbus 2.3.3 + gate Battery Temperature on three-phase (#174)

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.3.2,<3.0.0"
+    "givenergy-modbus>=2.3.3,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -391,6 +391,11 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda inv: inv.t_battery,
+        # Three-phase units inherit this single-phase register address but their
+        # firmware never populates it, so it reads frozen rather than unavailable
+        # (#174). Real 3ph battery temperature comes from the HV cluster
+        # (Bcu.cluster_cell_temperature) once HV-stack support lands (#179).
+        single_phase_only=True,
     ),
     GivEnergyInverterSensorDescription(
         # key kept (unique_id suffix); the library field was renamed to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.3.2,<3.0.0",
+    "givenergy-modbus>=2.3.3,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -96,10 +96,11 @@ def test_setup_filter_skips_bad_descriptor_instead_of_crashing():
 
 def test_single_phase_only_sensors_gated_on_three_phase():
     """single_phase_only descriptions are dropped on three-phase plants but kept on
-    single-phase — otherwise the single-phase-only PV/capacity fields surface as
-    permanently-unavailable orphan entities on three-phase inverters (#94)."""
+    single-phase — the single-phase-only PV/capacity fields would otherwise surface as
+    permanently-unavailable orphan entities on three-phase inverters (#94), and
+    t_battery would read a frozen, unpopulated single-phase register there (#174)."""
     inv = MagicMock()
-    gated_keys = {"p_pv", "e_pv_day", "battery_capacity_kwh"}
+    gated_keys = {"p_pv", "e_pv_day", "battery_capacity_kwh", "t_battery"}
 
     # Every gated key must actually carry the flag (guards against silent drift if
     # one is renamed/removed) ...
@@ -154,9 +155,11 @@ async def test_expected_sensor_count(hass, setup_integration):
 async def test_single_phase_only_sensors_absent_on_three_phase(
     hass, mock_client, mock_config_entry
 ):
-    """On a three-phase plant the single-phase-only PV/capacity sensors must not be
-    created — otherwise they render as permanently-unavailable orphans (#94). The
-    default (single-phase) fixture keeps them, asserted by test_expected_sensor_count.
+    """On a three-phase plant the single-phase-only PV/capacity/battery-temperature
+    sensors must not be created — the PV/capacity ones would render as
+    permanently-unavailable orphans (#94), and t_battery reads a frozen, unpopulated
+    single-phase register on three-phase (#174). The default (single-phase) fixture
+    keeps them, asserted by test_expected_sensor_count.
     """
     from givenergy_modbus.model.inverter import Model
     from givenergy_modbus.model.plant import PlantCapabilities
@@ -174,7 +177,7 @@ async def test_single_phase_only_sensors_absent_on_three_phase(
     await hass.async_block_till_done()
 
     registry = er.async_get(hass)
-    for key in ("p_pv", "e_pv_day", "battery_capacity_kwh"):
+    for key in ("p_pv", "e_pv_day", "battery_capacity_kwh", "t_battery"):
         assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is None, (
             f"{key} should be suppressed on three-phase"
         )

--- a/uv.lock
+++ b/uv.lock
@@ -929,7 +929,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.3.2,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.3.3,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -942,16 +942,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.3.2"
+version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/67/a3c989c2e9a106c6e708166e089584ed59fd17823e0531b121c9839020d2/givenergy_modbus-2.3.2.tar.gz", hash = "sha256:a6c623c25b0c05c2dd8673de1ed6abf5f06b71e908ce1b7a05385ed7e433fb29", size = 407320, upload-time = "2026-06-14T16:50:49.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/40/217dc2758f30d22b0947d2ffdc5cfa75cd863c272ba2bbd43b4a4d6a98ef/givenergy_modbus-2.3.3.tar.gz", hash = "sha256:1959e5fba2f1ddc999cbccbf42d972b6f24d52f8e7fc9575b3342b9a3df2b12b", size = 409633, upload-time = "2026-06-17T12:40:02.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/5d/288f4aad7e877b234166b50c1d41527d969e138d27f30a7666bbc20c0e58/givenergy_modbus-2.3.2-py3-none-any.whl", hash = "sha256:20b95732543aacb79b581646ca7e6b1cd2c0f7020a28e147b0ec6afa0a98f763", size = 154734, upload-time = "2026-06-14T16:50:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7a/f7a99e84f5ce57ff62daeef234cd41b09bc9feba0d2669154ae8376f1397/givenergy_modbus-2.3.3-py3-none-any.whl", hash = "sha256:d3ab6059bd103ab5ff3a0846ec43b34167d72809110947fb0dc23d0588498025", size = 155584, upload-time = "2026-06-17T12:40:00.552Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts givenergy-modbus 2.3.3 and completes the three-phase inverter-level battery sensors for #174.

**The dependency bump (auto-generated)** corrects three of the four 3ph battery sensors at the library level, so they need no integration change:
- **Battery Power** and **Battery Throughput** now read the native three-phase registers (the #262 facade) instead of the frozen inherited single-phase ones.
- **Battery Current**'s 10× scale is fixed (#264).

**The added commit** handles the fourth: **Battery Temperature** (`t_battery`) has no inverter-level three-phase source — on 3ph it inherits a single-phase register the firmware never populates, so it reads frozen. It's now `single_phase_only`, dropped on three-phase rather than surfacing a stale value. The real 3ph battery temperature will come from the HV cluster (`Bcu.cluster_cell_temperature`) once HV-stack support lands (#179). Single-phase users are unaffected (the gate fires only on three-phase).

Addresses the battery-sensor part of #174; the dashboard and per-pack HV work are tracked separately (#179).
