### PR TITLE
test: coordinator failure-recovery + sensor value-helper coverage

### DIFF
--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -482,7 +482,18 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                 # Full expected topology is present — let the caller clear any
                 # stale "device missing" repair and reconcile entities against the
                 # confirmed topology (covers both restart and mid-session recovery).
-                await self._on_topology_healed(confirmed)
+                try:
+                    await self._on_topology_healed(confirmed)
+                except Exception:  # noqa: BLE001
+                    # The connection is up and detect() succeeded; a failure in
+                    # the caller's reconcile/repair callback must not discard the
+                    # freshly-connected client (which the outer BaseException
+                    # handler would do) or fail the poll. Log and carry on — the
+                    # stale repair issue, if any, simply clears on a later heal.
+                    _LOGGER.warning(
+                        "topology-healed callback failed; connection is up, continuing",
+                        exc_info=True,
+                    )
             self._last_inverter_time = None
             self._unchanged_ticks = 0
             self._active_tick = 0
@@ -600,8 +611,16 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         """Close and discard the client so the next tick triggers a reconnect."""
         if self._client is not None:
             _LOGGER.info("Closing connection to %s:%s", self.host, self.port)
-            await self._client.close()
-            self._client = None
+            try:
+                await self._client.close()
+            except Exception as exc:  # noqa: BLE001
+                # A failure tearing the socket down must not strand a dead
+                # client: the finally below guarantees we discard it so the
+                # next tick reconnects cleanly. CancelledError is deliberately
+                # left to propagate (not an Exception).
+                _LOGGER.debug("Error while closing client (ignored): %s", exc)
+            finally:
+                self._client = None
 
     async def async_close(self) -> None:
         await self._reset_client()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -113,6 +113,20 @@ async def test_async_close_closes_client(hass, mock_client, setup_integration):
     assert coordinator._client is None
 
 
+async def test_reset_client_discards_even_if_close_raises(hass):
+    """If close() raises while tearing the socket down, the client is still
+    discarded so the next tick reconnects rather than reusing a dead client."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+    client = AsyncMock()
+    client.close = AsyncMock(side_effect=OSError("close failed"))
+    coordinator._client = client
+
+    await coordinator._reset_client()  # must NOT raise
+
+    client.close.assert_awaited_once()
+    assert coordinator._client is None
+
+
 async def test_timeout_raises_update_failed(hass):
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
 
@@ -642,6 +656,30 @@ async def test_refresh_failed_nontimeout_cause_resets_immediately(hass, mock_pla
         assert coordinator.total_failures == 1
 
 
+async def test_refresh_failed_mixed_group_cause_resets_immediately(hass, mock_plant):
+    """A RefreshFailed whose ExceptionGroup mixes a timeout with a non-timeout is
+    NOT treated as a transient timeout: it resets the client and fails at once,
+    rather than serving stale within the tolerance window."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, timeout_tolerance=3)
+    mixed = _refresh_failed(TimeoutError(), ConnectionResetError("peer reset"))
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.refresh = AsyncMock(side_effect=mixed)
+        mock_cls.return_value = client
+        coordinator._client = client
+        coordinator.data = mock_plant  # present, but must not be served
+
+        with pytest.raises(UpdateFailed, match="Error communicating"):
+            await coordinator._async_update_data()
+
+        client.close.assert_called_once()
+        assert coordinator._client is None
+        assert coordinator.total_failures == 1
+
+
 # ---------------------------------------------------------------------------
 # Active / passive refresh cadence
 # ---------------------------------------------------------------------------
@@ -1127,6 +1165,27 @@ async def test_loss_retried_then_heals(hass, mock_plant):
     on_changed.assert_not_awaited()
     on_healed.assert_awaited_once()
     assert coordinator._prior_capabilities is prior  # full prior never overwritten
