### PR TITLE
ci: surface deprecation warnings (non-blocking) + migrate off deprecated set_charge_target

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -77,7 +77,7 @@ jobs:
       # alarm. Real test failures are absorbed here (they fail `tests`).
       - name: Surface deprecation warnings
         run: |
-          uv run pytest -q -W always::DeprecationWarning 2>&1 | tee dep.log || true
+          uv run pytest -q -W always::DeprecationWarning -W always::PendingDeprecationWarning 2>&1 | tee dep.log || true
           if grep -iE "DeprecationWarning|PendingDeprecationWarning" dep.log >/dev/null; then
             count=$(grep -icE "DeprecationWarning|PendingDeprecationWarning" dep.log)
             echo "::warning title=Deprecation warnings ($count)::Deprecated APIs are in use — migrate before upstream removes them (see log below)."

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -60,6 +60,32 @@ jobs:
       - run: uv sync
       - run: uv run pytest
 
+  deprecations:
+    name: deprecation watch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+        with:
+          enable-cache: true
+      - run: uv sync
+      # Non-blocking: surface (don't gate on) deprecation warnings so an upcoming
+      # upstream API removal can't catch us out. Emits a GitHub warning annotation
+      # if any fire, then exits 0 — the `tests` job owns gating, this is just an
+      # alarm. Real test failures are absorbed here (they fail `tests`).
+      - name: Surface deprecation warnings
+        run: |
+          uv run pytest -q -W always::DeprecationWarning 2>&1 | tee dep.log || true
+          if grep -iE "DeprecationWarning|PendingDeprecationWarning" dep.log >/dev/null; then
+            count=$(grep -icE "DeprecationWarning|PendingDeprecationWarning" dep.log)
+            echo "::warning title=Deprecation warnings ($count)::Deprecated APIs are in use — migrate before upstream removes them (see log below)."
+            grep -iE "DeprecationWarning|PendingDeprecationWarning" dep.log | sort -u
+          else
+            echo "No deprecation warnings — clean."
+          fi
+
   js-tests:
     name: js tests
     runs-on: ubuntu-latest

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -34,7 +34,7 @@ NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
         native_step=1,
         mode=NumberMode.BOX,
         value_fn=lambda inv: inv.charge_target_soc,
-        set_value_cmd=lambda v: commands.set_charge_target(int(v)),
+        set_value_cmd=lambda v: commands.set_charge_target_enabled(int(v)),
         entity_category=EntityCategory.CONFIG,
     ),
     GivEnergyNumberEntityDescription(


### PR DESCRIPTION
Two-part deprecation hygiene, prompted by Codex noting (non-blocking, on #180) that `number.py` still calls the deprecated `set_charge_target`.

## The problem
That `DeprecationWarning` has been firing on every test run, unnoticed — and nothing flags it: pytest has no `filterwarnings`, CI runs plain `pytest`, and mypy can't see a runtime `warnings.warn`. So it would stay invisible until givenergy-modbus actually removes the alias, breaking at runtime with no prior signal.

## Changes
1. **Migrate the call** — `commands.set_charge_target(...)` → `set_charge_target_enabled(...)` (the deprecation message's named drop-in; same `target_soc` argument). The existing test asserts only that a command is sent, so behaviour is unchanged. Clears the sole deprecation in the suite → clean baseline.
2. **Non-blocking `deprecation watch` CI job** — runs the suite surfacing all `DeprecationWarning`s and emits a GitHub warning annotation if any fire, then exits 0. It never gates (the `tests` job owns that) — a smoke alarm, not a lock. With the baseline now at zero, the next deprecation (ours or HA core's) shows up loud and isolated at adoption time, with runway before the API is removed.

No behaviour change for users; no test changes needed.
