### PR TITLE
fix(deps): bump givenergy-modbus to 2.5.4

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.5.3,<3.0.0"
+    "givenergy-modbus>=2.5.4,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.5.3,<3.0.0",
+    "givenergy-modbus>=2.5.4,<3.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.3,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.4,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.5.3"
+version = "2.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/e5/a8b7c235c2e7de99d80a3007ca511b805f70ec5ff7ae9803abd2200d82b7/givenergy_modbus-2.5.3.tar.gz", hash = "sha256:09dcc28d4f09522be196ba4d1a2b3473b19659b1ba876e8078374becf27c2598", size = 432610, upload-time = "2026-06-23T17:25:36.484Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/1b/6c8c237bbf2a3b30593215e634bf45056688d1e5ed4ffde6c21d97b345ee/givenergy_modbus-2.5.4.tar.gz", hash = "sha256:39de56ba061cfc7b1a9cd90d023ffa9cb6d6d686e7003cfeb0978cae794292fd", size = 433888, upload-time = "2026-06-23T19:04:25.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/ba/1bd94df1a7ec833d05c938d232bb96f2e253c451ce1eee5d8f3a68ed1efa/givenergy_modbus-2.5.3-py3-none-any.whl", hash = "sha256:5b1766c1130659e9cda08c5f5388468b3954973357947205875519b3f1b0bc23", size = 164494, upload-time = "2026-06-23T17:25:34.535Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1d/e418b5ffa84f7221fcb51ad71c27d7f41095b64da76e927a975668ff7c65/givenergy_modbus-2.5.4-py3-none-any.whl", hash = "sha256:bc08b4bedf80f0797b2dffa938d20ef57ec42980d0b5af3a0225536b1f44c9bc", size = 165086, upload-time = "2026-06-23T19:04:24.504Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated bump triggered by [givenergy-modbus@2.5.4](https://github.com/dewet22/givenergy-modbus/releases/tag/v2.5.4).