### PR TITLE
feat: AIO feedback follow-ups — drop bogus HV Battery Power, gate PV sensors, add-time battery-data-only (#95)

### DIFF
--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -37,6 +37,13 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+# Initial setup also offers battery-data-only, so a parallel-mode AIO can be added
+# without its inverter-level sensors ever being created and then going unavailable
+# (#95). Reconfigure uses the base schema — the toggle lives in options thereafter.
+STEP_USER_SETUP_SCHEMA = STEP_USER_DATA_SCHEMA.extend(
+    {vol.Required(CONF_BATTERY_DATA_ONLY, default=DEFAULT_BATTERY_DATA_ONLY): bool}
+)
+
 
 class GivEnergyLocalConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 2
@@ -59,14 +66,21 @@ class GivEnergyLocalConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 await self.async_set_unique_id(serial)
                 self._abort_if_unique_id_configured()
+                # The toggle is read from entry.options everywhere (it's normally
+                # set via the options flow), so split it out of data into options
+                # rather than leaving it in data where nothing would read it.
+                battery_data_only = user_input.pop(
+                    CONF_BATTERY_DATA_ONLY, DEFAULT_BATTERY_DATA_ONLY
+                )
                 return self.async_create_entry(
                     title=f"GivEnergy {serial}",
                     data=user_input,
+                    options={CONF_BATTERY_DATA_ONLY: battery_data_only},
                 )
 
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=STEP_USER_SETUP_SCHEMA,
             errors=errors,
         )
 

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1512,9 +1512,12 @@ async def async_setup_entry(
     inverter = coordinator.data.inverter
     capabilities = coordinator.data.capabilities
     is_three_phase = bool(capabilities and capabilities.is_three_phase)
-    # An AIO (battery-only) plant carries per-module battery devices; its inverter
-    # exposes PV/solar fields that read meaningless values, so gate those out (#95).
-    is_aio = bool(coordinator.data.aio_battery_modules)
+    # A pure All-in-One is battery-only, so its inverter's PV/solar fields read
+    # meaningless values — gate those sensors out (#95). Key off the detected model
+    # (restored from the on-disk capabilities cache), NOT decoded module telemetry:
+    # an AIO whose modules drop out on the setup poll must still be recognised, and
+    # ALL_IN_ONE_HYBRID genuinely has PV so is deliberately excluded.
+    is_aio = bool(capabilities) and capabilities.device_type is Model.ALL_IN_ONE
     battery_data_only = entry.options.get(CONF_BATTERY_DATA_ONLY, DEFAULT_BATTERY_DATA_ONLY)
 
     entities: list[SensorEntity] = []

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -56,6 +56,11 @@ class GivEnergyInverterSensorDescription(SensorEntityDescription):
     value_fn: Callable[[InverterModel], Any] = field(default=lambda _: None)
     # If True, the entity is not created when value_fn returns None at first refresh.
     skip_if_none: bool = False
+    # If True, the entity is not created on an AIO (battery-only) plant, where the
+    # field reads a meaningless value rather than None (MPPT count 0, a solar
+    # diverter total, a static yearly discharge figure), so skip_if_none can't
+    # catch it (#95).
+    skip_if_aio: bool = False
     # If True, the entity is not created on three-phase inverters, where the
     # underlying field is single-phase-only (e.g. a p_pv1+p_pv2 sum) and so would
     # be meaningless or surface as a permanently-unavailable orphan entity.
@@ -723,7 +728,10 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda inv: inv.e_discharge_year,
-        # None on AIO (IR29 unpopulated) — drop rather than show "Unknown" (#194).
+        # AIO reports a static, meaningless figure here (not None), so skip_if_none
+        # never caught it — gate on AIO topology instead (#95). skip_if_none still
+        # drops it on any non-AIO model where the register is genuinely absent.
+        skip_if_aio=True,
         skip_if_none=True,
     ),
     # --- Lifetime battery energy totals (routed per-model in givenergy-modbus
@@ -757,6 +765,8 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        # No PV/solar on a battery-only AIO; reads 0.0 not None, so gate on AIO (#95).
+        skip_if_aio=True,
         skip_if_none=True,
         value_fn=lambda inv: inv.e_solar_diverter,
     ),
@@ -841,7 +851,8 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         key="num_mppt",
         name="MPPT Count",
         value_fn=lambda inv: inv.num_mppt,
-        # None on AIO (HR3 high byte unpopulated) — drop rather than "Unknown" (#194).
+        # No PV strings on a battery-only AIO; reads 0 not None, so gate on AIO (#95).
+        skip_if_aio=True,
         skip_if_none=True,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
