### PR TITLE
fix(deps): bump givenergy-modbus to 2.5.1

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.5.0,<3.0.0"
+    "givenergy-modbus>=2.5.1,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.5.0,<3.0.0",
+    "givenergy-modbus>=2.5.1,<3.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -929,7 +929,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.0,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.1,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -942,16 +942,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.5.0"
+version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/a7/dedf26efa95ae39b10fca690d811dd0bf1385f0df41e224ed468b42b01b9/givenergy_modbus-2.5.0.tar.gz", hash = "sha256:c2e7c22e58faaca63e675b9e5fbd6f891ce81b881b94f907e0139afb46468f98", size = 422272, upload-time = "2026-06-17T23:32:13.546Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/45/e26f96d2a873a13ef3a3e85ad98879b07d2ff232dba26c89ad131e2e3a43/givenergy_modbus-2.5.1.tar.gz", hash = "sha256:a1a47c7db9348016f273d2a2d465b0ddcd1a66b30aa933d99e30e3ce86d04781", size = 423084, upload-time = "2026-06-22T16:07:21.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/01/2dfc3389605358da54025833dcb4ae3726faba3540859d18f423780ba303/givenergy_modbus-2.5.0-py3-none-any.whl", hash = "sha256:8b6390776a5a30035191e06328cd939d2cb6450cf74e8eadf4440bd3c2d966fd", size = 159458, upload-time = "2026-06-17T23:32:12.033Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/14/f10caa44ff063d0767c2a76918c076beb4c6c1194cef9b047090ad0aabb3/givenergy_modbus-2.5.1-py3-none-any.whl", hash = "sha256:a229370332b4d99dec11a14451054ee7c25a154a545a00290e9f6febc12f03cf", size = 160166, upload-time = "2026-06-22T16:07:20.075Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated bump triggered by [givenergy-modbus@2.5.1](https://github.com/dewet22/givenergy-modbus/releases/tag/v2.5.1).