### PR TITLE
test: add coverage gate + service-handler tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -58,7 +58,10 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync
-      - run: uv run pytest
+      # --cov reads its source/branch/fail_under config from pyproject's
+      # [tool.coverage.*]. term-missing surfaces the uncovered lines in the log
+      # so the fail_under floor can be ratcheted up as coverage improves.
+      - run: uv run pytest --cov --cov-report=term-missing
 
   deprecations:
     name: deprecation watch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
+    "pytest-cov>=5.0",
     "pytest-homeassistant-custom-component>=0.13",
     "ruff>=0.9",
     "mypy>=1.10",
@@ -35,6 +36,26 @@ package = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+# Coverage is measured against the integration package only (the standalone
+# migration script under scripts/ has its own focused tests). Run locally with
+# `uv run pytest --cov`; CI gates on it. See [tool.coverage.*] below.
+[tool.coverage.run]
+source = ["custom_components/givenergy_local"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+]
+# Conservative starting floor so the gate can't be silently regressed. Ratchet
+# this upward toward the real figure (printed by CI's term-missing report) as
+# the under-tested service/coordinator/migration paths gain coverage.
+fail_under = 70
 
 [tool.ruff]
 target-version = "py314"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,11 +2,13 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from givenergy_modbus.exceptions import PlantTopologyMismatch
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
@@ -22,7 +24,10 @@ from custom_components.givenergy_local.const import (
     CONF_TIMEOUT_TOLERANCE,
     DOMAIN,
     EXPOSE_RECOMMENDED_ENTITY_KEYS,
+    SERVICE_CALIBRATE_BATTERY_SOC,
+    SERVICE_CAPTURE_FRAMES,
     SERVICE_EXPOSE_RECOMMENDED_ENTITIES,
+    SERVICE_REBOOT_INVERTER,
     SERVICE_REDETECT_PLANT,
     SERVICE_SET_SYSTEM_DATETIME,
 )
@@ -216,6 +221,133 @@ async def test_set_system_datetime_service_sends_command(hass, mock_client, setu
         blocking=True,
     )
     mock_client.one_shot_command.assert_called_once()
+
+
+def _inverter_device_id(hass, entry_id):
+    """Return the HA device_id of the inverter registered for `entry_id`."""
+    device_reg = dr.async_get(hass)
+    return next(d for d in device_reg.devices.values() if entry_id in d.config_entries).id
+
+
+async def test_reboot_inverter_service_sends_command(hass, mock_client, setup_integration):
+    """The reboot_inverter service issues a one-shot reboot command for the device."""
+    device_id = _inverter_device_id(hass, setup_integration.entry_id)
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_REBOOT_INVERTER,
+        {"device_id": device_id},
+        blocking=True,
+    )
+    mock_client.one_shot_command.assert_called_once()
+
+
+async def test_calibrate_battery_soc_service_sends_command(hass, mock_client, setup_integration):
+    """The calibrate_battery_soc service issues a one-shot calibration command."""
+    device_id = _inverter_device_id(hass, setup_integration.entry_id)
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CALIBRATE_BATTERY_SOC,
+        {"device_id": device_id},
+        blocking=True,
+    )
+    mock_client.one_shot_command.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "service",
+    [SERVICE_REBOOT_INVERTER, SERVICE_CALIBRATE_BATTERY_SOC, SERVICE_SET_SYSTEM_DATETIME],
+)
+async def test_device_services_reject_unknown_device(hass, mock_client, setup_integration, service):
+    """Hardware-command services raise (and send nothing) for an unknown device_id."""
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {"device_id": "does-not-exist"},
+            blocking=True,
+        )
+    mock_client.one_shot_command.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "service",
+    [SERVICE_REBOOT_INVERTER, SERVICE_CALIBRATE_BATTERY_SOC, SERVICE_SET_SYSTEM_DATETIME],
+)
+async def test_device_services_reject_disconnected_client(
+    hass, mock_client, setup_integration, service
+):
+    """Hardware-command services refuse to act while the inverter is offline."""
+    device_id = _inverter_device_id(hass, setup_integration.entry_id)
+    mock_client.connected = False
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {"device_id": device_id},
+            blocking=True,
+        )
+    mock_client.one_shot_command.assert_not_called()
+
+
+async def test_set_system_datetime_resolves_by_serial(hass, mock_client, setup_integration):
+    """set_system_datetime also accepts a `serial` target (the unique_id path)."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_SYSTEM_DATETIME,
+        {"serial": setup_integration.unique_id},
+        blocking=True,
+    )
+    mock_client.one_shot_command.assert_called_once()
+
+
+async def test_set_system_datetime_unknown_serial_raises(hass, mock_client, setup_integration):
+    """An unmatched serial surfaces a HomeAssistantError and sends nothing."""
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_SYSTEM_DATETIME,
+            {"serial": "NOPE0000X1"},
+            blocking=True,
+        )
+    mock_client.one_shot_command.assert_not_called()
+
+
+async def test_capture_frames_unknown_device_raises(hass, mock_client, setup_integration):
+    """capture_frames rejects an unknown device_id before touching the wire."""
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CAPTURE_FRAMES,
+            {"device_id": "does-not-exist", "duration": 10},
+            blocking=True,
+        )
+    mock_client.capture_frames.assert_not_called()
+
+
+async def test_capture_frames_no_connected_inverter_raises(hass, mock_client, setup_integration):
+    """With no device_id and every inverter offline, capture_frames raises."""
+    mock_client.connected = False
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CAPTURE_FRAMES,
+            {"duration": 10},
+            blocking=True,
+        )
+    mock_client.capture_frames.assert_not_called()
+
+
+async def test_expose_recommended_entities_unknown_device_raises(
+    hass, mock_client, setup_integration
+):
+    """expose_recommended_entities raises for a device_id that isn't registered."""
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_EXPOSE_RECOMMENDED_ENTITIES,
+            {"device_id": "does-not-exist"},
+            blocking=True,
+        )
 
 
 async def test_topology_mismatch_persists_actual_and_raises_repairs_issue(

--- a/uv.lock
+++ b/uv.lock
@@ -924,6 +924,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "pytest-homeassistant-custom-component" },
     { name = "ruff" },
 ]
