### PR TITLE
fix: coordinator robustness + battery staleness gate (#176)

### DIFF
--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -441,40 +441,54 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         — required for three-phase, AIO-HV, EMS and other non-default topologies.
         """
         self._client = Client(host=self.host, port=self.port)
-        await self._client.connect()
-        topology_confirmed = True
         try:
-            # The library's battery sweep probes additional packs (0x33+) with a
-            # stingy default budget (probe_timeout=0.5s, probe_retries=1) and
-            # BREAKS at the first non-responding slot — so a single transiently
-            # slow BMS during a reconnect truncates the whole battery chain, and
-            # that reduced topology then gets persisted (a 2nd battery silently
-            # vanished after a reconnect this way). Because of the break, a detect
-            # probes at most one empty slot, so a generous probe budget costs only
-            # ~one extra slow probe on a cold sweep — cheap insurance against
-            # dropping a real pack.
-            await self._client.detect(
-                prior=self._prior_capabilities,
-                probe_timeout=PROBE_TIMEOUT_SECONDS,
-                probe_retries=PROBE_RETRIES,
-            )
-        except PlantTopologyMismatch as exc:
-            topology_confirmed = await self._handle_topology_mismatch(exc)
-        if self._client is None:
-            # The entry was unloaded/reloaded while _handle_topology_mismatch
-            # yielded (retry sleeps) and async_close() discarded the client —
-            # nothing to confirm against, we're shutting down.
-            return
-        confirmed = self._client.plant.capabilities
-        if topology_confirmed and self._on_topology_healed is not None and confirmed is not None:
-            # Full expected topology is present — let the caller clear any
-            # stale "device missing" repair and reconcile entities against the
-            # confirmed topology (covers both restart and mid-session recovery).
-            await self._on_topology_healed(confirmed)
-        self._last_inverter_time = None
-        self._unchanged_ticks = 0
-        self._active_tick = 0
-        _LOGGER.info("Connected to inverter at %s:%s", self.host, self.port)
+            await self._client.connect()
+            topology_confirmed = True
+            try:
+                # The library's battery sweep probes additional packs (0x33+) with a
+                # stingy default budget (probe_timeout=0.5s, probe_retries=1) and
+                # BREAKS at the first non-responding slot — so a single transiently
+                # slow BMS during a reconnect truncates the whole battery chain, and
+                # that reduced topology then gets persisted (a 2nd battery silently
+                # vanished after a reconnect this way). Because of the break, a detect
+                # probes at most one empty slot, so a generous probe budget costs only
+                # ~one extra slow probe on a cold sweep — cheap insurance against
+                # dropping a real pack.
+                await self._client.detect(
+                    prior=self._prior_capabilities,
+                    probe_timeout=PROBE_TIMEOUT_SECONDS,
+                    probe_retries=PROBE_RETRIES,
+                )
+            except PlantTopologyMismatch as exc:
+                topology_confirmed = await self._handle_topology_mismatch(exc)
+            if self._client is None:
+                # The entry was unloaded/reloaded while _handle_topology_mismatch
+                # yielded (retry sleeps) and async_close() discarded the client —
+                # nothing to confirm against, we're shutting down.
+                return
+            confirmed = self._client.plant.capabilities
+            if (
+                topology_confirmed
+                and self._on_topology_healed is not None
+                and confirmed is not None
+            ):
+                # Full expected topology is present — let the caller clear any
+                # stale "device missing" repair and reconcile entities against the
+                # confirmed topology (covers both restart and mid-session recovery).
+                await self._on_topology_healed(confirmed)
+            self._last_inverter_time = None
+            self._unchanged_ticks = 0
+            self._active_tick = 0
+            _LOGGER.info("Connected to inverter at %s:%s", self.host, self.port)
+        except Exception:
+            # connect()/detect() failed before capabilities were established (a
+            # PlantTopologyMismatch is handled above and doesn't reach here). Discard
+            # the half-initialised client so the next tick reconnects and re-detects
+            # cleanly — a connected-but-capability-less client would otherwise be kept
+            # by the timeout-tolerance path, and its next refresh() raises
+            # PlantNotDetected ("requires plant capabilities") (#176).
+            await self._reset_client()
+            raise
 
     async def _handle_topology_mismatch(self, exc: PlantTopologyMismatch) -> bool:
         """Resolve a detect() topology mismatch.

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -487,13 +487,15 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
             self._unchanged_ticks = 0
             self._active_tick = 0
             _LOGGER.info("Connected to inverter at %s:%s", self.host, self.port)
-        except Exception:
+        except BaseException:
             # connect()/detect() failed before capabilities were established (a
             # PlantTopologyMismatch is handled above and doesn't reach here). Discard
             # the half-initialised client so the next tick reconnects and re-detects
             # cleanly — a connected-but-capability-less client would otherwise be kept
             # by the timeout-tolerance path, and its next refresh() raises
-            # PlantNotDetected ("requires plant capabilities") (#176).
+            # PlantNotDetected ("requires plant capabilities") (#176). BaseException,
+            # not Exception, so a CancelledError (HA cancelling the connect mid-flight)
+            # also cleans up rather than leaking the client; re-raised either way.
             await self._reset_client()
             raise
 

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -173,7 +173,14 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         self.partial_failures: int = 0
         # The ReadFailure records from the most recent partial poll, surfaced as
         # a diagnostic sensor attribute so users can see *which* device dropped.
+        # Deliberately NOT cleared by a subsequent clean poll (#176): an
+        # intermittent failure would otherwise be un-diagnosable after the fact —
+        # the detail must outlive the recovery so the sensor can still name the
+        # bank that dropped, paired with last_partial_at below.
         self.last_partial_failures: list[ReadFailure] = []
+        # When the most recent partial poll occurred (UTC), retained alongside
+        # last_partial_failures so the diagnostic sensor can show how long ago.
+        self.last_partial_at: datetime | None = None
         # Length of the current unbroken run of partial polls, used only to
         # throttle the partial log (see _record_partial). Reset by a clean poll.
         self._consecutive_partials: int = 0
@@ -211,11 +218,10 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                 else await self._active_update()
             )
 
