### PR TITLE
feat: extra inverter power sensors + AIO sensor hygiene (#194)

### DIFF
--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -220,8 +220,10 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         value_fn=lambda inv: (
             ", ".join(inv.inverter_fault_messages) if inv.inverter_fault_messages else None
         ),
-        # None on AIO (no fault block) — drop rather than show "Unknown" (#194).
-        skip_if_none=True,
+        # Deliberately NOT skip_if_none: value_fn returns None for the healthy
+        # *empty fault list* too, not just the unsupported-on-AIO case. Skipping
+        # would drop this on a healthy single-phase install at setup, leaving a
+        # later fault nowhere to surface until a reload (Codex review, #194).
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     # ChargeStatus mapping shipped in modbus 2.3.1 (#222) — render the
@@ -1410,8 +1412,15 @@ async def async_setup_entry(
         # Skip a module whose serial we've already created entities for: a
         # duplicate serial (placeholder/garbled, or a repeated BMS read) would
         # otherwise collide on unique_id and HA would drop the second module's
-        # entities with an error per cell (#194).
+        # entities with an error per cell (#194). Log it loudly — real modules
+        # have unique serials, so a duplicate means a module is missing from HA.
         if module.serial_number in seen_module_serials:
+            _LOGGER.warning(
+                "Skipping AIO battery module at index %d: duplicate serial %s "
+                "(real modules have unique serials — check for a placeholder/garbled read)",
+                module_index,
+                module.serial_number,
+            )
             continue
         seen_module_serials.add(module.serial_number)
         entities.extend(

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -191,6 +191,8 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         key="inverter_errors",
         name="Inverter Errors",
         value_fn=lambda inv: inv.inverter_errors,
+        # None on AIO (HR223/224 unpopulated) — drop rather than show "Unknown" (#194).
+        skip_if_none=True,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     GivEnergyInverterSensorDescription(
@@ -218,6 +220,8 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         value_fn=lambda inv: (
             ", ".join(inv.inverter_fault_messages) if inv.inverter_fault_messages else None
         ),
+        # None on AIO (no fault block) — drop rather than show "Unknown" (#194).
+        skip_if_none=True,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     # ChargeStatus mapping shipped in modbus 2.3.1 (#222) — render the
@@ -684,6 +688,8 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda inv: inv.e_inverter_export_total,
+        # None on AIO (no single-phase inverter-export register) — drop (#194).
+        skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
         key="e_inverter_in_total",
@@ -700,6 +706,8 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda inv: inv.e_discharge_year,
+        # None on AIO (IR29 unpopulated) — drop rather than show "Unknown" (#194).
+        skip_if_none=True,
     ),
     # --- Lifetime battery energy totals (routed per-model in givenergy-modbus
     # #76; return None on models with no known total register — e.g. AC-coupled
@@ -816,12 +824,47 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         key="num_mppt",
         name="MPPT Count",
         value_fn=lambda inv: inv.num_mppt,
+        # None on AIO (HR3 high byte unpopulated) — drop rather than "Unknown" (#194).
+        skip_if_none=True,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     GivEnergyInverterSensorDescription(
         key="num_phases",
         name="Phase Count",
         value_fn=lambda inv: inv.num_phases,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyInverterSensorDescription(
+        key="grid_port_max_power_output",
+        name="Grid Export Power Limit",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda inv: inv.grid_port_max_power_output,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyInverterSensorDescription(
+        key="inverter_max_power",
+        name="Inverter Max Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda inv: inv.inverter_max_power,
+        # Computed from the device-type code; None when the DTC isn't in the
+        # library's lookup (e.g. some AIO variants) — drop rather than "Unknown" (#194).
+        skip_if_none=True,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyInverterSensorDescription(
+        key="battery_max_power",
+        name="Battery Max Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda inv: inv.battery_max_power,
+        # Computed from DTC + firmware; None until the modbus DTC lookup has the
+        # entry — drop rather than "Unknown" (#194).
+        skip_if_none=True,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     GivEnergyInverterSensorDescription(
@@ -1360,9 +1403,17 @@ async def async_setup_entry(
     # Like the battery entities, this set is fixed at setup: a module absent
     # during the initial probe gets no entities until a reload (tracked in #148,
     # to be fixed uniformly for all device types).
+    seen_module_serials: set[str] = set()
     for module_index, module in enumerate(coordinator.data.aio_battery_modules):
         if not module.is_valid():
             continue
+        # Skip a module whose serial we've already created entities for: a
+        # duplicate serial (placeholder/garbled, or a repeated BMS read) would
+        # otherwise collide on unique_id and HA would drop the second module's
+        # entities with an error per cell (#194).
+        if module.serial_number in seen_module_serials:
+            continue
+        seen_module_serials.add(module.serial_number)
         entities.extend(
             GivEnergyAioModuleSensor(coordinator, description, module_index)
             for description in AIO_MODULE_SENSORS

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -102,12 +102,15 @@ def test_aio_inapplicable_inverter_sensors_skip_if_none():
     for key in (
         "num_mppt",
         "e_inverter_export_total",
-        "inverter_fault_messages",
         "inverter_errors",
         "e_discharge_year",
         "e_solar_diverter",  # already had it — guard against regression
     ):
         assert _inverter_desc(key).skip_if_none is True, key
+    # Fault Messages is deliberately NOT skipped: its value_fn returns None for the
+    # healthy empty-fault list too, so skipping would drop it on healthy single-phase
+    # installs and a later fault couldn't surface until reload (#194).
+    assert _inverter_desc("inverter_fault_messages").skip_if_none is False
 
 
 def test_extra_inverter_capability_sensors():

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -96,6 +96,36 @@ def test_setup_filter_skips_bad_descriptor_instead_of_crashing():
     assert _include_inverter_sensor(plain, inv, False) is True
 
 
+def test_aio_inapplicable_inverter_sensors_skip_if_none():
+    """Inverter sensors that read None on an AIO are dropped (skip_if_none), not
+    shown as a permanently-Unknown orphan (#194)."""
+    for key in (
+        "num_mppt",
+        "e_inverter_export_total",
+        "inverter_fault_messages",
+        "inverter_errors",
+        "e_discharge_year",
+        "e_solar_diverter",  # already had it — guard against regression
+    ):
+        assert _inverter_desc(key).skip_if_none is True, key
+
+
+def test_extra_inverter_capability_sensors():
+    """The new rated/limit fields are surfaced as power sensors; the DTC-computed
+    ones skip when None (unmapped DTC) rather than showing Unknown (#194)."""
+    from homeassistant.components.sensor import SensorDeviceClass
+
+    grid = _inverter_desc("grid_port_max_power_output")
+    assert grid.native_unit_of_measurement == "W"
+    assert grid.device_class == SensorDeviceClass.POWER
+    assert grid.skip_if_none is False  # raw HR, wanted on AIO — never skipped
+    for key in ("inverter_max_power", "battery_max_power"):
+        desc = _inverter_desc(key)
+        assert desc.native_unit_of_measurement == "W", key
+        assert desc.device_class == SensorDeviceClass.POWER, key
+        assert desc.skip_if_none is True, key
+
+
 def test_single_phase_only_sensors_gated_on_three_phase():
     """single_phase_only descriptions are dropped on three-phase plants but kept on
     single-phase — the single-phase-only PV/capacity fields would otherwise surface as
@@ -840,6 +870,27 @@ async def test_aio_module_with_invalid_serial_is_skipped(hass, mock_client, mock
     _setup_aio_plant(
         mock_client,
         [_mock_aio_module("HX2414G831", 0x50), _mock_aio_module("", 0x51, valid=False)],
+    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    dev_registry = dr.async_get(hass)
+    modules = [
+        d
+        for d in dr.async_entries_for_config_entry(dev_registry, mock_config_entry.entry_id)
+        if d.model == "AIO Battery Module"
+    ]
+    assert len(modules) == 1
+    assert modules[0].serial_number == "HX2414G831"
+
+
+async def test_aio_modules_dedup_duplicate_serial(hass, mock_client, mock_config_entry):
+    """Two modules reporting the same serial create exactly one device — the
+    duplicate is skipped rather than colliding on unique_id (#194)."""
+    _setup_aio_plant(
+        mock_client,
+        [_mock_aio_module("HX2414G831", 0x50), _mock_aio_module("HX2414G831", 0x51)],
     )
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)


### PR DESCRIPTION
## Summary
The three capture-independent items from #194 (follow-ups to #95).
- **New diagnostic sensors:** Grid Export Power Limit (`grid_port_max_power_output` — the G99 export cap AberDino asked for), Inverter Max Power, Battery Max Power. The two DTC-computed ones skip when their value is None (unmapped device-type code) rather than showing "Unknown". `model` not added — it's already in the device info.
- **AIO hygiene:** `skip_if_none` on the inverter sensors that read None on an AIO (MPPT Count, Inverter Export Total, Fault Messages, Inverter Errors, Battery Discharge This Year), so they drop instead of surfacing as permanently-Unknown orphans.
- **Dedup AIO modules by serial** — a duplicate/placeholder module serial no longer collides on unique_id (the error flood seen testing #95 against the mock).

Gateway-connection support stays tracked in #194.

## Test plan
- 456 tests pass (3 new); ruff + mypy clean.
- **Live check on a real single-phase inverter:** confirm the 3 new sensors populate (especially the G99 export limit) and that no previously-present inverter sensor vanished from the `skip_if_none` additions — `e_inverter_export_total` (extended HR block) is the one to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new inverter power-limit sensors: Grid Export Power Limit, Inverter Max Power, and Battery Max Power.

* **Bug Fixes**
  * Improved handling of inverter diagnostic sensors—they no longer appear as "Unknown" when unavailable on certain models.
  * Fixed duplicate battery module devices appearing during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->