### PR TITLE
feat: surface EMS-managed inverters as child devices

### DIFF
--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1294,7 +1294,7 @@ MANAGED_INVERTER_SENSORS: tuple[GivEnergyManagedInverterSensorDescription, ...] 
         key="status",
         name="Status",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda summary: getattr(summary.status, "name", summary.status),
+        value_fn=lambda summary: summary.status.name if summary.status is not None else None,
     ),
     GivEnergyManagedInverterSensorDescription(
         key="power",

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from givenergy_modbus.model.aio_battery import AioBatteryModule
 from givenergy_modbus.model.battery import Battery, BatteryMaintenance
+from givenergy_modbus.model.devices import InverterSummary
 from givenergy_modbus.model.hv_bcu import Bcu, HvStack
 from givenergy_modbus.model.inverter import (
     BatteryCalibrationStage,
@@ -114,6 +115,20 @@ def _bcu_attr(name: str) -> Callable[[Bcu], Any]:
     guaranteed present by the pinned givenergy-modbus model.
     """
     return lambda bcu: getattr(bcu, name)
+
+
+@dataclass(frozen=True, kw_only=True)
+class GivEnergyManagedInverterSensorDescription(SensorEntityDescription):
+    value_fn: Callable[[InverterSummary], Any] = field(default=lambda _: None)
+
+
+def _summary_attr(name: str) -> Callable[[InverterSummary], Any]:
+    """Return a value_fn that reads `name` off an EMS managed-inverter summary.
+
+    Counterpart of `_module_attr`/`_bcu_attr` for the blinded `InverterSummary`
+    rollup an EMS controller exposes per managed inverter.
+    """
+    return lambda summary: getattr(summary, name)
 
 
 def _battery_hex(name: str, width: int) -> Callable[[Battery], Any]:
@@ -1270,6 +1285,45 @@ HV_STACK_SENSORS: tuple[GivEnergyHvStackSensorDescription, ...] = (
 )
 
 
+# EMS managed-inverter summary sensors. On an EMS plant the 0x11 device is the
+# controller; each inverter it manages is reported only as a blinded rollup
+# summary (status/power/SoC/temp — no per-string detail). One HA device per
+# managed inverter, keyed by its own serial. See GivEnergyManagedInverterSensor.
+MANAGED_INVERTER_SENSORS: tuple[GivEnergyManagedInverterSensorDescription, ...] = (
+    GivEnergyManagedInverterSensorDescription(
+        key="status",
+        name="Status",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda summary: getattr(summary.status, "name", summary.status),
+    ),
+    GivEnergyManagedInverterSensorDescription(
+        key="power",
+        name="Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_summary_attr("p_inverter_out"),
+    ),
+    GivEnergyManagedInverterSensorDescription(
+        key="battery_soc",
+        name="Battery SOC",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_summary_attr("battery_soc"),
+    ),
+    GivEnergyManagedInverterSensorDescription(
+        key="temperature",
+        name="Temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_summary_attr("t_inverter_heatsink"),
+    ),
+)
+
+
 def _partial_failure_attributes(
     coordinator: GivEnergyUpdateCoordinator,
 ) -> dict[str, Any] | None:
@@ -1502,6 +1556,27 @@ async def async_setup_entry(
             GivEnergyHvStackSensor(coordinator, description, stack_index)
             for description in HV_STACK_SENSORS
         )
+
+    # EMS-managed inverters — empty unless this is an EMS plant. The 0x11 device
+    # is the EMS controller; each inverter it manages is a blinded rollup summary
+    # (status/power/SoC/temp). Surface each as its own device parented to the
+    # controller. managed_inverters already filters empty slots; dedup by serial
+    # defensively, mirroring the AIO loop.
+    ems = coordinator.data.ems
+    if ems is not None:
+        seen_managed_serials: set[str] = set()
+        for summary in ems.managed_inverters:
+            if summary.serial_number in seen_managed_serials:
+                _LOGGER.warning(
+                    "Skipping EMS managed inverter: duplicate serial %s",
+                    summary.serial_number,
+                )
+                continue
+            seen_managed_serials.add(summary.serial_number)
+            entities.extend(
+                GivEnergyManagedInverterSensor(coordinator, description, summary.serial_number)
+                for description in MANAGED_INVERTER_SENSORS
+            )
 
     entities.extend(
         GivEnergyCoordinatorSensor(coordinator, description) for description in COORDINATOR_SENSORS
@@ -2019,6 +2094,67 @@ class GivEnergyHvStackSensor(
         if stack is None:
             return None
         return self.entity_description.value_fn(stack.bcu)
+
+
+class GivEnergyManagedInverterSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity):
+    """Summary sensor for one EMS-managed inverter.
+
+    On an EMS plant the 0x11 device is the EMS *controller*; the inverters it
+    manages appear only as blinded rollup summaries (status / power / SoC /
+    heatsink temp — no per-string detail). Each managed inverter becomes its own
+    HA device, parented to the controller via `via_device` and identified by its
+    own serial. The rollup lives in the EMS block on 0x11 (there's no per-inverter
+    register bank), so there's no stale gate: availability is simply whether the
+    serial is still present in the latest poll.
+    """
+
+    _attr_has_entity_name = True
+    entity_description: GivEnergyManagedInverterSensorDescription
+
+    def __init__(
+        self,
+        coordinator: GivEnergyUpdateCoordinator,
+        description: GivEnergyManagedInverterSensorDescription,
+        serial: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        # Bind to the managed inverter's serial, not its slot position: the rollup
+        # is rebuilt each refresh and a dropped slot shifts the rest, so resolving
+        # by serial keeps each entity tied to its own inverter.
+        self._serial = serial
+        self._attr_unique_id = f"{serial}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy Managed Inverter {serial}",
+            manufacturer="GivEnergy",
+            model="Managed Inverter (EMS)",
+            serial_number=serial,
+            via_device=(DOMAIN, coordinator.data.inverter_serial_number),
+        )
+
+    def _summary(self) -> InverterSummary | None:
+        """Resolve this entity's managed inverter by serial in the latest data."""
+        data = self.coordinator.data
+        if data is None or data.ems is None:
+            return None
+        return next(
+            (s for s in data.ems.managed_inverters if s.serial_number == self._serial),
+            None,
+        )
+
+    @property
+    def available(self) -> bool:
+        # Unavailable when this managed inverter has dropped out of the EMS
+        # rollup (its serial is no longer reported).
+        return super().available and self._summary() is not None
+
+    @property
+    def native_value(self) -> Any:
+        summary = self._summary()
+        if summary is None:
+            return None
+        return self.entity_description.value_fn(summary)
 
 
 class GivEnergyCoordinatorSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity):

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from givenergy_modbus.model import TimeSlot
+from givenergy_modbus.model.devices import InverterSummary
 from givenergy_modbus.model.inverter import Model
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
@@ -40,6 +41,7 @@ def mock_ems() -> MagicMock:
     ems.export_target_3 = 4
     ems.export_power_limit = 3600
     ems.plant_enabled = True
+    ems.managed_inverters = []
     return ems
 
 
@@ -56,6 +58,34 @@ async def ems_setup(hass, mock_client, mock_plant, mock_inverter, mock_ems, mock
 
 def _entity_id(hass, platform: str, unique_id: str) -> str | None:
     return er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
+
+
+def _managed(serial: str, *, power=1000, soc=55, temp=31.5, status=None) -> InverterSummary:
+    """Build a blinded managed-inverter rollup summary."""
+    return InverterSummary(
+        serial_number=serial,
+        status=status,
+        p_inverter_out=power,
+        battery_soc=soc,
+        t_inverter_heatsink=temp,
+    )
+
+
+@pytest.fixture
+async def managed_ems_setup(
+    hass, mock_client, mock_plant, mock_inverter, mock_ems, mock_config_entry
+):
+    """An EMS plant whose controller fronts two managed inverters."""
+    mock_ems.managed_inverters = [
+        _managed("SA1111A001", power=1500, soc=60, temp=30.5),
+        _managed("SA2222A002", power=-200, soc=45, temp=28.0),
+    ]
+    mock_plant.ems = mock_ems
+    mock_inverter.model = Model.EMS
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
 
 
 # ---------------------------------------------------------------------------
@@ -242,3 +272,77 @@ async def test_realignment_issue_raised_for_stale_inverter_prefixed_entities(
         DOMAIN, f"ems_entity_ids_outdated_{mock_config_entry.entry_id}"
     )
     assert issue is not None
+
+
+# ---------------------------------------------------------------------------
+# Managed-inverter child devices
+# ---------------------------------------------------------------------------
+
+
+async def test_managed_inverter_devices_created_and_parented(hass, managed_ems_setup):
+    """Each managed inverter is its own device, parented to the EMS controller."""
+    registry = er.async_get(hass)
+    dev_registry = dr.async_get(hass)
+    controller = dev_registry.async_get_device(identifiers={(DOMAIN, "SA1234G123")})
+    assert controller is not None
+    for serial in ("SA1111A001", "SA2222A002"):
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_power")
+        assert entity_id is not None, f"{serial} has no power sensor"
+        device = dev_registry.async_get(registry.async_get(entity_id).device_id)
+        assert (DOMAIN, serial) in device.identifiers
+        assert device.name == f"GivEnergy Managed Inverter {serial}"
+        assert device.model == "Managed Inverter (EMS)"
+        assert device.via_device_id == controller.id
+
+
+async def test_managed_inverter_values(hass, managed_ems_setup):
+    """The blinded summary fields surface on the child sensors."""
+    assert hass.states.get(_entity_id(hass, "sensor", "SA1111A001_power")).state == "1500"
+    assert hass.states.get(_entity_id(hass, "sensor", "SA1111A001_battery_soc")).state == "60"
+    temp = hass.states.get(_entity_id(hass, "sensor", "SA1111A001_temperature"))
+    assert float(temp.state) == 30.5
+    assert temp.attributes["unit_of_measurement"] == "°C"
+    assert hass.states.get(_entity_id(hass, "sensor", "SA2222A002_power")).state == "-200"
+
+
+async def test_managed_inverter_resolves_by_serial(hass, managed_ems_setup):
+    """A managed inverter that drops out of the rollup goes unavailable while the
+    survivor keeps reporting — entities track serial, not slot position."""
+    coordinator = hass.data[DOMAIN][managed_ems_setup.entry_id]
+    coordinator.data.ems.managed_inverters = [_managed("SA2222A002", power=-200, soc=45, temp=28.0)]
+    coordinator.async_set_updated_data(coordinator.data)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(_entity_id(hass, "sensor", "SA2222A002_power")).state == "-200"
+    assert hass.states.get(_entity_id(hass, "sensor", "SA1111A001_power")).state == "unavailable"
+
+
+async def test_no_managed_inverter_devices_for_non_ems_plant(hass, setup_integration):
+    """A non-EMS plant gets no managed-inverter devices."""
+    dev_registry = dr.async_get(hass)
+    managed = [
+        d
+        for d in dr.async_entries_for_config_entry(dev_registry, setup_integration.entry_id)
+        if d.model == "Managed Inverter (EMS)"
+    ]
+    assert managed == []
+
+
+async def test_managed_inverter_dedup_duplicate_serial(
+    hass, mock_client, mock_plant, mock_inverter, mock_ems, mock_config_entry
+):
+    """Two rollup slots reporting the same serial yield a single device."""
+    mock_ems.managed_inverters = [_managed("SA3333A003"), _managed("SA3333A003", power=99)]
+    mock_plant.ems = mock_ems
+    mock_inverter.model = Model.EMS
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    dev_registry = dr.async_get(hass)
+    managed = [
+        d
+        for d in dr.async_entries_for_config_entry(dev_registry, mock_config_entry.entry_id)
+        if d.model == "Managed Inverter (EMS)"
+    ]
+    assert len(managed) == 1

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -223,6 +223,28 @@ async def test_comms_counter_sensors_default_to_zero(hass, setup_integration):
         assert state.state == "0"
 
 
+def test_managed_inverter_sensor_descriptions():
+    """Managed-inverter summary sensors carry the right units/classes, and the
+    status value_fn renders an enum's name while tolerating None."""
+    from types import SimpleNamespace
+
+    from homeassistant.components.sensor import SensorDeviceClass
+
+    from custom_components.givenergy_local.sensor import MANAGED_INVERTER_SENSORS
+
+    by_key = {d.key: d for d in MANAGED_INVERTER_SENSORS}
+    assert set(by_key) == {"status", "power", "battery_soc", "temperature"}
+    assert by_key["power"].device_class == SensorDeviceClass.POWER
+    assert by_key["power"].native_unit_of_measurement == "W"
+    assert by_key["battery_soc"].device_class == SensorDeviceClass.BATTERY
+    assert by_key["temperature"].device_class == SensorDeviceClass.TEMPERATURE
+    assert by_key["temperature"].native_unit_of_measurement == "°C"
+
+    status_fn = by_key["status"].value_fn
+    assert status_fn(SimpleNamespace(status=SimpleNamespace(name="ONLINE"))) == "ONLINE"
+    assert status_fn(SimpleNamespace(status=None)) is None
+
+
 async def test_single_phase_only_sensors_absent_on_three_phase(
     hass, mock_client, mock_config_entry
 ):


### PR DESCRIPTION
## Summary

On an EMS plant the device at modbus `0x11` is the EMS **controller**, and the inverters it manages are reported only as blinded rollup summaries (no per-string detail). Until now those managed inverters weren't modelled at all — the integration only consumed `Plant.ems` for the scheduling controls.

This surfaces each managed inverter as its own HA **device**, parented to the EMS controller:

- A `GivEnergyManagedInverterSensor` + `MANAGED_INVERTER_SENSORS` covering the summary fields the library exposes: **status**, **power** (W), **battery SOC** (%), **heatsink temperature** (°C).
- Each managed inverter is its own device, keyed by its **own serial**, `via_device` → the EMS controller (`inverter_serial_number`), resolved **by serial each poll** (the rollup is rebuilt per refresh; a dropped slot shifts the rest).
- Read-only (the summaries are blinded — no controls). **No stale gate**: the rollup lives in the EMS block on `0x11` with no per-inverter register bank, so availability is simply whether the serial is still present in the latest poll.
- Empty/no-op on every non-EMS plant.

## Context

This is the first slice of modelling the real plant topology on the consumer side, per the topology analysis: the `0x11` device is always the comms root and is already typed by role (`_device_kind`), so the modelling gap is **downstream** — the units a controller fronts. EMS is the validatable half today; the gateway equivalent (parallel AIOs) uses the identical pattern but is staged behind a Gen-1 Gateway wire capture (#194). It also exercises the typed-device enumeration the dormant modbus#106 graph would formalise.

## Test plan

- [x] `uv run pytest -q` — 470 passed
- [x] ruff + mypy + pre-commit clean
- New tests: device creation + parenting to the controller, value surfacing, resolve-by-serial (drop one → unavailable, survivor keeps value), dedup-by-serial, none-on-non-EMS, descriptor units + status `value_fn`.
- [ ] Live: confirm on a real EMS install (Nick's) that the managed-inverter devices appear with sensible status/power/SoC/temp — and specifically whether the install fronts **more than one** managed inverter (a single-inverter EMS makes the child device somewhat redundant, though still correct).