@@ -936,6 +937,7 @@ dev = [
     { name = "mypy", specifier = ">=1.10" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "pytest-cov", specifier = ">=5.0" },
     { name = "pytest-homeassistant-custom-component", specifier = ">=0.13" },
     { name = "ruff", specifier = ">=0.9" },
 ]


### PR DESCRIPTION
## Summary

First slice of the test-coverage improvements from a coverage analysis of the codebase. Tackles the two highest-leverage gaps: **no coverage measurement at all**, and the **untested service-handler layer** in `__init__.py`.

### Coverage gate
- Add `pytest-cov` to the dev group.
- Configure `[tool.coverage.*]` in `pyproject.toml`: branch coverage scoped to the integration package, `term-missing` report, and a conservative `fail_under` floor meant to be ratcheted upward as coverage improves.
- Run the `tests` CI job with `--cov --cov-report=term-missing` so regressions are caught and the real figure is visible in the log.

### Service-handler tests (`tests/test_init.py`)
Previously the service layer was the most under-tested surface relative to its risk (it sends real hardware commands). Added:
- `reboot_inverter` and `calibrate_battery_soc` — happy path (were entirely untested).
- Guard branches across the hardware-command services: unknown `device_id`, disconnected client (parametrized over reboot / calibrate / set_system_datetime).
- `set_system_datetime` — `serial`-target resolution and unknown-serial error path.
- `capture_frames` — unknown `device_id` and "no connected inverter" error paths.
- `expose_recommended_entities` — unknown `device_id` error path.

## Verification
- New tests pass locally (the sandbox needed a small `typing.ByteString` shim because only Python 3.14.0rc2 is installable there, not the project's required 3.14.2; CI runs on the real interpreter via the lockfile).
- Full suite reports **94%** coverage, comfortably above the floor.

## Follow-ups (remaining items from the analysis, not in this PR)
- Coordinator failure-recovery edge cases (mixed `ExceptionGroup`, `_reset_client` close-on-error, healed-callback exceptions).
- Config-flow `detect()` / `PlantTopologyMismatch` handling at setup time (likely a real fix, not just a test).
- `sensor.py` helper branches (`_battery_hex` exception/Enum paths) and the unasserted battery `status_*` / `warning_2` sensors.
- Migration-script I/O layer (`HAWebSocket`, `rebase_sum`, time helpers).
- Ratchet `fail_under` upward once CI reports the steady-state number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gp5kqvsPsWDKu2XSESMpA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gp5kqvsPsWDKu2XSESMpA5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Implemented code coverage measurement with a 70% minimum threshold to ensure quality standards.
  * Added comprehensive integration tests for device commands, system configuration, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->