### PR TITLE
feat: trim EMS controller device to its real role (#201)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -421,6 +421,55 @@ def _migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
             break
 
 
+def _retired_inverter_unique_ids(serial: str) -> set[str]:
+    """Unique IDs of the inverter-level entities retired on an EMS plant (#201).
+
+    On an EMS controller the inverter sensors and inverter-level controls are no
+    longer created — the 0x11 device is a controller, not an inverter. Built from
+    the exact description tuples the EMS setup path now skips, keyed by the
+    controller serial. Coordinator, EMS-specific, battery, AIO and managed-inverter
+    entities use different keys or their own serials, so they're excluded.
+    """
+    # Local imports: these platform modules are imported by the platform setup
+    # anyway, and importing them at module scope here risks a load-order cycle.
+    from .number import AC_COUPLED_NUMBER_DESCRIPTIONS, NUMBER_DESCRIPTIONS
+    from .select import AC_COUPLED_SELECT_DESCRIPTIONS, SELECT_DESCRIPTIONS
+    from .sensor import INVERTER_SENSORS
+    from .switch import AC_COUPLED_SWITCH_DESCRIPTIONS, SWITCH_DESCRIPTIONS
+    from .time import SMART_LOAD_TIME_DESCRIPTIONS, TIME_DESCRIPTIONS
+
+    retired = (
+        *INVERTER_SENSORS,
+        *SWITCH_DESCRIPTIONS,
+        *AC_COUPLED_SWITCH_DESCRIPTIONS,
+        *NUMBER_DESCRIPTIONS,
+        *AC_COUPLED_NUMBER_DESCRIPTIONS,
+        *SELECT_DESCRIPTIONS,
+        *AC_COUPLED_SELECT_DESCRIPTIONS,
+        *TIME_DESCRIPTIONS,
+        *SMART_LOAD_TIME_DESCRIPTIONS,
+    )
+    return {f"{serial}_{description.key}" for description in retired}
+
+
+def _reconcile_ems_entities(hass: HomeAssistant, entry: ConfigEntry, serial: str) -> None:
+    """Remove inverter-level entities retired on an EMS plant (#201).
+
+    Suppressing creation only affects fresh installs: on an upgraded EMS entry HA
+    keeps the existing registry rows when a platform stops adding those entities,
+    so the controller would otherwise stay cluttered with orphaned/unavailable
+    inverter sensors and controls. Remove exactly those rows (matched by the
+    controller serial + a retired key), leaving coordinator, battery, AIO,
+    managed-inverter and EMS-specific entities untouched.
+    """
+    registry = er.async_get(hass)
+    retired = _retired_inverter_unique_ids(serial)
+    for ent in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if ent.unique_id in retired:
+            _LOGGER.info("Removing inverter entity %s retired on EMS plant (#201)", ent.entity_id)
+            registry.async_remove(ent.entity_id)
+
+
 async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload the entry when its options change (registered as an update listener)."""
     await hass.config_entries.async_reload(entry.entry_id)
@@ -554,6 +603,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Re-point any entities under renamed unique_ids before the platforms create
     # them, so the existing entity (and its history) is reused rather than orphaned.
     _migrate_unique_ids(hass, entry)
+
+    # On an EMS plant the 0x11 device is a controller, not an inverter (#201). An
+    # upgraded entry still carries the inverter sensors/controls an earlier version
+    # created; remove them so the controller falls to its lean EMS set instead of
+    # keeping them as orphaned/unavailable rows. Fresh installs match nothing.
+    if coordinator.data.ems is not None:
+        _reconcile_ems_entities(hass, entry, coordinator.data.inverter_serial_number)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -205,20 +205,24 @@ async def async_setup_entry(
     if entry.options.get(CONF_BATTERY_DATA_ONLY, False):
         # Battery-data-only (#95): this unit's controls are owned by its Gateway.
         return
-    entities: list[NumberEntity] = [
-        GivEnergyNumberEntity(coordinator, description) for description in NUMBER_DESCRIPTIONS
-    ]
+    entities: list[NumberEntity] = []
     if coordinator.data.ems is not None:
+        # EMS plant: the controller's slot/target controls are authoritative; all
+        # inverter-level controls (standard + AC-coupled) are redundant here (#201).
         entities.extend(
             GivEnergyEmsNumberEntity(coordinator, description)
             for description in EMS_NUMBER_DESCRIPTIONS
         )
-    caps = coordinator.data.capabilities
-    if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
+    else:
         entities.extend(
-            GivEnergyNumberEntity(coordinator, description)
-            for description in AC_COUPLED_NUMBER_DESCRIPTIONS
+            GivEnergyNumberEntity(coordinator, description) for description in NUMBER_DESCRIPTIONS
         )
+        caps = coordinator.data.capabilities
+        if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
+            entities.extend(
+                GivEnergyNumberEntity(coordinator, description)
+                for description in AC_COUPLED_NUMBER_DESCRIPTIONS
+            )
     async_add_entities(entities)
 
 

--- a/custom_components/givenergy_local/select.py
+++ b/custom_components/givenergy_local/select.py
@@ -119,15 +119,19 @@ async def async_setup_entry(
     if entry.options.get(CONF_BATTERY_DATA_ONLY, False):
         # Battery-data-only (#95): this unit's controls are owned by its Gateway.
         return
-    entities: list[SelectEntity] = [
-        GivEnergySelectEntity(coordinator, description) for description in SELECT_DESCRIPTIONS
-    ]
-    caps = coordinator.data.capabilities
-    if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
+    entities: list[SelectEntity] = []
+    if coordinator.data.ems is None:
+        # Inverter-level selects (battery power/pause mode) are redundant on an EMS
+        # plant (#201); there are no EMS-specific selects, so the controller gets none.
         entities.extend(
-            GivEnergySelectEntity(coordinator, description)
-            for description in AC_COUPLED_SELECT_DESCRIPTIONS
+            GivEnergySelectEntity(coordinator, description) for description in SELECT_DESCRIPTIONS
         )
+        caps = coordinator.data.capabilities
+        if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
+            entities.extend(
+                GivEnergySelectEntity(coordinator, description)
+                for description in AC_COUPLED_SELECT_DESCRIPTIONS
+            )
     async_add_entities(entities)
 
 

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -9,6 +9,7 @@ from typing import Any
 from givenergy_modbus.model.aio_battery import AioBatteryModule
 from givenergy_modbus.model.battery import Battery, BatteryMaintenance
 from givenergy_modbus.model.devices import InverterSummary
+from givenergy_modbus.model.ems import Ems
 from givenergy_modbus.model.hv_bcu import Bcu, HvStack
 from givenergy_modbus.model.inverter import (
     BatteryCalibrationStage,
@@ -125,6 +126,11 @@ def _bcu_attr(name: str) -> Callable[[Bcu], Any]:
 @dataclass(frozen=True, kw_only=True)
 class GivEnergyManagedInverterSensorDescription(SensorEntityDescription):
     value_fn: Callable[[InverterSummary], Any] = field(default=lambda _: None)
+
+
+@dataclass(frozen=True, kw_only=True)
+class GivEnergyEmsSensorDescription(SensorEntityDescription):
+    value_fn: Callable[[Ems], Any] = field(default=lambda _: None)
 
 
 def _summary_attr(name: str) -> Callable[[InverterSummary], Any]:
@@ -1327,6 +1333,89 @@ MANAGED_INVERTER_SENSORS: tuple[GivEnergyManagedInverterSensorDescription, ...] 
 )
 
 
+def _ems_attr(name: str) -> Callable[[Ems], Any]:
+    """Return a value_fn that reads `name` off the EMS plant model."""
+    return lambda ems: getattr(ems, name)
+
+
+def _ems_status_label(ems: Ems) -> str | None:
+    """Render the EMS runtime status (IR2040) as a lowercase Status name.
+
+    `Ems` is built with use_enum_values, so `ems_status` is the raw int; map it
+    back through Status for a friendly label, returning None for an unread or
+    unrecognised value rather than raising.
+    """
+    raw = ems.ems_status
+    if raw is None:
+        return None
+    try:
+        return Status(raw).name.lower()
+    except ValueError:
+        return None
+
+
+# Plant-level telemetry for an EMS controller (device 0x11), surfaced in place of
+# the inverter sensor set (suppressed on EMS — see async_setup_entry). Names carry
+# an "EMS" prefix so they group together on the controller device.
+EMS_SENSORS: tuple[GivEnergyEmsSensorDescription, ...] = (
+    GivEnergyEmsSensorDescription(
+        key="ems_status",
+        name="EMS Status",
+        device_class=SensorDeviceClass.ENUM,
+        options=[s.name.lower() for s in Status],
+        value_fn=_ems_status_label,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyEmsSensorDescription(
+        key="ems_inverter_count",
+        name="EMS Managed Inverter Count",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_ems_attr("inverter_count"),
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyEmsSensorDescription(
+        key="ems_calc_load_power",
+        name="EMS Calculated Load Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_ems_attr("calc_load_power"),
+    ),
+    GivEnergyEmsSensorDescription(
+        key="ems_measured_load_power",
+        name="EMS Measured Load Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_ems_attr("measured_load_power"),
+    ),
+    GivEnergyEmsSensorDescription(
+        key="ems_grid_meter_power",
+        name="EMS Grid Meter Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_ems_attr("grid_meter_power"),
+    ),
+    GivEnergyEmsSensorDescription(
+        key="ems_total_battery_power",
+        name="EMS Total Battery Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_ems_attr("total_battery_power"),
+    ),
+    GivEnergyEmsSensorDescription(
+        key="ems_remaining_battery_energy",
+        name="EMS Remaining Battery Energy",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY_STORAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_ems_attr("remaining_battery_wh"),
+    ),
+)
+
+
 def _partial_failure_attributes(
     coordinator: GivEnergyUpdateCoordinator,
 ) -> dict[str, Any] | None:
@@ -1519,19 +1608,31 @@ async def async_setup_entry(
     # ALL_IN_ONE_HYBRID genuinely has PV so is deliberately excluded.
     is_aio = bool(capabilities) and capabilities.device_type is Model.ALL_IN_ONE
     battery_data_only = entry.options.get(CONF_BATTERY_DATA_ONLY, DEFAULT_BATTERY_DATA_ONLY)
+    ems = coordinator.data.ems
 
     entities: list[SensorEntity] = []
 
+    # On an EMS plant the 0x11 device is a controller, not an inverter: its inverter
+    # registers (PV/battery/grid/AC) are absent, so the whole inverter sensor set
+    # would surface as permanently-unavailable orphans (#201). Suppress them and
+    # emit the EMS plant-level aggregates instead.
+    #
     # Battery-data-only (#95): a parallel-mode AIO is controlled by its Gateway,
     # so its own inverter-level sensors (PV/grid/load/derived consumption) are
     # misleading. Drop them; keep the battery pack / HV stack / module / coordinator
     # data below. Control platforms suppress themselves the same way.
-    if not battery_data_only:
+    if not battery_data_only and ems is None:
         entities.extend(
             GivEnergyInverterSensor(coordinator, description)
             for description in INVERTER_SENSORS
             if _include_inverter_sensor(description, inverter, is_three_phase, is_aio)
         )
+
+    if ems is not None:
+        # EMS controller plant-level telemetry (#201): status, managed-inverter
+        # count, calculated/measured load, grid-meter power, total battery power and
+        # remaining battery energy — the controller's actually-useful data.
+        entities.extend(GivEnergyEmsSensor(coordinator, description) for description in EMS_SENSORS)
 
     for battery_index, battery in enumerate(coordinator.data.batteries):
         entities.extend(
@@ -1585,7 +1686,6 @@ async def async_setup_entry(
     # (status/power/SoC/temp). Surface each as its own device parented to the
     # controller. managed_inverters already filters empty slots; dedup by serial
     # defensively, mirroring the AIO loop.
-    ems = coordinator.data.ems
     if ems is not None:
         seen_managed_serials: set[str] = set()
         for summary in ems.managed_inverters:
@@ -2178,6 +2278,51 @@ class GivEnergyManagedInverterSensor(CoordinatorEntity[GivEnergyUpdateCoordinato
         if summary is None:
             return None
         return self.entity_description.value_fn(summary)
+
+
+class GivEnergyEmsSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity):
+    """Plant-level telemetry sensor for an EMS controller (device 0x11).
+
+    On an EMS plant the 0x11 device is the controller, not an inverter, so its
+    inverter registers (PV/battery/grid/AC) are absent and the inverter sensor set
+    is suppressed (#201). This surfaces the EMS aggregates instead — status,
+    managed-inverter count, load / grid / battery power and remaining energy — on
+    the same controller device, which it also names (the inverter sensors that used
+    to define the device are gone on EMS).
+    """
+
+    _attr_has_entity_name = True
+    entity_description: GivEnergyEmsSensorDescription
+
+    def __init__(
+        self,
+        coordinator: GivEnergyUpdateCoordinator,
+        description: GivEnergyEmsSensorDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        serial = coordinator.data.inverter_serial_number
+        self._attr_unique_id = f"{serial}_{description.key}"
+        model = coordinator.data.inverter.model
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy {_device_kind(model)} {serial}",
+            manufacturer="GivEnergy",
+            model=_MODEL_NAMES.get(model, model.name),
+            sw_version=coordinator.data.inverter.firmware_version,
+            serial_number=serial,
+        )
+
+    @property
+    def available(self) -> bool:
+        return super().available and self.coordinator.data.ems is not None
+
+    @property
+    def native_value(self) -> Any:
+        ems = self.coordinator.data.ems
+        if ems is None:
+            return None
+        return self.entity_description.value_fn(ems)
 
 
 class GivEnergyCoordinatorSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity):

--- a/custom_components/givenergy_local/switch.py
+++ b/custom_components/givenergy_local/switch.py
@@ -99,20 +99,25 @@ async def async_setup_entry(
     if entry.options.get(CONF_BATTERY_DATA_ONLY, False):
         # Battery-data-only (#95): this unit's controls are owned by its Gateway.
         return
-    entities: list[SwitchEntity] = [
-        GivEnergySwitchEntity(coordinator, description) for description in SWITCH_DESCRIPTIONS
-    ]
-    caps = coordinator.data.capabilities
-    if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
-        entities.extend(
-            GivEnergySwitchEntity(coordinator, description)
-            for description in AC_COUPLED_SWITCH_DESCRIPTIONS
-        )
+    entities: list[SwitchEntity] = []
     if coordinator.data.ems is not None:
+        # EMS plant: inverter-level switches are redundant — only Flexi EMS Control
+        # applies (#201). The controller is authoritative and its managed inverters
+        # are blinded.
         entities.extend(
             GivEnergyEmsSwitchEntity(coordinator, description)
             for description in EMS_SWITCH_DESCRIPTIONS
         )
+    else:
+        entities.extend(
+            GivEnergySwitchEntity(coordinator, description) for description in SWITCH_DESCRIPTIONS
+        )
+        caps = coordinator.data.capabilities
+        if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
+            entities.extend(
+                GivEnergySwitchEntity(coordinator, description)
+                for description in AC_COUPLED_SWITCH_DESCRIPTIONS
+            )
     async_add_entities(entities)
 
 

--- a/custom_components/givenergy_local/time.py
+++ b/custom_components/givenergy_local/time.py
@@ -210,19 +210,21 @@ async def async_setup_entry(
     if entry.options.get(CONF_BATTERY_DATA_ONLY, False):
         # Battery-data-only (#95): this unit's controls are owned by its Gateway.
         return
-    entities: list[TimeEntity] = [
-        GivEnergyTimeEntity(coordinator, description) for description in TIME_DESCRIPTIONS
-    ]
+    entities: list[TimeEntity] = []
     if coordinator.data.ems is not None:
         # EMS plant: the controller owns scheduling. Expose its slots and skip the
-        # inverter-level Smart Load slots — the library only populates HR(554-573)
-        # on non-EMS inverters, so creating them here would leave a block of
-        # permanently-unavailable config entities with silent-no-op writes.
+        # inverter-level charge/discharge and Smart Load slots — redundant when the
+        # EMS is authoritative, and the library only populates the inverter slot
+        # registers (incl. HR554-573) on non-EMS inverters, so they'd be a block of
+        # permanently-unavailable config entities with silent-no-op writes (#201).
         entities.extend(
             GivEnergyEmsTimeEntity(coordinator, description)
             for description in EMS_TIME_DESCRIPTIONS
         )
     else:
+        entities.extend(
+            GivEnergyTimeEntity(coordinator, description) for description in TIME_DESCRIPTIONS
+        )
         entities.extend(
             GivEnergyTimeEntity(coordinator, description)
             for description in SMART_LOAD_TIME_DESCRIPTIONS

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 from givenergy_modbus.model import TimeSlot
 from givenergy_modbus.model.devices import InverterSummary
-from givenergy_modbus.model.inverter import Model
+from givenergy_modbus.model.inverter import Model, Status
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
@@ -42,6 +42,14 @@ def mock_ems() -> MagicMock:
     ems.export_power_limit = 3600
     ems.plant_enabled = True
     ems.managed_inverters = []
+    # Plant-level aggregate telemetry (#201) surfaced as EMS_SENSORS.
+    ems.ems_status = Status.NORMAL
+    ems.inverter_count = 2
+    ems.calc_load_power = 1234
+    ems.measured_load_power = 1300
+    ems.grid_meter_power = -500
+    ems.total_battery_power = 800
+    ems.remaining_battery_wh = 5000
     return ems
 
 
@@ -346,3 +354,50 @@ async def test_managed_inverter_dedup_duplicate_serial(
         if d.model == "Managed Inverter (EMS)"
     ]
     assert len(managed) == 1
+
+
+# ---------------------------------------------------------------------------
+# Inverter-entity suppression on EMS (#201)
+# ---------------------------------------------------------------------------
+
+
+async def test_inverter_sensors_suppressed_on_ems_plant(hass, ems_setup):
+    """The EMS controller is not an inverter, so the inverter sensor set is
+    suppressed — it would otherwise be a wall of permanently-unavailable
+    entities. The EMS aggregates below take their place."""
+    assert _entity_id(hass, "sensor", "SA1234G123_status") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_p_load_demand") is None
+
+
+async def test_inverter_controls_suppressed_on_ems_plant(hass, ems_setup):
+    """Inverter-level controls are redundant on an EMS plant — the EMS slots are
+    authoritative — so they're suppressed across switch/number/select/time."""
+    assert _entity_id(hass, "switch", "SA1234G123_enable_charge") is None
+    assert _entity_id(hass, "number", "SA1234G123_charge_target_soc") is None
+    assert _entity_id(hass, "select", "SA1234G123_battery_power_mode") is None
+    assert _entity_id(hass, "time", "SA1234G123_charge_slot_1_start") is None
+
+
+# ---------------------------------------------------------------------------
+# EMS plant-level telemetry sensors (#201)
+# ---------------------------------------------------------------------------
+
+
+async def test_ems_sensors_created_and_read(hass, ems_setup):
+    """The EMS aggregate telemetry surfaces on the controller device."""
+    assert hass.states.get(_entity_id(hass, "sensor", "SA1234G123_ems_status")).state == "normal"
+    assert hass.states.get(_entity_id(hass, "sensor", "SA1234G123_ems_inverter_count")).state == "2"
+    grid = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_ems_grid_meter_power"))
+    assert grid.state == "-500"
+    assert grid.attributes["unit_of_measurement"] == "W"
+    assert grid.attributes["device_class"] == "power"
+    remaining = hass.states.get(
+        _entity_id(hass, "sensor", "SA1234G123_ems_remaining_battery_energy")
+    )
+    assert remaining.state == "5000"
+
+
+async def test_no_ems_sensors_for_non_ems_plant(hass, setup_integration):
+    """A non-EMS plant must not get the EMS aggregate sensors."""
+    assert _entity_id(hass, "sensor", "SA1234G123_ems_grid_meter_power") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_ems_status") is None

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -264,13 +264,15 @@ async def test_realignment_issue_raised_for_stale_inverter_prefixed_entities(
     mock_inverter.model = Model.EMS
     mock_config_entry.add_to_hass(hass)
 
-    # Pre-seed a stale entity id (as a pre-rename install would have).
+    # Pre-seed a surviving entity (a coordinator diagnostic) under the stale
+    # givenergy_inverter_ prefix. Inverter sensors are removed on EMS now (#201),
+    # so the realignment prompt must key off an entity that actually persists.
     er.async_get(hass).async_get_or_create(
         "sensor",
         DOMAIN,
-        "SA1234G123_status",
+        "SA1234G123_total_failures",
         config_entry=mock_config_entry,
-        suggested_object_id="givenergy_inverter_sa1234g123_status",
+        suggested_object_id="givenergy_inverter_sa1234g123_total_failures",
     )
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -376,6 +378,47 @@ async def test_inverter_controls_suppressed_on_ems_plant(hass, ems_setup):
     assert _entity_id(hass, "number", "SA1234G123_charge_target_soc") is None
     assert _entity_id(hass, "select", "SA1234G123_battery_power_mode") is None
     assert _entity_id(hass, "time", "SA1234G123_charge_slot_1_start") is None
+
+
+async def test_upgrade_removes_retired_inverter_entities_on_ems(
+    hass, mock_client, mock_plant, mock_inverter, mock_ems, mock_config_entry
+):
+    """Upgrade path (#201): inverter sensor/control rows a pre-#201 EMS install
+    created are removed from the registry, while coordinator and EMS entities
+    survive. Suppressing creation alone wouldn't clean up an existing entry — HA
+    keeps registry rows a platform stops adding."""
+    mock_plant.ems = mock_ems
+    mock_inverter.model = Model.EMS
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    # Rows a pre-#201 EMS controller would carry, across every affected platform.
+    for domain, unique_id in (
+        ("sensor", "SA1234G123_status"),
+        ("sensor", "SA1234G123_p_load_demand"),
+        ("switch", "SA1234G123_enable_charge"),
+        ("number", "SA1234G123_charge_target_soc"),
+        ("select", "SA1234G123_battery_power_mode"),
+        ("time", "SA1234G123_charge_slot_1_start"),
+    ):
+        registry.async_get_or_create(domain, DOMAIN, unique_id, config_entry=mock_config_entry)
+    # A coordinator diagnostic that must survive the reconciliation.
+    registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_total_failures", config_entry=mock_config_entry
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Retired inverter sensors + controls removed.
+    assert _entity_id(hass, "sensor", "SA1234G123_status") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_p_load_demand") is None
+    assert _entity_id(hass, "switch", "SA1234G123_enable_charge") is None
+    assert _entity_id(hass, "number", "SA1234G123_charge_target_soc") is None
+    assert _entity_id(hass, "select", "SA1234G123_battery_power_mode") is None
+    assert _entity_id(hass, "time", "SA1234G123_charge_slot_1_start") is None
+    # Coordinator diagnostic and EMS telemetry survive.
+    assert _entity_id(hass, "sensor", "SA1234G123_total_failures") is not None
+    assert _entity_id(hass, "sensor", "SA1234G123_ems_grid_meter_power") is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #201.

## Summary

On an EMS plant the device at modbus `0x11` is an EMS **controller**, not an inverter, but the integration gave it the full inverter entity set — ~120 mostly-unavailable sensors plus redundant inverter controls. Validated against @njhcarroll's real EMS plant (#52): his controller device carried **128 entities**, the bulk unavailable.

This gates on `coordinator.data.ems is not None` (the established EMS signal, mirroring the existing `time.py` EMS/Smart-Load branch):

- **Sensors:** suppress the whole inverter sensor loop on EMS and surface the `Ems` plant-level aggregates instead — **EMS Status**, **EMS Managed Inverter Count**, **EMS Calculated/Measured Load Power**, **EMS Grid Meter Power**, **EMS Total Battery Power**, **EMS Remaining Battery Energy**. Names are prefixed `EMS` so they group on the controller device.
- **Controls:** suppress the inverter-level controls on EMS across switch / number / select / time. The already-gated EMS slot/target controls (and Flexi EMS Control) are authoritative and remain.

A directly-connected inverter entry is unaffected (`ems is None` → it keeps its full sensor + control set). The managed-inverter rollup devices (#199) are unchanged. The battery out-of-spec binary sensor self-gates on `batteries` and stays (it's battery data).

Net effect on Nick's controller: ~128 entities → a lean set (7 `EMS …` sensors + the coordinator/Comms diagnostics + the EMS slot controls).

## Scope notes
- The #199 managed-inverter serial-collision with directly-connected inverters is tracked separately in #203.
- `_device_kind`/`_MODEL_NAMES` lacking an `EMS_COMMERCIAL` label is pre-existing and left as-is.

## Test plan
- [x] `uv run pytest -q` — 474 passed (4 new EMS tests: inverter sensors + controls suppressed on EMS; EMS aggregates created/read; absent on non-EMS)
- [x] ruff + mypy + pre-commit clean
- Live validation against an EMS mock / Nick's plant to follow before release.