-            # A fully clean poll — clear any stale partial-failure detail so the
-            # diagnostic sensor stops naming devices that have since recovered,
-            # and end the partial run so the next one warns afresh.
-            # (The cumulative partial_failures counter is left untouched.)
-            self.last_partial_failures = []
+            # A fully clean poll ends the partial run so the next one warns afresh.
+            # The last_partial_failures detail and last_partial_at are deliberately
+            # retained (#176) so the diagnostic sensor can still name the bank that
+            # dropped after an intermittent failure has recovered.
             self._consecutive_partials = 0
             self._mark_success(plant)
             return plant
@@ -309,6 +315,7 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         """
         self.partial_failures += 1
         self.last_partial_failures = exc.failures
+        self.last_partial_at = dt_util.utcnow()
         self._consecutive_partials += 1
         if self._consecutive_partials == 1:
             _LOGGER.warning(

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1091,12 +1091,14 @@ def _partial_failure_attributes(
     """Summarise the most recent partial poll's failed reads for the UI.
 
     Names the device(s) that dropped (e.g. "0x34" for a battery) plus the
-    per-bank detail, so a flaky device can be identified even though its
-    entities stay available with stale data.
+    per-bank detail and when it last happened, so a flaky device can be
+    identified even after the poll has recovered (the detail is retained past
+    a clean poll — #176).
     """
     failures = coordinator.last_partial_failures
     if not failures:
         return None
+    last_partial_at = coordinator.last_partial_at
     return {
         "last_failed_devices": sorted({f"0x{f.device_address:02x}" for f in failures}),
         "last_failure_count": len(failures),
@@ -1106,6 +1108,7 @@ def _partial_failure_attributes(
             f"@ {f.base_register}+{f.register_count}"
             for f in failures
         ],
+        "last_partial_at": last_partial_at.isoformat() if last_partial_at else None,
     }
 
 

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1523,6 +1523,12 @@ class GivEnergyBatterySensor(CoordinatorEntity[GivEnergyUpdateCoordinator], Sens
         self.entity_description = description
         self._battery_index = battery_index
         battery = coordinator.data.batteries[battery_index]
+        self._source_ir_registers = _source_ir_registers(type(battery), description.key)
+        interval = coordinator.update_interval
+        self._stale_ir_ceiling = max(
+            _STALE_IR_CEILING_FLOOR,
+            _STALE_IR_CEILING_SCANS * (interval.total_seconds() if interval else 0.0),
+        )
         precision = _derive_display_precision(description, battery)
         if precision is not None:
             self._attr_suggested_display_precision = precision
@@ -1536,6 +1542,31 @@ class GivEnergyBatterySensor(CoordinatorEntity[GivEnergyUpdateCoordinator], Sens
             serial_number=serial,
             via_device=(DOMAIN, coordinator.data.inverter_serial_number),
         )
+
+    @property
+    def available(self) -> bool:
+        """Drop to unavailable when this pack's IR bank has stopped committing (#152).
+
+        Mirrors the inverter gate (#152): when the library holds last-good on a
+        sub-bus splice (#256), the battery bank stops being re-stamped and its
+        register_age() grows — past the ceiling the pack's sensors go unavailable
+        instead of showing a confidently-wrong frozen value (the #176 case). A
+        sensor with no resolvable IR source keeps the default coordinator
+        availability, as does a never-committed bank.
+        """
+        if not super().available:
+            return False
+        if not self._source_ir_registers:
+            return True
+        capabilities = self.coordinator.data.capabilities
+        if capabilities is None or self._battery_index >= len(capabilities.lv_battery_addresses):
+            return True
+        address = capabilities.lv_battery_addresses[self._battery_index]
+        for register in self._source_ir_registers:
+            age = self.coordinator.data.register_age(address, register)
+            if age is not None and age > self._stale_ir_ceiling:
+                return False
+        return True
 
     @property
     def native_value(self) -> Any:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
 """Tests for the GivEnergy Local coordinator."""
 
+import asyncio
 import logging
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
@@ -208,6 +209,28 @@ async def test_detect_timeout_on_reconnect_discards_client(hass, mock_plant):
         assert result is mock_plant
         assert coordinator._client is client
         assert coordinator.consecutive_failures == 0
+
+
+async def test_cancelled_connect_discards_client(hass, mock_plant):
+    """A cancellation during _connect() (HA cancelling the attempt) must still
+    discard the half-initialised client. CancelledError is a BaseException, not
+    Exception, so the cleanup boundary has to catch it too — and re-raise the
+    cancellation. Regression for #176 review (Codex/Gemini)."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+    coordinator.data = mock_plant
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.detect.side_effect = asyncio.CancelledError()
+        mock_cls.return_value = client
+
+        with pytest.raises(asyncio.CancelledError):
+            await coordinator._async_update_data()
+
+    assert coordinator._client is None  # cleaned up despite the cancellation
+    client.close.assert_awaited_once()  # _reset_client() ran
 
 
 async def test_timeout_increments_consecutive_failures(hass):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -172,6 +172,44 @@ async def test_timeout_reaching_tolerance_resets_client(hass, mock_plant):
         assert coordinator._client is None
 
 
+async def test_detect_timeout_on_reconnect_discards_client(hass, mock_plant):
+    """A reconnect whose detect() times out must not retain a capability-less client.
+
+    Otherwise the next tick skips _connect() (the socket still reports connected),
+    calls refresh() with capabilities=None, and the library raises PlantNotDetected.
+    The half-initialised client must be dropped so the next tick reconnects and
+    re-detects cleanly. Regression for #176.
+    """
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+    coordinator.data = mock_plant  # seed stale data so the tolerance path serves it
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.detect.side_effect = TimeoutError()
+        mock_cls.return_value = client
+
+        # Reconnect tick (_client is None): _connect() → detect() times out.
+        result = await coordinator._async_update_data()
+
+        assert result is mock_plant  # last-known served for this tick
+        assert coordinator._client is None  # the fix: don't retain a caps-less client
+        assert coordinator.consecutive_failures == 1
+        client.refresh.assert_not_called()  # never reached refresh on a caps-less client
+
+        # Next tick: detect() now succeeds → clean reconnect, no PlantNotDetected.
+        client.detect.side_effect = None
+        client.load_config = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+
+        result = await coordinator._async_update_data()
+
+        assert result is mock_plant
+        assert coordinator._client is client
+        assert coordinator.consecutive_failures == 0
+
+
 async def test_timeout_increments_consecutive_failures(hass):
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -434,9 +434,11 @@ async def test_partial_log_periodic_rewarn(hass, mock_plant, caplog):
     assert coordinator.partial_failures == _PARTIAL_LOG_EVERY
 
 
-async def test_clean_poll_clears_stale_partial_detail(hass, mock_plant):
-    """After a partial, a later clean poll clears last_partial_failures so the
-    diagnostic stops naming a recovered device — but the cumulative counter stays."""
+async def test_clean_poll_retains_partial_detail(hass, mock_plant):
+    """After a partial, a later clean poll RETAINS last_partial_failures and
+    last_partial_at so the diagnostic can still name the bank that dropped after
+    an intermittent failure recovers (#176). The throttle run still ends and the
+    cumulative counter is unaffected."""
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
 
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
@@ -449,9 +451,12 @@ async def test_clean_poll_clears_stale_partial_detail(hass, mock_plant):
 
         await coordinator._async_update_data()  # partial — detail populated
         assert coordinator.last_partial_failures
-        await coordinator._async_update_data()  # clean — detail cleared
+        assert coordinator.last_partial_at is not None
+        await coordinator._async_update_data()  # clean — detail retained
 
-    assert coordinator.last_partial_failures == []
+    assert coordinator.last_partial_failures  # retained past the clean poll
+    assert coordinator.last_partial_at is not None
+    assert coordinator._consecutive_partials == 0  # throttle run ended
     assert coordinator.partial_failures == 1  # counter is cumulative, retained
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -986,6 +986,88 @@ def test_sensor_without_ir_source_keeps_default_availability(mock_plant):
     mock_plant.register_age.assert_not_called()
 
 
+def _battery_desc(key: str):
+    return next(d for d in BATTERY_SENSORS if d.key == key)
+
+
+def test_battery_sensor_unavailable_when_backing_ir_block_stale(mock_plant):
+    """A battery's IR bank that stopped committing past the ceiling drops the
+    pack's sensors to unavailable — the path that catches the library keeping
+    last-good on a sub-bus splice (#176/#152). Freshness via Plant.register_age()."""
+    from datetime import timedelta
+
+    from givenergy_modbus.model.register import IR
+
+    from custom_components.givenergy_local.sensor import GivEnergyBatterySensor
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.update_interval = timedelta(seconds=30)
+    coordinator.data = mock_plant
+    entity = GivEnergyBatterySensor(coordinator, _battery_desc("soc"), 0)
+    # The conftest battery is a MagicMock with no register LUT, so inject the
+    # source registers the resolver would derive from the real Battery model.
+    entity._source_ir_registers = (IR(64),)
+    mock_plant.register_age = MagicMock()
+
+    # Fresh bank: available, and queried against the battery's device address.
+    mock_plant.register_age.return_value = 35.0
+    assert entity.available is True
+    (addr, reg) = mock_plant.register_age.call_args.args
+    assert addr == 0x32  # conftest capabilities.lv_battery_addresses[0]
+    assert (reg.reg_type, reg.index) == ("IR", 64)
+    # Bank stopped committing 10 minutes ago (ceiling at 30 s interval = 300 s).
+    mock_plant.register_age.return_value = 600.0
+    assert entity.available is False
+    # Never committed: stays available (its value reads None/unknown anyway).
+    mock_plant.register_age.return_value = None
+    assert entity.available is True
+    # Coordinator-level failure still wins regardless of bank ages.
+    mock_plant.register_age.return_value = 35.0
+    coordinator.last_update_success = False
+    assert entity.available is False
+
+
+def test_battery_sensor_without_ir_source_keeps_default_availability(mock_plant):
+    """A battery sensor whose key resolves to no IR registers never consults ages."""
+    from datetime import timedelta
+
+    from custom_components.givenergy_local.sensor import GivEnergyBatterySensor
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.update_interval = timedelta(seconds=30)
+    coordinator.data = mock_plant
+    entity = GivEnergyBatterySensor(coordinator, _battery_desc("soc"), 0)
+
+    assert entity._source_ir_registers == ()  # mock battery model has no LUT
+    mock_plant.register_age = MagicMock()
+    assert entity.available is True
+    mock_plant.register_age.assert_not_called()
+
+
+def test_battery_sensor_available_when_index_out_of_range(mock_plant):
+    """A pack index beyond the known battery addresses keeps default availability
+    (bounds guard) rather than indexing past the capabilities list."""
+    from datetime import timedelta
+
+    from givenergy_modbus.model.register import IR
+
+    from custom_components.givenergy_local.sensor import GivEnergyBatterySensor
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.update_interval = timedelta(seconds=30)
+    coordinator.data = mock_plant
+    entity = GivEnergyBatterySensor(coordinator, _battery_desc("soc"), 0)
+    entity._battery_index = 5  # beyond capabilities.lv_battery_addresses ([0x32])
+    entity._source_ir_registers = (IR(64),)
+    mock_plant.register_age = MagicMock()
+
+    assert entity.available is True
+    mock_plant.register_age.assert_not_called()
+
+
 # --- #142: monotonic clamp must not accept transient dips as counter resets ---
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the GivEnergy Local sensor platform."""
 
+from datetime import UTC
 from unittest.mock import MagicMock
 
 import pytest
@@ -391,6 +392,39 @@ async def test_diagnostic_sensors_available_during_coordinator_failure(
 async def test_partial_failures_starts_at_zero(hass, setup_integration):
     state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_partial_failures"))
     assert state.state == "0"
+
+
+def test_partial_failure_attributes_name_device_and_time():
+    """The diagnostic attributes name the dropped bank, count, per-bank detail and
+    when it last happened — retained past a clean poll so an intermittent failure
+    stays diagnosable (#176)."""
+    from datetime import datetime
+
+    from givenergy_modbus.exceptions import ReadFailure
+
+    from custom_components.givenergy_local.sensor import _partial_failure_attributes
+
+    coordinator = MagicMock()
+    coordinator.last_partial_failures = [
+        ReadFailure(
+            device_address=0x34,
+            request_type="ReadInputRegisters",
+            base_register=60,
+            register_count=60,
+        )
+    ]
+    stamp = datetime(2026, 6, 17, 12, 0, tzinfo=UTC)
+    coordinator.last_partial_at = stamp
+
+    attrs = _partial_failure_attributes(coordinator)
+    assert attrs["last_failed_devices"] == ["0x34"]
+    assert attrs["last_failure_count"] == 1
+    assert attrs["last_failures"] == ["0x34 ReadInputRegisters @ 60+60"]
+    assert attrs["last_partial_at"] == stamp.isoformat()
+
+    # No failures recorded → no attributes.
+    coordinator.last_partial_failures = []
+    assert _partial_failure_attributes(coordinator) is None
 
 
 async def test_partial_failures_increments_and_attributes_name_device(


### PR DESCRIPTION
Re-scoped #176 after Nick's diagnostic logs (the original "sustained partial freezes data forever" hypothesis didn't hold — his partials are intermittent and the real frozen-battery path is the modbus library holding last-good on a sub-bus splice, which it reports as success). Three independent fixes, one atomic commit each:

**Discard a half-initialised client on a failed reconnect.** A reconnect whose `detect()` timed out left a connected client with no capabilities attached; the timeout-tolerance path kept it, the next tick skipped `_connect()` (the socket still reported connected), and `refresh()` then raised `PlantNotDetected`. It self-healed after a couple of noisy ERROR ticks. `_connect()` now drops the client on any failure before capabilities are established, so the next tick reconnects and re-detects cleanly. `PlantTopologyMismatch` is still handled in-line and unaffected.

**Battery staleness gate (#152 follow-up).** Battery sensors had no staleness gate, so a held/frozen bank showed a confidently-wrong value indefinitely — the frozen-SOC symptom behind the reports. They now go unavailable once the backing IR bank stops committing past the same ceiling the inverter sensors already use (max 5 min / 10× scan interval), mirroring the existing inverter gate. AIO per-module sensors aren't covered yet: `AioBatteryModule` has no register-getter, so resolving its registers needs a library-side change first, which I'll raise separately.

**Retain partial-failure diagnostics.** The "Partial Refresh Failures" sensor used to forget which device dropped the moment a poll recovered, making intermittent failures un-diagnosable after the fact. It now retains the last detail plus a `last_partial_at` timestamp, so a recovered flaky device stays identifiable.

All TDD — each fix has a regression test. Full suite (332) + mypy + ruff green locally.

Re #176, #152.