### PR TITLE
feat: surface cold-start baseline holds + bump modbus floor to 2.5.5

### DIFF
--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -192,6 +192,9 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         self.splice_rejections_by_device: dict[int, int] = {}
         self.splice_holds_by_device: dict[int, int] = {}
         self.read_retries_by_device: dict[int, int] = {}
+        # Cold-start battery-baseline holds (modbus #289, 2.5.5): a benign
+        # "establishing baseline" signal, distinct from splice_holds (corruption).
+        self.cold_start_held_by_device: dict[int, int] = {}
         # Last cumulative value seen per library attr per device, for delta-ing.
         self._comms_last_seen: dict[str, dict[int, int]] = {}
         # Length of the current unbroken run of partial polls, used only to
@@ -319,6 +322,7 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         ("splice_reject_count", "splice_rejections_by_device"),
         ("splice_held_count", "splice_holds_by_device"),
         ("retry_count", "read_retries_by_device"),
+        ("cold_start_held_count", "cold_start_held_by_device"),
     )
 
     def _accumulate_comms_counters(self, plant: Plant) -> None:

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.5.4,<3.0.0"
+    "givenergy-modbus>=2.5.5,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1408,7 +1408,7 @@ COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
     ),
     GivEnergyCoordinatorSensorDescription(
         key="crc_failures",
-        name="CRC Errors",
+        name="Comms CRC Errors",
         # Per-device CRC-failed responses the library skipped (keep-last-good).
         # A few a day is the normal noise floor; a climbing rate on one device
         # flags a degrading link. The attributes name which device(s).
@@ -1419,7 +1419,7 @@ COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
     ),
     GivEnergyCoordinatorSensorDescription(
         key="splice_rejections",
-        name="Splice Guard Rejections",
+        name="Comms Splice Guard Rejections",
         # Battery banks hard-rejected by the sub-bus splice guard (keep-last-
         # good). Expected to be near-zero; a sustained climb on one pack points
         # at sub-bus corruption or a poisoned baseline.
@@ -1430,7 +1430,7 @@ COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
     ),
     GivEnergyCoordinatorSensorDescription(
         key="splice_holds",
-        name="Splice Guard Holds",
+        name="Comms Splice Guard Holds",
         # Banks escrowed for one poll pending confirmation — the softer splice
         # signal (often benign). Counts hold events, not currently-held banks.
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -1440,7 +1440,7 @@ COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
     ),
     GivEnergyCoordinatorSensorDescription(
         key="read_retries",
-        name="Read Retries",
+        name="Comms Read Retries",
         # Register reads that needed at least one re-request before succeeding
         # (or giving up). The earliest creeping-degradation signal — a read that
         # recovers on retry is otherwise reported as a clean success. A climbing
@@ -1452,7 +1452,7 @@ COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
     ),
     GivEnergyCoordinatorSensorDescription(
         key="cold_start_holds",
-        name="Cold Start Holds",
+        name="Comms Cold Start Holds",
         # Battery banks held one extra poll at cold start awaiting baseline
         # corroboration (modbus #289). A benign "establishing baseline" signal —
         # distinct from Splice Guard Holds (which means corruption is being held).

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1450,6 +1450,17 @@ COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
         attributes_fn=_comms_counter_attributes("read_retries_by_device"),
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    GivEnergyCoordinatorSensorDescription(
+        key="cold_start_holds",
+        name="Cold Start Holds",
+        # Battery banks held one extra poll at cold start awaiting baseline
+        # corroboration (modbus #289). A benign "establishing baseline" signal —
+        # distinct from Splice Guard Holds (which means corruption is being held).
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda coord: sum(coord.cold_start_held_by_device.values()),
+        attributes_fn=_comms_counter_attributes("cold_start_held_by_device"),
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.5.4,<3.0.0",
+    "givenergy-modbus>=2.5.5,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -423,7 +423,9 @@ async def test_partial_success_increments_partial_failures_cumulatively(hass, mo
     assert coordinator.total_failures == 0
 
 
-def _comms_plant(crc=None, reject=None, held=None, retry=None, system_time=None) -> SimpleNamespace:
+def _comms_plant(
+    crc=None, reject=None, held=None, retry=None, cold=None, system_time=None
+) -> SimpleNamespace:
     """A minimal plant stub carrying the library's comms-quality counters."""
     return SimpleNamespace(
         inverter=SimpleNamespace(system_time=system_time),
@@ -431,6 +433,7 @@ def _comms_plant(crc=None, reject=None, held=None, retry=None, system_time=None)
         splice_reject_count=reject if reject is not None else {},
         splice_held_count=held if held is not None else {},
         retry_count=retry if retry is not None else {},
+        cold_start_held_count=cold if cold is not None else {},
     )
 
 
@@ -439,21 +442,35 @@ async def test_comms_counters_accumulate_per_device(hass):
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
 
     coordinator._accumulate_comms_counters(
-        _comms_plant(crc={0x32: 2, 0x33: 1}, reject={0x33: 4}, held={0x70: 5}, retry={0x33: 6})
+        _comms_plant(
+            crc={0x32: 2, 0x33: 1},
+            reject={0x33: 4},
+            held={0x70: 5},
+            retry={0x33: 6},
+            cold={0x32: 2},
+        )
     )
     assert coordinator.crc_failures_by_device == {0x32: 2, 0x33: 1}
     assert coordinator.splice_rejections_by_device == {0x33: 4}
     assert coordinator.splice_holds_by_device == {0x70: 5}
     assert coordinator.read_retries_by_device == {0x33: 6}
+    assert coordinator.cold_start_held_by_device == {0x32: 2}
 
     # A later poll with higher cumulative values accrues only the delta.
     coordinator._accumulate_comms_counters(
-        _comms_plant(crc={0x32: 5, 0x33: 1}, reject={0x33: 4}, held={0x70: 9}, retry={0x33: 10})
+        _comms_plant(
+            crc={0x32: 5, 0x33: 1},
+            reject={0x33: 4},
+            held={0x70: 9},
+            retry={0x33: 10},
+            cold={0x32: 5},
+        )
     )
     assert coordinator.crc_failures_by_device == {0x32: 5, 0x33: 1}
     assert coordinator.splice_rejections_by_device == {0x33: 4}
     assert coordinator.splice_holds_by_device == {0x70: 9}
     assert coordinator.read_retries_by_device == {0x33: 10}
+    assert coordinator.cold_start_held_by_device == {0x32: 5}
 
 
 async def test_comms_counters_monotonic_across_plant_reset(hass):
@@ -478,6 +495,7 @@ async def test_comms_counters_absent_leaves_zero(hass):
     assert coordinator.splice_rejections_by_device == {}
     assert coordinator.splice_holds_by_device == {}
     assert coordinator.read_retries_by_device == {}
+    assert coordinator.cold_start_held_by_device == {}
 
 
 async def test_mark_success_accumulates_comms_counters(hass):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -199,9 +199,16 @@ def test_comms_counter_descriptions_compute_total_and_breakdown():
         splice_rejections_by_device={},
         splice_holds_by_device={0x70: 5},
         read_retries_by_device={0x33: 8},
+        cold_start_held_by_device={0x32: 3},
     )
 
-    for key in ("crc_failures", "splice_rejections", "splice_holds", "read_retries"):
+    for key in (
+        "crc_failures",
+        "splice_rejections",
+        "splice_holds",
+        "read_retries",
+        "cold_start_holds",
+    ):
         desc = by_key[key]
         assert desc.state_class == SensorStateClass.TOTAL_INCREASING
         assert desc.entity_category == EntityCategory.DIAGNOSTIC
@@ -213,11 +220,18 @@ def test_comms_counter_descriptions_compute_total_and_breakdown():
     assert by_key["splice_rejections"].attributes_fn(coord) is None
     assert by_key["splice_holds"].value_fn(coord) == 5
     assert by_key["read_retries"].value_fn(coord) == 8
+    assert by_key["cold_start_holds"].value_fn(coord) == 3
 
 
 async def test_comms_counter_sensors_default_to_zero(hass, setup_integration):
-    """The four noise-floor counters are created and read 0 on a clean plant."""
-    for key in ("crc_failures", "splice_rejections", "splice_holds", "read_retries"):
+    """The five noise-floor counters are created and read 0 on a clean plant."""
+    for key in (
+        "crc_failures",
+        "splice_rejections",
+        "splice_holds",
+        "read_retries",
+        "cold_start_holds",
+    ):
         state = hass.states.get(_entity_id(hass, "sensor", f"SA1234G123_{key}"))
         assert state is not None, f"{key} sensor should be created"
         assert state.state == "0"

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.4,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.5,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.5.4"
+version = "2.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/1b/6c8c237bbf2a3b30593215e634bf45056688d1e5ed4ffde6c21d97b345ee/givenergy_modbus-2.5.4.tar.gz", hash = "sha256:39de56ba061cfc7b1a9cd90d023ffa9cb6d6d686e7003cfeb0978cae794292fd", size = 433888, upload-time = "2026-06-23T19:04:25.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/52/63789d0a96f1e6c5fb53b4d9bdd6c194f9a53c44132d84cafcd6b3033a64/givenergy_modbus-2.5.5.tar.gz", hash = "sha256:526112bcf26d3749ce0d15f75b13007f1341d7db2ccde2a133f3e65379d3dbec", size = 439836, upload-time = "2026-06-23T21:12:16.545Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/1d/e418b5ffa84f7221fcb51ad71c27d7f41095b64da76e927a975668ff7c65/givenergy_modbus-2.5.4-py3-none-any.whl", hash = "sha256:bc08b4bedf80f0797b2dffa938d20ef57ec42980d0b5af3a0225536b1f44c9bc", size = 165086, upload-time = "2026-06-23T19:04:24.504Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a5/da5a98ee90f19aa08331e2ac67868f0b827b267ae049473246c64d816111/givenergy_modbus-2.5.5-py3-none-any.whl", hash = "sha256:90b632d795f237a34da7d5c76a6f7fba78936226880df32070c54893e662d3b6", size = 167688, upload-time = "2026-06-23T21:12:14.599Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

modbus 2.5.5 ([#289](https://github.com/dewet22/givenergy-modbus/issues/289)) adds cold-start battery-baseline confirmation — a battery bank is held one extra poll until a second read corroborates it, so a transient first-frame sub-bus splice can't poison the baseline. It exposes a per-device `cold_start_held_count`.

This:
- **Bumps the modbus floor to `>=2.5.5`** (manifest + pyproject + uv.lock) to pick up #289 — the cold-start half of the splice-guard work, completing the battery-offline-robustness saga (after 2.5.2's poisoned-baseline self-heal and 2.5.4's heal-after-insistence).
- **Surfaces `cold_start_held_count` as a fifth coordinator diagnostic** ("Comms Cold Start Holds"), reusing the existing reset-aware comms-counter accumulation and the per-device breakdown attribute. It's a benign "establishing baseline" signal — deliberately distinct from "Comms Splice Guard Holds" (which means corruption is being held).
- **Groups the five noise-floor diagnostics under a "Comms" name prefix** (CRC Errors, Splice Guard Rejections/Holds, Read Retries, Cold Start Holds) so they cluster together in the device's Diagnostic section. Display-name only — each sensor's `key`/`unique_id` is unchanged, so the four already shipped in v1.3.8 keep their entity_id and history; only the friendly name moves.

No other behaviour change: #289's "battery telemetry appears ~1 poll later at cold start" is already tolerated (absent battery registers render unavailable, well under the 300s staleness ceiling).

## Test plan
- [x] `uv run pytest -q` — 470 passed
- [x] ruff + mypy + pre-commit clean
- [x] Verified `Plant.cold_start_held_count` is present in modbus 2.5.5
- Extended the coordinator accumulation tests and the sensor descriptor/default-zero tests to cover the fifth counter.