### PR TITLE
feat: comms noise-floor diagnostics — CRC, splice-guard & retry counters

### DIFF
--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -497,6 +497,12 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         — required for three-phase, AIO-HV, EMS and other non-default topologies.
         """
         self._client = Client(host=self.host, port=self.port)
+        # A fresh Client means a fresh Plant with its comms counters zeroed, so
+        # drop the per-device last-seen baselines: the next poll then captures
+        # the full post-reconnect value as the delta. Without this, a counter
+        # that climbs back past its pre-reconnect value before the first poll
+        # would be mistaken for monotonic growth and undercounted.
+        self._comms_last_seen.clear()
         try:
             await self._client.connect()
             topology_confirmed = True

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -181,6 +181,19 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         # When the most recent partial poll occurred (UTC), retained alongside
         # last_partial_failures so the diagnostic sensor can show how long ago.
         self.last_partial_at: datetime | None = None
+        # Comms-quality noise floor: per-device cumulative counts of CRC-failed
+        # responses, splice-guard trips, and read retries consumed — mirrored
+        # from the library's own Plant counters (which reset on each Client/Plant
+        # re-instantiation). We accumulate reset-aware deltas here so the
+        # diagnostic sensors stay monotonic across reconnects, like
+        # total_failures. Keyed by device address; the headline sensor value is
+        # the sum across devices.
+        self.crc_failures_by_device: dict[int, int] = {}
+        self.splice_rejections_by_device: dict[int, int] = {}
+        self.splice_holds_by_device: dict[int, int] = {}
+        self.read_retries_by_device: dict[int, int] = {}
+        # Last cumulative value seen per library attr per device, for delta-ing.
+        self._comms_last_seen: dict[str, dict[int, int]] = {}
         # Length of the current unbroken run of partial polls, used only to
         # throttle the partial log (see _record_partial). Reset by a clean poll.
         self._consecutive_partials: int = 0
@@ -298,6 +311,42 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         self._last_inverter_time = plant.inverter.system_time
         self.last_successful_refresh = dt_util.utcnow()
         self.consecutive_failures = 0
+        self._accumulate_comms_counters(plant)
+
+    # (library Plant attr, our per-device cumulative dict attr)
+    _COMMS_COUNTER_SOURCES = (
+        ("crc_failure_count", "crc_failures_by_device"),
+        ("splice_reject_count", "splice_rejections_by_device"),
+        ("splice_held_count", "splice_holds_by_device"),
+        ("retry_count", "read_retries_by_device"),
+    )
+
+    def _accumulate_comms_counters(self, plant: Plant) -> None:
+        """Fold the library's per-device comms-quality counters into our own.
+
+        givenergy-modbus exposes cumulative-since-construction counters for
+        CRC-failed responses and splice-guard trips (keyed by device address);
+        they reset whenever the Client/Plant is re-instantiated (e.g. on a
+        reconnect). We mirror them into coordinator-level dicts that survive
+        reconnects, accumulating reset-aware deltas so the diagnostic sensors
+        stay monotonic (like total_failures). Reads are defensive: on a modbus
+        build that predates these counters the attribute is absent (or, under a
+        MagicMock test plant, not a dict), so the counters simply stay at zero.
+        """
+        for lib_attr, dest_attr in self._COMMS_COUNTER_SOURCES:
+            lib_counts = getattr(plant, lib_attr, None)
+            if not isinstance(lib_counts, dict):
+                continue
+            dest: dict[int, int] = getattr(self, dest_attr)
+            last_seen = self._comms_last_seen.setdefault(lib_attr, {})
+            for device, current in lib_counts.items():
+                last = last_seen.get(device, 0)
+                # current < last ⇒ the library counter reset (fresh Plant);
+                # treat the new value as the delta rather than going negative.
+                delta = current - last if current >= last else current
+                if delta:
+                    dest[device] = dest.get(device, 0) + delta
+                last_seen[device] = current
 
     def _record_failure(self) -> None:
         """Count a poll that yielded no usable data."""

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1297,6 +1297,25 @@ def _partial_failure_attributes(
     }
 
 
+def _comms_counter_attributes(
+    by_device_attr: str,
+) -> Callable[[GivEnergyUpdateCoordinator], dict[str, Any] | None]:
+    """Build an attributes_fn exposing a per-device breakdown of a comms counter.
+
+    Mirrors _partial_failure_attributes: returns None when nothing has been
+    counted, else a hex-keyed {device: count} map so a noisy device (a flaky
+    bus, one splice-rejecting pack) can be spotted against the plant total.
+    """
+
+    def _attrs(coordinator: GivEnergyUpdateCoordinator) -> dict[str, Any] | None:
+        by_device: dict[int, int] = getattr(coordinator, by_device_attr)
+        if not by_device:
+            return None
+        return {"per_device": {f"0x{addr:02x}": count for addr, count in sorted(by_device.items())}}
+
+    return _attrs
+
+
 COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
     GivEnergyCoordinatorSensorDescription(
         key="last_successful_refresh",
@@ -1331,6 +1350,50 @@ COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda coord: coord.partial_failures,
         attributes_fn=_partial_failure_attributes,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyCoordinatorSensorDescription(
+        key="crc_failures",
+        name="CRC Errors",
+        # Per-device CRC-failed responses the library skipped (keep-last-good).
+        # A few a day is the normal noise floor; a climbing rate on one device
+        # flags a degrading link. The attributes name which device(s).
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda coord: sum(coord.crc_failures_by_device.values()),
+        attributes_fn=_comms_counter_attributes("crc_failures_by_device"),
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyCoordinatorSensorDescription(
+        key="splice_rejections",
+        name="Splice Guard Rejections",
+        # Battery banks hard-rejected by the sub-bus splice guard (keep-last-
+        # good). Expected to be near-zero; a sustained climb on one pack points
+        # at sub-bus corruption or a poisoned baseline.
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda coord: sum(coord.splice_rejections_by_device.values()),
+        attributes_fn=_comms_counter_attributes("splice_rejections_by_device"),
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyCoordinatorSensorDescription(
+        key="splice_holds",
+        name="Splice Guard Holds",
+        # Banks escrowed for one poll pending confirmation — the softer splice
+        # signal (often benign). Counts hold events, not currently-held banks.
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda coord: sum(coord.splice_holds_by_device.values()),
+        attributes_fn=_comms_counter_attributes("splice_holds_by_device"),
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyCoordinatorSensorDescription(
+        key="read_retries",
+        name="Read Retries",
+        # Register reads that needed at least one re-request before succeeding
+        # (or giving up). The earliest creeping-degradation signal — a read that
+        # recovers on retry is otherwise reported as a clean success. A climbing
+        # rate on one device flags a link starting to struggle.
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda coord: sum(coord.read_retries_by_device.values()),
+        attributes_fn=_comms_counter_attributes("read_retries_by_device"),
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -489,6 +489,42 @@ async def test_mark_success_accumulates_comms_counters(hass):
     assert coordinator.last_successful_refresh is not None
 
 
+async def test_reconnect_clears_comms_baseline(hass):
+    """A reconnect builds a fresh Client/Plant with zeroed counters, so _connect
+    must drop the last-seen baselines (else the next poll diffs against a stale
+    pre-reconnect value and undercounts)."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+    coordinator._comms_last_seen = {"crc_failure_count": {0x32: 9}}
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = False
+        client.connect.side_effect = OSError("connection refused")
+        mock_cls.return_value = client
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    # The clear runs at Client construction, before connect() is even attempted.
+    assert coordinator._comms_last_seen == {}
+
+
+async def test_comms_counters_full_count_after_baseline_reset(hass):
+    """With the baseline cleared on reconnect, a counter that climbs back past
+    its pre-reconnect value is counted in full, not diffed against the stale
+    baseline (Gemini #197)."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+
+    coordinator._accumulate_comms_counters(_comms_plant(crc={0x32: 2}))
+    assert coordinator.crc_failures_by_device == {0x32: 2}
+
+    # Reconnect: _connect() clears the baselines (fresh Plant, counters zeroed).
+    coordinator._comms_last_seen.clear()
+
+    # 3 errors before the first post-reconnect poll → current 3 (>= old last 2).
+    coordinator._accumulate_comms_counters(_comms_plant(crc={0x32: 3}))
+    assert coordinator.crc_failures_by_device == {0x32: 5}  # 2 + 3, not 2 + 1
+
+
 async def test_partial_log_throttled_and_resets(hass, mock_plant, caplog):
     """First partial of a run warns; subsequent ones drop to debug; a clean poll
     ends the run so the next partial warns afresh. (partial_failures unaffected.)"""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,7 +3,8 @@
 import asyncio
 import logging
 from datetime import datetime
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from givenergy_modbus.exceptions import (
@@ -420,6 +421,72 @@ async def test_partial_success_increments_partial_failures_cumulatively(hass, mo
     assert coordinator.partial_failures == 3
     assert coordinator.consecutive_failures == 0
     assert coordinator.total_failures == 0
+
+
+def _comms_plant(crc=None, reject=None, held=None, retry=None, system_time=None) -> SimpleNamespace:
+    """A minimal plant stub carrying the library's comms-quality counters."""
+    return SimpleNamespace(
+        inverter=SimpleNamespace(system_time=system_time),
+        crc_failure_count=crc if crc is not None else {},
+        splice_reject_count=reject if reject is not None else {},
+        splice_held_count=held if held is not None else {},
+        retry_count=retry if retry is not None else {},
+    )
+
+
+async def test_comms_counters_accumulate_per_device(hass):
+    """Each poll mirrors the library's per-device counters, accruing only deltas."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+
+    coordinator._accumulate_comms_counters(
+        _comms_plant(crc={0x32: 2, 0x33: 1}, reject={0x33: 4}, held={0x70: 5}, retry={0x33: 6})
+    )
+    assert coordinator.crc_failures_by_device == {0x32: 2, 0x33: 1}
+    assert coordinator.splice_rejections_by_device == {0x33: 4}
+    assert coordinator.splice_holds_by_device == {0x70: 5}
+    assert coordinator.read_retries_by_device == {0x33: 6}
+
+    # A later poll with higher cumulative values accrues only the delta.
+    coordinator._accumulate_comms_counters(
+        _comms_plant(crc={0x32: 5, 0x33: 1}, reject={0x33: 4}, held={0x70: 9}, retry={0x33: 10})
+    )
+    assert coordinator.crc_failures_by_device == {0x32: 5, 0x33: 1}
+    assert coordinator.splice_rejections_by_device == {0x33: 4}
+    assert coordinator.splice_holds_by_device == {0x70: 9}
+    assert coordinator.read_retries_by_device == {0x33: 10}
+
+
+async def test_comms_counters_monotonic_across_plant_reset(hass):
+    """A reconnect resets the library counter; our mirror stays monotonic."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+
+    coordinator._accumulate_comms_counters(_comms_plant(crc={0x32: 5}))
+    # Reconnect → fresh library Plant, counter resets to a lower value.
+    coordinator._accumulate_comms_counters(_comms_plant(crc={0x32: 2}))
+    assert coordinator.crc_failures_by_device == {0x32: 7}  # 5 banked + 2 new
+    coordinator._accumulate_comms_counters(_comms_plant(crc={0x32: 4}))
+    assert coordinator.crc_failures_by_device == {0x32: 9}  # + (4 - 2)
+
+
+async def test_comms_counters_absent_leaves_zero(hass):
+    """An older modbus (attrs absent) or a MagicMock plant no-ops cleanly."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+
+    coordinator._accumulate_comms_counters(SimpleNamespace())  # attrs absent
+    coordinator._accumulate_comms_counters(MagicMock())  # auto-attrs, not dicts
+    assert coordinator.crc_failures_by_device == {}
+    assert coordinator.splice_rejections_by_device == {}
+    assert coordinator.splice_holds_by_device == {}
+    assert coordinator.read_retries_by_device == {}
+
+
+async def test_mark_success_accumulates_comms_counters(hass):
+    """The accumulation is wired into _mark_success (every data-bearing poll)."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+
+    coordinator._mark_success(_comms_plant(crc={0x32: 3}, system_time=datetime.now()))
+    assert coordinator.crc_failures_by_device == {0x32: 3}
+    assert coordinator.last_successful_refresh is not None
 
 
 async def test_partial_log_throttled_and_resets(hass, mock_plant, caplog):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,11 +1,14 @@
 """Tests for the GivEnergy Local sensor platform."""
 
 from datetime import UTC
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.components.sensor import SensorStateClass
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity import EntityCategory
 
 from custom_components.givenergy_local.const import CONF_BATTERY_DATA_ONLY, DOMAIN
 from custom_components.givenergy_local.sensor import (
@@ -187,6 +190,39 @@ async def test_expected_sensor_count(hass, setup_integration):
     assert len(sensors) == expected
 
 
+def test_comms_counter_descriptions_compute_total_and_breakdown():
+    """The CRC/splice diagnostic counters sum across devices and expose a
+    per-device breakdown attribute (None when nothing has been counted)."""
+    by_key = {d.key: d for d in COORDINATOR_SENSORS}
+    coord = SimpleNamespace(
+        crc_failures_by_device={0x33: 2, 0x32: 1},
+        splice_rejections_by_device={},
+        splice_holds_by_device={0x70: 5},
+        read_retries_by_device={0x33: 8},
+    )
+
+    for key in ("crc_failures", "splice_rejections", "splice_holds", "read_retries"):
+        desc = by_key[key]
+        assert desc.state_class == SensorStateClass.TOTAL_INCREASING
+        assert desc.entity_category == EntityCategory.DIAGNOSTIC
+        assert desc.attributes_fn is not None
+
+    assert by_key["crc_failures"].value_fn(coord) == 3
+    assert by_key["crc_failures"].attributes_fn(coord) == {"per_device": {"0x32": 1, "0x33": 2}}
+    assert by_key["splice_rejections"].value_fn(coord) == 0
+    assert by_key["splice_rejections"].attributes_fn(coord) is None
+    assert by_key["splice_holds"].value_fn(coord) == 5
+    assert by_key["read_retries"].value_fn(coord) == 8
+
+
+async def test_comms_counter_sensors_default_to_zero(hass, setup_integration):
+    """The four noise-floor counters are created and read 0 on a clean plant."""
+    for key in ("crc_failures", "splice_rejections", "splice_holds", "read_retries"):
+        state = hass.states.get(_entity_id(hass, "sensor", f"SA1234G123_{key}"))
+        assert state is not None, f"{key} sensor should be created"
+        assert state.state == "0"
+
+
 async def test_single_phase_only_sensors_absent_on_three_phase(
     hass, mock_client, mock_config_entry
 ):
@@ -346,7 +382,6 @@ async def test_bms_status_warning_rendered_as_hex(hass, setup_integration):
 def test_battery_hex_formatter_branches():
     """The _battery_hex value_fn: formats ints, unwraps Enum-like `.value`, and
     fails soft (None) on missing or non-numeric attributes."""
-    from types import SimpleNamespace
 
     from custom_components.givenergy_local.sensor import _battery_hex
 


### PR DESCRIPTION
## Summary

Adds four coordinator **diagnostic** sensors that surface a plant's comms-quality "noise floor" — the events that are otherwise only visible by grepping logs after the fact:

- **CRC Errors** — CRC-failed responses the library skipped (keep-last-good)
- **Splice Guard Rejections** — battery banks hard-rejected by the sub-bus splice guard
- **Splice Guard Holds** — banks escrowed for one poll pending confirmation (the softer signal)
- **Read Retries** — register reads that needed a re-request (the earliest creeping-degradation signal)

Each is a `TOTAL_INCREASING` diagnostic sensor that sums across devices and carries a `per_device` breakdown attribute, so a single noisy device (a flaky bus, one splice-rejecting pack) stands out against the plant total.

## How it works

The coordinator mirrors per-device counters from the modbus library, accumulating **reset-aware deltas** in `_mark_success` (the one chokepoint hit by every data-bearing poll) so the figures stay monotonic across reconnects — same philosophy as the existing `total_failures`. Reads are **defensive** (`getattr` + `isinstance` dict check), so on a modbus build that predates the counters every sensor simply reads `0`.

## Cross-repo dependency

These counters don't exist in `givenergy-modbus` yet — they're handed off as a separate issue on that repo. Because the reads are defensive, this PR is a **safe no-op** until the modbus floor is bumped to a release exposing them; the sensors then light up with no further hass change. CRC skips and splice trips are reported by the library as *successful* polls (keep-last-good), so they're invisible to the coordinator's outer loop — which is exactly why the library-side counters are needed rather than deriving these from partial-refresh data.

## Test plan

- [x] `uv run pytest -q` — 462 passed
- [x] `uv run ruff check` + `ruff format` clean
- [x] `uv run mypy` clean
- [x] pre-commit hooks pass
- New unit tests cover per-device accumulation, monotonicity across a Plant reset (reconnect), the defensive no-op on an old/mock plant, the `_mark_success` wiring, and the four sensor descriptions (sum + `per_device` attribute).
- [ ] Live: confirm the four sensors appear and track the noise floor once the modbus floor is bumped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added diagnostic sensors for communication quality metrics, including per-device breakdowns of CRC failures, splice rejections, splice holds, and read retries.
  * Communication counters now persist and accumulate across device reconnections for improved system health monitoring.

* **Tests**
  * Added comprehensive test coverage for communication counter tracking and accumulation across reconnection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->