@@ -1188,14 +1199,6 @@ HV_STACK_SENSORS: tuple[GivEnergyHvStackSensorDescription, ...] = (
         value_fn=_bcu_attr("battery_current"),
     ),
     GivEnergyHvStackSensorDescription(
-        key="battery_power",
-        name="Battery Power",
-        native_unit_of_measurement=UnitOfPower.KILO_WATT,
-        device_class=SensorDeviceClass.POWER,
-        state_class=SensorStateClass.MEASUREMENT,
-        value_fn=_bcu_attr("battery_power"),
-    ),
-    GivEnergyHvStackSensorDescription(
         key="battery_soc_max",
         name="Battery SOC Max",
         native_unit_of_measurement=PERCENTAGE,
@@ -1468,6 +1471,7 @@ def _include_inverter_sensor(
     description: GivEnergyInverterSensorDescription,
     inverter: InverterModel,
     is_three_phase: bool,
+    is_aio: bool = False,
 ) -> bool:
     """Whether to create an inverter sensor at setup.
 
@@ -1483,6 +1487,8 @@ def _include_inverter_sensor(
     skip the offending sensor with a warning, but keep the rest.
     """
     if description.single_phase_only and is_three_phase:
+        return False
+    if description.skip_if_aio and is_aio:
         return False
     if not description.skip_if_none:
         return True
@@ -1506,6 +1512,9 @@ async def async_setup_entry(
     inverter = coordinator.data.inverter
     capabilities = coordinator.data.capabilities
     is_three_phase = bool(capabilities and capabilities.is_three_phase)
+    # An AIO (battery-only) plant carries per-module battery devices; its inverter
+    # exposes PV/solar fields that read meaningless values, so gate those out (#95).
+    is_aio = bool(coordinator.data.aio_battery_modules)
     battery_data_only = entry.options.get(CONF_BATTERY_DATA_ONLY, DEFAULT_BATTERY_DATA_ONLY)
 
     entities: list[SensorEntity] = []
@@ -1518,7 +1527,7 @@ async def async_setup_entry(
         entities.extend(
             GivEnergyInverterSensor(coordinator, description)
             for description in INVERTER_SENSORS
-            if _include_inverter_sensor(description, inverter, is_three_phase)
+            if _include_inverter_sensor(description, inverter, is_three_phase, is_aio)
         )
 
     for battery_index, battery in enumerate(coordinator.data.batteries):

--- a/custom_components/givenergy_local/strings.json
+++ b/custom_components/givenergy_local/strings.json
@@ -9,6 +9,7 @@
           "port": "Modbus Port",
           "scan_interval": "Scan Interval (seconds)",
           "passive": "Passive mode (listen only — another client drives refreshes)",
+          "battery_data_only": "Battery data only (suppress controls and system sensors)",
           "timeout_tolerance": "Timeout Tolerance (consecutive failures before unavailable)"
         }
       },

--- a/custom_components/givenergy_local/translations/en.json
+++ b/custom_components/givenergy_local/translations/en.json
@@ -8,7 +8,8 @@
           "host": "Inverter IP Address",
           "port": "Modbus Port",
           "scan_interval": "Scan Interval (seconds)",
-          "passive": "Passive mode (listen only — another client drives refreshes)"
+          "passive": "Passive mode (listen only — another client drives refreshes)",
+          "battery_data_only": "Battery data only (suppress controls and system sensors)"
         }
       },
       "reconfigure": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -40,6 +40,24 @@ async def test_successful_setup_creates_entry(hass, mock_client):
     assert result["data"] == VALID_USER_INPUT
 
 