+
+
+async def test_healed_callback_failure_does_not_break_connection(hass, mock_plant):
+    """A crash inside the topology-healed callback must not discard the freshly
+    connected client or fail the connect — the link is up, so we log and carry on."""
+    on_healed = AsyncMock(side_effect=RuntimeError("reload failed"))
+    coordinator = GivEnergyUpdateCoordinator(
+        hass, "192.168.1.1", 8899, 30, on_topology_healed=on_healed
+    )
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.detect = AsyncMock()  # clean detect → topology confirmed, callback fires
+        mock_cls.return_value = client
+
+        await coordinator._connect()  # must NOT raise despite the callback blowing up
+
+    on_healed.assert_awaited_once()
+    assert coordinator._client is client  # connection kept, not discarded
 
 
 async def test_persistent_loss_invokes_on_devices_missing(hass, mock_plant):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -675,7 +675,7 @@ async def test_refresh_failed_mixed_group_cause_resets_immediately(hass, mock_pl
         with pytest.raises(UpdateFailed, match="Error communicating"):
             await coordinator._async_update_data()
 
-        client.close.assert_called_once()
+        client.close.assert_awaited_once()
         assert coordinator._client is None
         assert coordinator.total_failures == 1
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -299,10 +299,35 @@ async def test_bms_status_warning_rendered_as_hex(hass, setup_integration):
     assert hass.states.get(_entity_id(hass, "sensor", "BT1234A001_status_3")).state == "0xA5"
     assert hass.states.get(_entity_id(hass, "sensor", "BT1234A001_status_1")).state == "0x00"
     assert hass.states.get(_entity_id(hass, "sensor", "BT1234A001_warning_1")).state == "0x00"
+    # The remaining status_* registers (every index 1–7 is wired up in a loop)
+    # and warning_2 are all exposed too, each rendered as 0x00 from the fixture.
+    for key in ("status_2", "status_4", "status_5", "status_6", "status_7", "warning_2"):
+        assert hass.states.get(_entity_id(hass, "sensor", f"BT1234A001_{key}")).state == "0x00"
     # Hex-formatted sensors deliberately omit state_class so HA doesn't
     # try to roll them into long-term statistics.
     state = hass.states.get(_entity_id(hass, "sensor", "BT1234A001_status_3"))
     assert "state_class" not in state.attributes
+
+
+def test_battery_hex_formatter_branches():
+    """The _battery_hex value_fn: formats ints, unwraps Enum-like `.value`, and
+    fails soft (None) on missing or non-numeric attributes."""
+    from types import SimpleNamespace
+
+    from custom_components.givenergy_local.sensor import _battery_hex
+
+    fn = _battery_hex("status_1", width=2)
+    # Plain int → fixed-width hex.
+    assert fn(SimpleNamespace(status_1=0xA5)) == "0xA5"
+    # Enum-like object → underlying numeric value is pulled before formatting
+    # (mirrors the inverter's usb_device_inserted having gone Enum upstream).
+    assert fn(SimpleNamespace(status_1=SimpleNamespace(value=0x07))) == "0x07"
+    # Missing attribute → None (surfaces as `unknown`, never raises).
+    assert fn(SimpleNamespace()) is None
+    # Present but non-numeric → None rather than a formatting crash.
+    assert fn(SimpleNamespace(status_1="oops")) is None
+    # Width is honoured (uint16 fields render as 4 chars).
+    assert _battery_hex("warning_2", width=4)(SimpleNamespace(warning_2=0x08)) == "0x0008"
 
 
 async def test_cell_voltages_attached_to_battery_device(hass, setup_integration):
@@ -861,12 +886,17 @@ def test_grid_split_power_helpers_resolve_both_directions():
 
     exporting = MagicMock(p_grid_out=1500)
     importing = MagicMock(p_grid_out=-800)
+    balanced = MagicMock(p_grid_out=0)
     unpolled = MagicMock(p_grid_out=None)
 
     assert _grid_export_power(exporting) == 1500
     assert _grid_import_power(exporting) == 0
     assert _grid_import_power(importing) == 800
     assert _grid_export_power(importing) == 0
+    # A balanced grid (p_grid_out == 0) reads 0 on both, not unknown — 0 is a
+    # real reading and must survive the falsy-vs-None distinction.
+    assert _grid_export_power(balanced) == 0
+    assert _grid_import_power(balanced) == 0
     assert _grid_export_power(unpolled) is None
     assert _grid_import_power(unpolled) is None
 


### PR DESCRIPTION
## Summary

Second slice of the test-coverage follow-ups from the coverage analysis (after #189). Covers the two highest-value remaining gaps: **coordinator failure-recovery** (the most complex resilience logic) and **sensor value-computation helpers**. Two of the coordinator paths were also missing defensive guards, so this fixes them rather than just testing the status quo.

### Production fixes (`coordinator.py`)
- **`_reset_client`** now closes the client inside `try/except/finally`, so the client is **always** discarded even if `close()` raises — previously an exception there left a dead client in place for the next tick to reuse. `CancelledError` is deliberately left to propagate.
- **`on_topology_healed` callback** is wrapped so a crash in the caller's reconcile/repair callback no longer trips the outer `except BaseException` (which would discard the freshly-connected client) or fail the poll. The connection is up at that point, so we log and carry on.

### Tests
**Coordinator** (`tests/test_coordinator.py`):
- Mixed-cause `ExceptionGroup` (timeout **+** non-timeout) resets the client immediately instead of serving stale within the tolerance window — the previously-untested `rest is not None` branch of `_is_timeout_failure`.
- `_reset_client` clears the client when `close()` raises (guards fix #1).
- A crashing `on_topology_healed` callback keeps the connection up and doesn't fail the connect (guards fix #2).

**Sensor** (`tests/test_sensor.py`):
- Assert the previously-unasserted BMS `status_2/4–7` and `warning_2` hex sensors render (only `status_1/3` and `warning_1` were checked before).
- Direct branch coverage for `_battery_hex`: plain int, Enum-like `.value` unwrap, missing attribute → `None`, non-numeric → `None`, and width handling.
- Grid power at the `p == 0` boundary reads `0` on both directions (not `unknown`).

## Verification
- New/modified tests pass locally (the sandbox needs a one-line `typing.ByteString` shim because only Python 3.14.0rc2 is installable there, not the required 3.14.2; CI runs on the real interpreter).
- Both production fixes are genuinely guarded — without them the close-raises test propagates `OSError` and the callback test re-raises via the outer handler.
- No new dependencies, so no `pyproject.toml` / `uv.lock` changes.

## Dropped from scope
The config-flow `detect()` / `PlantTopologyMismatch` item from the analysis turned out **not** to be a real bug: `_test_connection` already wraps `detect()` in the broad `except Exception` (→ `cannot_connect`), and `detect()` runs with no `prior`, so `PlantTopologyMismatch` can't arise during the flow.

## Remaining follow-ups (future PRs)
`sensor.py` monotonic-clamp edge cases, the migration-script I/O layer (`HAWebSocket`, `rebase_sum`, time helpers), and ratcheting `fail_under` upward once CI reports the steady-state number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gp5kqvsPsWDKu2XSESMpA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gp5kqvsPsWDKu2XSESMpA5)_