### PR TITLE
test: monotonic-clamp edge cases + raise coverage floor to 90

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,11 @@ exclude_lines = [
     "raise NotImplementedError",
     "if __name__ == .__main__.:",
 ]
-# Conservative starting floor so the gate can't be silently regressed. Ratchet
-# this upward toward the real figure (printed by CI's term-missing report) as
-# the under-tested service/coordinator/migration paths gain coverage.
-fail_under = 70
+# Floor tracks near the measured coverage (~94.5% on main) with deliberate
+# headroom: high enough to catch a real regression, low enough that one new
+# lightly-tested module doesn't fail CI on its own. Ratchet further as coverage
+# stabilises higher.
+fail_under = 90
 
 [tool.ruff]
 target-version = "py314"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1418,6 +1418,53 @@ def test_monotonic_clock_lag_reset_after_date_flip(mock_plant, freezer):
     assert _read(entity, mock_plant, 0.3) == 0.3
 
 
+def test_monotonic_deferred_reset_admitted_after_gap(mock_plant, freezer):
+    """The deferred owed-reset call honours the elapsed-scaled band too: after a
+    skewed (negative) boundary reading defers the decision, a reset that lands a
+    couple of hours later — above the 0.5 kWh floor but within 15 kW × elapsed —
+    is admitted rather than held as an ambiguous sag."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    freezer.tick(24 * 3600)
+    assert _read(entity, mock_plant, -1.0) == 0.0  # boundary skew: decision deferred
+    # Two hours later the reset surfaces at 1.8 kWh — over the floor, so only the
+    # elapsed-scaled ceiling (15 kW × 2 h = 30 kWh) lets it through.
+    freezer.tick(2 * 3600)
+    assert _read(entity, mock_plant, 1.8) == 1.8
+
+
+def test_monotonic_deferred_branch_tolerates_missing_last_read(mock_plant, freezer):
+    """Defensive: the deferred branch falls back to the 0.5 kWh floor when there
+    is no prior-read timestamp to scale against (``_monotonic_last_read`` unset),
+    rather than dividing against None."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 14.3) == 14.3
+    freezer.tick(24 * 3600)
+    assert _read(entity, mock_plant, -1.0) == 0.0  # boundary skew defers the call
+    # Force the no-timestamp edge, then a plausible (sub-floor) post-reset value
+    # still settles the deferred call against the bare floor.
+    entity._monotonic_last_read = None
+    assert _read(entity, mock_plant, 0.2) == 0.2
+
+
+def test_monotonic_max_none_invariant_guard(mock_plant, freezer):
+    """Defensive: if the running max is ever absent while the date is current
+    (an invariant the branches below rely on), a read floors it at max(value, 0)
+    instead of raising."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity = _monotonic_entity(mock_plant)
+
+    assert _read(entity, mock_plant, 10.0) == 10.0
+    # Break the invariant: same day, decision already settled, but no running max.
+    entity._monotonic_max = None
+    assert _read(entity, mock_plant, 5.2) == 5.2
+    assert entity._monotonic_max == 5.2
+
+
 async def test_monotonic_restore_floors_negative(hass, mock_plant):
     """A persisted negative state (recorded by pre-fix versions) must not
     re-seed a negative baseline after restart."""


### PR DESCRIPTION
## Summary

Third coverage-analysis follow-up (after #189, #190), covering two items:

1. **Monotonic-clamp edge-case tests** for `sensor.py`'s `GivEnergyInverterSensor.native_value`.
2. **Ratchet the coverage floor** — raise `fail_under` from `70` → `90`.

### Monotonic tests (`tests/test_sensor.py`, test-only)
The latest `main` CI run reported `sensor.py` at 97% with its only uncovered monotonic arcs being `1498->1501` (the deferred-reset branch's `last_read is None` fallback) and `1515` (the defensive `_monotonic_max is None` guard). The existing deferred-branch tests only exercise the `elapsed == 0` case, so these add:
- **Deferred reset admitted after a gap** — a skewed negative boundary reading defers the owed-reset decision; a reset surfacing two hours later (above the 0.5 kWh floor) is admitted via the elapsed-scaled `15 kW × elapsed` band. Exercises the deferred branch's ceiling-widening, which no existing test did.
- **Deferred branch tolerates a missing `last_read`** — falls back to the bare 0.5 kWh floor instead of dividing against `None` (closes `1498->1501`).
- **`_monotonic_max`-None invariant guard** — floors at `max(value, 0)` rather than raising (closes `1515`).

Verified locally (via the `typing.ByteString` shim the sandbox needs): all three pass, and `sensor.py`'s Missing column drops `1498`/`1515`, taking it to 98% (only the non-monotonic `1446/1595/1641/1663` remain, already missing pre-PR).

### Coverage floor (`pyproject.toml`)
Real coverage on `main` is **94.51%**. Raise `fail_under` `70` → `90`: meaningful regression protection with ~4–5 points of headroom so a single lightly-tested new module doesn't fail CI on its own. Coverage only rises with the tests added here.

## Verification
- New tests pass locally; targeted arcs confirmed covered.
- No production code or dependency changes (no `uv.lock` churn).
- Authoritative: the `tests` CI job must stay green with the new `fail_under = 90`.

## Remaining follow-up
The migration-script I/O layer tests (`HAWebSocket`, `rebase_sum`, time helpers) — the last item from the original analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gp5kqvsPsWDKu2XSESMpA5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gp5kqvsPsWDKu2XSESMpA5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added three new test cases for sensor monotonic-clamp functionality, covering deferred reset scenarios and edge cases to ensure robust handling of sensor readings under various conditions.

* **Chores**
  * Updated CI configuration to increase code coverage gate threshold, strengthening quality assurance standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->