### PR TITLE
feat: AIO-module staleness gate + shared _StaleIRGate mixin (#152)

### DIFF
--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1596,7 +1596,9 @@ class GivEnergyBatterySensor(
         return self.entity_description.value_fn(batteries[self._battery_index])
 
 
-class GivEnergyAioModuleSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity):
+class GivEnergyAioModuleSensor(
+    _StaleIRGate, CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity
+):
     """Per-cell sensor for one All-in-One removable battery module (#192).
 
     Each module is its own HA device, linked to the AIO inverter as parent via
@@ -1618,8 +1620,10 @@ class GivEnergyAioModuleSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], Se
         # is rebuilt every refresh from whichever module caches decoded, so indices
         # shift when a module drops out — resolving by serial keeps each entity tied
         # to its own module instead of cross-wiring to a neighbour's cell data.
-        serial = coordinator.data.aio_battery_modules[module_index].serial_number
+        module = coordinator.data.aio_battery_modules[module_index]
+        serial = module.serial_number
         self._module_serial = serial
+        self._init_stale_gate(coordinator, type(module), description.key)
         self._attr_unique_id = f"{serial}_{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
@@ -1642,8 +1646,15 @@ class GivEnergyAioModuleSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], Se
 
     @property
     def available(self) -> bool:
-        # Unavailable (not cross-wired) when this module is absent from the poll.
-        return super().available and self._module() is not None
+        # Unavailable (not cross-wired) when this module is absent from the poll,
+        # then — like the inverter/battery gates (#152) — when its own IR bank has
+        # stopped committing past the ceiling (a frozen/held module, #176).
+        module = self._module()
+        if not super().available or module is None:
+            return False
+        if not self._source_ir_registers:
+            return True
+        return not self._ir_bank_stale(module.module_address)
 
     @property
     def native_value(self) -> Any:

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1327,8 +1327,50 @@ def _source_ir_registers(model_cls: type, key: str) -> tuple[Register, ...]:
     return tuple(r for r in getter.registers_of(key) if r.reg_type == "IR")
 
 
+class _StaleIRGate:
+    """Marks a sensor unavailable when a backing input-register bank has stopped
+    committing past a ceiling (#152).
+
+    Shared by the inverter, battery and AIO-module sensors — each resolves its own
+    device address (the inverter's is fixed, the per-pack/per-module ones come from
+    capabilities or the module itself), while this mixin owns the register
+    resolution, the staleness ceiling, and the per-bank age check. Freshness comes
+    from the library's Plant.register_age() (2.3.0, #248), which scans the stamped
+    block windows generically. A held/rejected bank stops being re-stamped, so its
+    age grows past the ceiling and the device's sensors go unavailable instead of
+    showing a confidently-wrong frozen value (#176).
+    """
+
+    coordinator: GivEnergyUpdateCoordinator
+    _source_ir_registers: tuple[Register, ...]
+    _stale_ir_ceiling: float
+
+    def _init_stale_gate(
+        self, coordinator: GivEnergyUpdateCoordinator, model_cls: type, key: str
+    ) -> None:
+        self._source_ir_registers = _source_ir_registers(model_cls, key)
+        interval = coordinator.update_interval
+        self._stale_ir_ceiling = max(
+            _STALE_IR_CEILING_FLOOR,
+            _STALE_IR_CEILING_SCANS * (interval.total_seconds() if interval else 0.0),
+        )
+
+    def _ir_bank_stale(self, device_address: int) -> bool:
+        """True if any backing IR bank for ``device_address`` is older than the ceiling.
+
+        False when there is no resolvable IR source (computed / HR-backed fields) or
+        a bank was never committed — neither is a staleness signal.
+        """
+        plant = self.coordinator.data
+        for register in self._source_ir_registers:
+            age = plant.register_age(device_address, register)
+            if age is not None and age > self._stale_ir_ceiling:
+                return True
+        return False
+
+
 class GivEnergyInverterSensor(
-    CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity, RestoreEntity
+    _StaleIRGate, CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity, RestoreEntity
 ):
     _attr_has_entity_name = True
     entity_description: GivEnergyInverterSensorDescription
@@ -1345,13 +1387,10 @@ class GivEnergyInverterSensor(
         self._monotonic_last_read: datetime | None = None
         self._monotonic_reset_pending: bool | None = False
         self._monotonic_prior_day_value: float | None = None
-        self._source_ir_registers = _source_ir_registers(
-            type(coordinator.data.inverter), description.source_field or description.key
-        )
-        interval = coordinator.update_interval
-        self._stale_ir_ceiling = max(
-            _STALE_IR_CEILING_FLOOR,
-            _STALE_IR_CEILING_SCANS * (interval.total_seconds() if interval else 0.0),
+        self._init_stale_gate(
+            coordinator,
+            type(coordinator.data.inverter),
+            description.source_field or description.key,
         )
         precision = _derive_display_precision(description, coordinator.data.inverter)
         if precision is not None:
@@ -1397,14 +1436,7 @@ class GivEnergyInverterSensor(
 
     @property
     def available(self) -> bool:
-        """Drop to unavailable when a backing IR bank has stopped committing (#152).
-
-        Freshness comes from the library's Plant.register_age() (2.3.0, #248),
-        which scans the stamped block windows generically — which banks a
-        device serves varies by model and address. Sensors with no resolvable
-        IR source (computed fields, HR-backed config) keep the default
-        coordinator availability, as does a never-committed bank.
-        """
+        """Drop to unavailable when a backing IR bank has stopped committing (#152)."""
         if not super().available:
             return False
         if not self._source_ir_registers:
@@ -1412,11 +1444,7 @@ class GivEnergyInverterSensor(
         capabilities = self.coordinator.data.capabilities
         if capabilities is None:
             return True
-        for register in self._source_ir_registers:
-            age = self.coordinator.data.register_age(capabilities.inverter_address, register)
-            if age is not None and age > self._stale_ir_ceiling:
-                return False
-        return True
+        return not self._ir_bank_stale(capabilities.inverter_address)
 
     @property
     def native_value(self) -> Any:
@@ -1512,7 +1540,9 @@ class GivEnergyInverterSensor(
         return value
 
 
-class GivEnergyBatterySensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity):
+class GivEnergyBatterySensor(
+    _StaleIRGate, CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity
+):
     _attr_has_entity_name = True
     entity_description: GivEnergyBatterySensorDescription
 
@@ -1526,12 +1556,7 @@ class GivEnergyBatterySensor(CoordinatorEntity[GivEnergyUpdateCoordinator], Sens
         self.entity_description = description
         self._battery_index = battery_index
         battery = coordinator.data.batteries[battery_index]
-        self._source_ir_registers = _source_ir_registers(type(battery), description.key)
-        interval = coordinator.update_interval
-        self._stale_ir_ceiling = max(
-            _STALE_IR_CEILING_FLOOR,
-            _STALE_IR_CEILING_SCANS * (interval.total_seconds() if interval else 0.0),
-        )
+        self._init_stale_gate(coordinator, type(battery), description.key)
         precision = _derive_display_precision(description, battery)
         if precision is not None:
             self._attr_suggested_display_precision = precision
@@ -1550,12 +1575,9 @@ class GivEnergyBatterySensor(CoordinatorEntity[GivEnergyUpdateCoordinator], Sens
     def available(self) -> bool:
         """Drop to unavailable when this pack's IR bank has stopped committing (#152).
 
-        Mirrors the inverter gate (#152): when the library holds last-good on a
-        sub-bus splice (#256), the battery bank stops being re-stamped and its
-        register_age() grows — past the ceiling the pack's sensors go unavailable
-        instead of showing a confidently-wrong frozen value (the #176 case). A
-        sensor with no resolvable IR source keeps the default coordinator
-        availability, as does a never-committed bank.
+        Catches the library holding last-good on a sub-bus splice (#256): the bank
+        stops being re-stamped and ages past the ceiling, so the pack's sensors go
+        unavailable rather than showing a frozen value (the #176 case).
         """
         if not super().available:
             return False
@@ -1564,12 +1586,7 @@ class GivEnergyBatterySensor(CoordinatorEntity[GivEnergyUpdateCoordinator], Sens
         capabilities = self.coordinator.data.capabilities
         if capabilities is None or self._battery_index >= len(capabilities.lv_battery_addresses):
             return True
-        address = capabilities.lv_battery_addresses[self._battery_index]
-        for register in self._source_ir_registers:
-            age = self.coordinator.data.register_age(address, register)
-            if age is not None and age > self._stale_ir_ceiling:
-                return False
-        return True
+        return not self._ir_bank_stale(capabilities.lv_battery_addresses[self._battery_index])
 
     @property
     def native_value(self) -> Any:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1102,6 +1102,75 @@ def test_battery_sensor_available_when_index_out_of_range(mock_plant):
     mock_plant.register_age.assert_not_called()
 
 
+def _aio_desc(key: str):
+    return next(d for d in AIO_MODULE_SENSORS if d.key == key)
+
+
+def test_aio_module_sensor_unavailable_when_backing_ir_block_stale(mock_plant):
+    """An AIO module's IR bank that stopped committing past the ceiling drops its
+    cell sensors to unavailable, queried against the module's own device address
+    (#176/#152). Mirrors the LV-battery gate via AioBatteryModule.REGISTER_GETTER."""
+    from datetime import timedelta
+
+    from givenergy_modbus.model.register import IR
+
+    from custom_components.givenergy_local.sensor import GivEnergyAioModuleSensor
+
+    module = _mock_aio_module("HX2414G831", 0x50)
+    mock_plant.aio_battery_modules = [module]
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.update_interval = timedelta(seconds=30)
+    coordinator.data = mock_plant
+    entity = GivEnergyAioModuleSensor(coordinator, _aio_desc("v_cell_01"), 0)
+    # The mock module is a MagicMock with no register LUT, so inject the
+    # source registers the resolver would derive from the real model.
+    entity._source_ir_registers = (IR(60),)
+    mock_plant.register_age = MagicMock()
+
+    # Fresh bank: available, and queried against the module's own device address.
+    mock_plant.register_age.return_value = 35.0
+    assert entity.available is True
+    (addr, reg) = mock_plant.register_age.call_args.args
+    assert addr == 0x50  # module.module_address, not a positional capabilities lookup
+    assert (reg.reg_type, reg.index) == ("IR", 60)
+    # Bank stopped committing past the ceiling: unavailable.
+    mock_plant.register_age.return_value = 600.0
+    assert entity.available is False
+    # Never committed: stays available.
+    mock_plant.register_age.return_value = None
+    assert entity.available is True
+    # Module absent from the poll: unavailable regardless, and freshness isn't
+    # even consulted (the presence gate short-circuits).
+    mock_plant.aio_battery_modules = []
+    mock_plant.register_age.reset_mock()
+    mock_plant.register_age.return_value = 35.0
+    assert entity.available is False
+    mock_plant.register_age.assert_not_called()
+
+
+def test_aio_module_sensor_without_ir_source_keeps_default_availability(mock_plant):
+    """An AIO sensor whose key resolves to no IR registers never consults ages."""
+    from datetime import timedelta
+
+    from custom_components.givenergy_local.sensor import GivEnergyAioModuleSensor
+
+    module = _mock_aio_module("HX2414G831", 0x50)
+    mock_plant.aio_battery_modules = [module]
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.update_interval = timedelta(seconds=30)
+    coordinator.data = mock_plant
+    entity = GivEnergyAioModuleSensor(coordinator, _aio_desc("v_cell_01"), 0)
+
+    assert entity._source_ir_registers == ()  # mock module model has no LUT
+    mock_plant.register_age = MagicMock()
+    assert entity.available is True
+    mock_plant.register_age.assert_not_called()
+
+
 # --- #142: monotonic clamp must not accept transient dips as counter resets ---
 
 


### PR DESCRIPTION
Final piece of the #152 staleness work, now unblocked by givenergy-modbus 2.5.0 (modbus#273). Per-module AIO battery sensors now go unavailable when their backing IR bank stops committing — the same gate the inverter and battery sensors already use — so a frozen/held module reads unavailable instead of a confidently-wrong value, consistent with the #176 fix for LV packs.

The gate logic, previously duplicated across the inverter and battery sensors, is pulled into a shared `_StaleIRGate` mixin (register resolution + ceiling + `register_age()` check) — the inverter/battery refactor is behaviour-preserving.

HV `Bmu` per-module gating stays out of scope: those registers are stride-offset per module and need a different approach (gated on modbus#265, tied to #179).

Verified end-to-end against the real 2.5.0 `AioBatteryModule.REGISTER_GETTER` (`v_cell_01`→IR(60), `t_cell_24`→IR(113), `module_address`→() graceful). Full suite (335) + mypy + ruff green.

With this, the #152 staleness work and the re-scoped #176 are fully addressed — I'd propose closing both on merge.

Re #152, #176, #192.