+async def test_setup_with_battery_data_only_sets_option(hass, mock_client):
+    """Ticking battery-data-only at add time lands in entry.options (where it's read
+    everywhere), not data — so a parallel-mode AIO can be added without its
+    inverter-level sensors ever being created then going unavailable (#95)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {**VALID_USER_INPUT, CONF_BATTERY_DATA_ONLY: True}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == "create_entry"
+    assert result["options"] == {CONF_BATTERY_DATA_ONLY: True}
+    assert CONF_BATTERY_DATA_ONLY not in result["data"]
+    assert result["data"] == VALID_USER_INPUT
+
+
 async def test_cannot_connect_shows_error(hass, mock_client):
     mock_client.connect.side_effect = ConnectionRefusedError()
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1098,6 +1098,18 @@ async def test_hv_stack_creates_one_device(hass, hv_setup):
     assert state.attributes["unit_of_measurement"] == "V"
 
 
+async def test_aio_model_suppresses_pv_sensors_even_with_empty_modules(hass, hv_setup):
+    """The AIO gate keys off the detected model (Model.ALL_IN_ONE, restored from the
+    capabilities cache), not decoded module telemetry. hv_setup is an AIO whose
+    aio_battery_modules list is empty (the cold-start / transient-drop case), yet the
+    PV/solar-only inverter sensors must still be suppressed (#95, review)."""
+    registry = er.async_get(hass)
+    for key in ("num_mppt", "e_solar_diverter", "e_discharge_year"):
+        assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is None, key
+    # Sanity: the inverter-sensor loop did run (only the PV/solar fields were gated).
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_system_mode") is not None
+
+
 async def test_non_hv_plant_creates_no_stack_entities(hass, setup_integration):
     """The default (non-HV) fixture must not create any HV-stack devices."""
     dev_registry = dr.async_get(hass)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -116,6 +116,20 @@ def test_aio_inapplicable_inverter_sensors_skip_if_none():
     assert _inverter_desc("inverter_fault_messages").skip_if_none is False
 
 
+def test_aio_inapplicable_inverter_sensors_gated_on_aio():
+    """MPPT Count, Solar Diverter and Battery Discharge This Year read a meaningless
+    value (0, 0.0, a static figure) — not None — on an AIO, so skip_if_none never
+    dropped them. They're gated on AIO topology instead (#95)."""
+    inv = MagicMock()  # every attr returns a truthy mock, i.e. "not None"
+    aio_gated = {"num_mppt", "e_solar_diverter", "e_discharge_year"}
+    flagged = {d.key for d in INVERTER_SENSORS if d.skip_if_aio}
+    assert flagged == aio_gated
+    for key in aio_gated:
+        # Dropped on an AIO; kept elsewhere even though the value is non-None.
+        assert _include_inverter_sensor(_inverter_desc(key), inv, False, is_aio=True) is False, key
+        assert _include_inverter_sensor(_inverter_desc(key), inv, False, is_aio=False) is True, key
+
+
 def test_extra_inverter_capability_sensors():
     """The new rated/limit fields are surfaced as power sensors; the DTC-computed
     ones skip when None (unmapped DTC) rather than showing Unknown (#194)."""
@@ -1013,7 +1027,6 @@ def _mock_bcu(version: str = "GA000009", **overrides) -> MagicMock:
     defaults = {
         "battery_voltage": 220.0,
         "battery_current": 12.5,
-        "battery_power": 2.5,
         "battery_soc_max": 99,
         "battery_soc_min": 97,
         "battery_soh": 100,
@@ -1105,7 +1118,6 @@ def test_hv_stack_sensor_descriptions_cover_expected_fields():
     assert keys == {
         "battery_voltage",
         "battery_current",
-        "battery_power",
         "battery_soc_max",
         "battery_soc_min",
         "battery_soh",
@@ -1118,13 +1130,13 @@ def test_hv_stack_sensor_descriptions_cover_expected_fields():
         "number_of_cycles",
         "pack_software_version",
     }
+    # battery_power is deliberately absent: on a real AIO BCU it reads a 0xFFFF
+    # sentinel (~65.53 kW) when discharging and 0 when idle, never a usable figure —
+    # the inverter-level Battery Power is authoritative (#95, AberDino).
+    assert "battery_power" not in keys
     voltage = next(d for d in HV_STACK_SENSORS if d.key == "battery_voltage")
     assert voltage.device_class == SensorDeviceClass.VOLTAGE
     assert voltage.native_unit_of_measurement == "V"
-    # Power is kW (the modbus C.milli converter divides IR79 by 1000), not W — a
-    # unit typo here would render readings 1000x off, so pin it.
-    power = next(d for d in HV_STACK_SENSORS if d.key == "battery_power")
-    assert power.native_unit_of_measurement == "kW"
     energy = next(d for d in HV_STACK_SENSORS if d.key == "charge_energy_total")
     assert energy.native_unit_of_measurement == "kWh"
 


### PR DESCRIPTION
## Summary

Addresses AberDino's v1.3.8 testing round on [#95](https://github.com/dewet22/givenergy-hass/issues/95) (Gen-1 Gateway + 2 AIOs):

- **Drop the HV-stack "Battery Power" sensor.** On a real AIO BCU it reads a 0xFFFF sentinel (~65.53 kW when discharging, 0 when idle) — never a usable figure. The inverter-level Battery Power is authoritative. (His explicit ask.)
- **Gate three inverter sensors on AIO topology, not None.** MPPT Count, Solar Diverter Energy and Battery Discharge This Year read 0 / 0.0 / a static figure on an AIO — *not* None — so the v1.3.6 `skip_if_none` never dropped them. New `skip_if_aio` flag, evaluated against the plant carrying AIO battery modules.
- **Offer battery-data-only at add time.** Previously options-only, so adding a parallel-mode AIO created all the inverter sensors first and they then went unavailable. The toggle is now on the initial config-flow step too, landing in `entry.options` (read everywhere).

Tracked separately, not in this PR: the "PV Generation" naming on AIO (a register-identity question for givenergy-modbus) and first-class Gateway connection ([#194](https://github.com/dewet22/givenergy-hass/issues/194)).

## Test plan
- [x] `uv run pytest -q` — 472 passed (+2: AIO sensor gating, add-time battery-data-only)
- [x] ruff + mypy + pre-commit clean
- Real-hardware confirmation to come from AberDino on the next release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Battery data only" configuration option during initial setup, allowing users to suppress controls and non-essential system sensors.

* **Bug Fixes**
  * Removed inverter sensors that are not applicable to battery-only systems, reducing unnecessary data display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->