### PR TITLE
fix: keep meaningful inverter sensors on EMS controllers (#201 narrowing)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -422,12 +422,14 @@ def _migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 
 def _retired_inverter_unique_ids(serial: str) -> set[str]:
-    """Unique IDs of the inverter-level entities retired on an EMS plant (#201).
+    """Unique IDs of the entities retired on an EMS plant (#201).
 
-    On an EMS controller the inverter sensors and inverter-level controls are no
-    longer created — the 0x11 device is a controller, not an inverter. Built from
-    the exact description tuples the EMS setup path now skips, keyed by the
-    controller serial. Coordinator, EMS-specific, battery, AIO and managed-inverter
+    On an EMS controller the inverter-level *controls* are suppressed (the EMS
+    slots are authoritative) and a few *derived* inverter sensors are gated via
+    `skip_if_ems` (House Consumption), plus the dropped duplicate `ems_status`
+    aggregate. The rest of the inverter sensors stay — the 0x11 block carries real
+    plant data (PV/grid/battery/AC) — so they are deliberately NOT in this set.
+    Keyed by the controller serial; coordinator, battery, AIO and managed-inverter
     entities use different keys or their own serials, so they're excluded.
     """
     # Local imports: these platform modules are imported by the platform setup
@@ -438,8 +440,8 @@ def _retired_inverter_unique_ids(serial: str) -> set[str]:
     from .switch import AC_COUPLED_SWITCH_DESCRIPTIONS, SWITCH_DESCRIPTIONS
     from .time import SMART_LOAD_TIME_DESCRIPTIONS, TIME_DESCRIPTIONS
 
-    retired = (
-        *INVERTER_SENSORS,
+    # All inverter-level controls are suppressed on EMS.
+    controls = (
         *SWITCH_DESCRIPTIONS,
         *AC_COUPLED_SWITCH_DESCRIPTIONS,
         *NUMBER_DESCRIPTIONS,
@@ -449,7 +451,12 @@ def _retired_inverter_unique_ids(serial: str) -> set[str]:
         *TIME_DESCRIPTIONS,
         *SMART_LOAD_TIME_DESCRIPTIONS,
     )
-    return {f"{serial}_{description.key}" for description in retired}
+    keys = {d.key for d in controls}
+    # Derived inverter sensors gated on EMS (House Consumption).
+    keys.update(d.key for d in INVERTER_SENSORS if d.skip_if_ems)
+    # Duplicate EMS aggregate dropped in favour of the retained inverter Status sensor.
+    keys.add("ems_status")
+    return {f"{serial}_{key}" for key in keys}
 
 
 def _reconcile_ems_entities(hass: HomeAssistant, entry: ConfigEntry, serial: str) -> None:
@@ -457,9 +464,10 @@ def _reconcile_ems_entities(hass: HomeAssistant, entry: ConfigEntry, serial: str
 
     Suppressing creation only affects fresh installs: on an upgraded EMS entry HA
     keeps the existing registry rows when a platform stops adding those entities,
-    so the controller would otherwise stay cluttered with orphaned/unavailable
-    inverter sensors and controls. Remove exactly those rows (matched by the
-    controller serial + a retired key), leaving coordinator, battery, AIO,
+    so the controller would otherwise keep orphaned rows for the entities no longer
+    created on EMS (inverter controls, the EMS-gated House Consumption, the dropped
+    ems_status). Remove exactly those (matched by the controller serial + a retired
+    key), leaving the retained inverter sensors and all coordinator, battery, AIO,
     managed-inverter and EMS-specific entities untouched.
     """
     registry = er.async_get(hass)

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -62,6 +62,11 @@ class GivEnergyInverterSensorDescription(SensorEntityDescription):
     # diverter total, a static yearly discharge figure), so skip_if_none can't
     # catch it (#95).
     skip_if_aio: bool = False
+    # If True, the entity is not created on an EMS plant. The 0x11 controller's
+    # direct registers are meaningful (PV/grid/battery/AC), but a few *derived*
+    # sensors (House Consumption = inverter-battery-grid) are computed for a single
+    # unit and read wrong on a controller, so gate just those (#201).
+    skip_if_ems: bool = False
     # If True, the entity is not created on three-phase inverters, where the
     # underlying field is single-phase-only (e.g. a p_pv1+p_pv2 sum) and so would
     # be meaningless or surface as a permanently-unavailable orphan entity.
@@ -658,6 +663,10 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
             inv, "e_consumption_today", getattr(inv, "e_load_today", None)
         ),
         skip_if_none=True,
+        # Derived (inverter-battery-grid) — wrong on an EMS controller, where it
+        # computes a per-controller figure (e.g. -9.8) rather than whole-plant load;
+        # the EMS load aggregates cover it there instead (#201).
+        skip_if_ems=True,
         # Resolves per-model: e_load_today isn't in the single-phase LUT (the
         # derived value stays untracked for staleness), but on three-phase it
         # names the native register the value_fn falls back to (#152/#158).
@@ -1338,34 +1347,10 @@ def _ems_attr(name: str) -> Callable[[Ems], Any]:
     return lambda ems: getattr(ems, name)
 
 
-def _ems_status_label(ems: Ems) -> str | None:
-    """Render the EMS runtime status (IR2040) as a lowercase Status name.
-
-    `Ems` is built with use_enum_values, so `ems_status` is the raw int; map it
-    back through Status for a friendly label, returning None for an unread or
-    unrecognised value rather than raising.
-    """
-    raw = ems.ems_status
-    if raw is None:
-        return None
-    try:
-        return Status(raw).name.lower()
-    except ValueError:
-        return None
-
-
-# Plant-level telemetry for an EMS controller (device 0x11), surfaced in place of
-# the inverter sensor set (suppressed on EMS — see async_setup_entry). Names carry
-# an "EMS" prefix so they group together on the controller device.
+# Plant-level aggregates an EMS controller carries that the inverter registers
+# don't (#201) — the inverter sensors (PV/grid/battery/AC) stay on the controller;
+# these complement them. Names carry an "EMS" prefix so they group on the device.
 EMS_SENSORS: tuple[GivEnergyEmsSensorDescription, ...] = (
-    GivEnergyEmsSensorDescription(
-        key="ems_status",
-        name="EMS Status",
-        device_class=SensorDeviceClass.ENUM,
-        options=[s.name.lower() for s in Status],
-        value_fn=_ems_status_label,
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
     GivEnergyEmsSensorDescription(
         key="ems_inverter_count",
         name="EMS Managed Inverter Count",
@@ -1561,6 +1546,7 @@ def _include_inverter_sensor(
     inverter: InverterModel,
     is_three_phase: bool,
     is_aio: bool = False,
+    is_ems: bool = False,
 ) -> bool:
     """Whether to create an inverter sensor at setup.
 
@@ -1578,6 +1564,8 @@ def _include_inverter_sensor(
     if description.single_phase_only and is_three_phase:
         return False
     if description.skip_if_aio and is_aio:
+        return False
+    if description.skip_if_ems and is_ems:
         return False
     if not description.skip_if_none:
         return True
@@ -1612,26 +1600,28 @@ async def async_setup_entry(
 
     entities: list[SensorEntity] = []
 
-    # On an EMS plant the 0x11 device is a controller, not an inverter: its inverter
-    # registers (PV/battery/grid/AC) are absent, so the whole inverter sensor set
-    # would surface as permanently-unavailable orphans (#201). Suppress them and
-    # emit the EMS plant-level aggregates instead.
+    # On an EMS plant the 0x11 device is a controller, but its inverter registers
+    # still carry meaningful plant data (PV/grid/battery/AC), so the inverter
+    # sensors stay — only the derived House Consumption is gated out per-description
+    # via skip_if_ems (#201). The EMS plant-level aggregates are added alongside.
     #
     # Battery-data-only (#95): a parallel-mode AIO is controlled by its Gateway,
     # so its own inverter-level sensors (PV/grid/load/derived consumption) are
     # misleading. Drop them; keep the battery pack / HV stack / module / coordinator
     # data below. Control platforms suppress themselves the same way.
-    if not battery_data_only and ems is None:
+    if not battery_data_only:
         entities.extend(
             GivEnergyInverterSensor(coordinator, description)
             for description in INVERTER_SENSORS
-            if _include_inverter_sensor(description, inverter, is_three_phase, is_aio)
+            if _include_inverter_sensor(
+                description, inverter, is_three_phase, is_aio, ems is not None
+            )
         )
 
     if ems is not None:
-        # EMS controller plant-level telemetry (#201): status, managed-inverter
-        # count, calculated/measured load, grid-meter power, total battery power and
-        # remaining battery energy — the controller's actually-useful data.
+        # EMS controller plant-level aggregates the inverter registers don't carry
+        # (#201): managed-inverter count, calculated/measured load, grid-meter
+        # power, total battery power and remaining battery energy.
         entities.extend(GivEnergyEmsSensor(coordinator, description) for description in EMS_SENSORS)
 
     for battery_index, battery in enumerate(coordinator.data.batteries):

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -63,9 +63,10 @@ class GivEnergyInverterSensorDescription(SensorEntityDescription):
     # catch it (#95).
     skip_if_aio: bool = False
     # If True, the entity is not created on an EMS plant. The 0x11 controller's
-    # direct registers are meaningful (PV/grid/battery/AC), but a few *derived*
-    # sensors (House Consumption = inverter-battery-grid) are computed for a single
-    # unit and read wrong on a controller, so gate just those (#201).
+    # direct registers are mostly meaningful (PV/grid/battery/AC), but a couple of
+    # load figures are controller-local — House Consumption's per-unit derivation
+    # and the inverter busbar load (p_load_demand) — and are superseded by the EMS
+    # calc/measured-load aggregates, so gate just those (#201).
     skip_if_ems: bool = False
     # If True, the entity is not created on three-phase inverters, where the
     # underlying field is single-phase-only (e.g. a p_pv1+p_pv2 sum) and so would
@@ -639,6 +640,10 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda inv: inv.p_load_demand,
+        # Controller-local on an EMS (IR42 inverter busbar load): on the capture it
+        # reads 48 W vs the EMS calc_load_power 489 W, so it misrepresents the plant
+        # load. The EMS load aggregates are authoritative there (#201).
+        skip_if_ems=True,
     ),
     GivEnergyInverterSensorDescription(
         # House consumption, sourced per model (#154). Single-phase inverters

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -363,12 +363,13 @@ async def test_managed_inverter_dedup_duplicate_serial(
 # ---------------------------------------------------------------------------
 
 
-async def test_inverter_sensors_suppressed_on_ems_plant(hass, ems_setup):
-    """The EMS controller is not an inverter, so the inverter sensor set is
-    suppressed — it would otherwise be a wall of permanently-unavailable
-    entities. The EMS aggregates below take their place."""
-    assert _entity_id(hass, "sensor", "SA1234G123_status") is None
-    assert _entity_id(hass, "sensor", "SA1234G123_p_load_demand") is None
+async def test_inverter_sensors_kept_on_ems_except_house_consumption(hass, ems_setup):
+    """The EMS controller's 0x11 block carries real plant data (PV/grid/battery/AC),
+    so the inverter sensors stay (#201). Only the derived House Consumption, which
+    computes a wrong per-controller figure, is gated off via skip_if_ems."""
+    assert _entity_id(hass, "sensor", "SA1234G123_status") is not None
+    assert _entity_id(hass, "sensor", "SA1234G123_battery_soc") is not None
+    assert _entity_id(hass, "sensor", "SA1234G123_e_consumption_today") is None
 
 
 async def test_inverter_controls_suppressed_on_ems_plant(hass, ems_setup):
@@ -380,45 +381,43 @@ async def test_inverter_controls_suppressed_on_ems_plant(hass, ems_setup):
     assert _entity_id(hass, "time", "SA1234G123_charge_slot_1_start") is None
 
 
-async def test_upgrade_removes_retired_inverter_entities_on_ems(
+async def test_upgrade_narrows_retired_entities_on_ems(
     hass, mock_client, mock_plant, mock_inverter, mock_ems, mock_config_entry
 ):
-    """Upgrade path (#201): inverter sensor/control rows a pre-#201 EMS install
-    created are removed from the registry, while coordinator and EMS entities
-    survive. Suppressing creation alone wouldn't clean up an existing entry — HA
-    keeps registry rows a platform stops adding."""
+    """Upgrade path (#201): on an existing EMS entry the reconciliation removes only
+    the inverter-level controls, the EMS-gated House Consumption, and the dropped
+    ems_status aggregate — the meaningful inverter sensors and diagnostics survive."""
     mock_plant.ems = mock_ems
     mock_inverter.model = Model.EMS
     mock_config_entry.add_to_hass(hass)
     registry = er.async_get(hass)
-    # Rows a pre-#201 EMS controller would carry, across every affected platform.
+    # Rows a prior install would carry: retired (controls + broken derived sensor +
+    # dropped aggregate) and retained (a real inverter sensor + a diagnostic).
     for domain, unique_id in (
-        ("sensor", "SA1234G123_status"),
-        ("sensor", "SA1234G123_p_load_demand"),
         ("switch", "SA1234G123_enable_charge"),
         ("number", "SA1234G123_charge_target_soc"),
         ("select", "SA1234G123_battery_power_mode"),
         ("time", "SA1234G123_charge_slot_1_start"),
+        ("sensor", "SA1234G123_e_consumption_today"),
+        ("sensor", "SA1234G123_ems_status"),
+        ("sensor", "SA1234G123_status"),
+        ("sensor", "SA1234G123_total_failures"),
     ):
         registry.async_get_or_create(domain, DOMAIN, unique_id, config_entry=mock_config_entry)
-    # A coordinator diagnostic that must survive the reconciliation.
-    registry.async_get_or_create(
-        "sensor", DOMAIN, "SA1234G123_total_failures", config_entry=mock_config_entry
-    )
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # Retired inverter sensors + controls removed.
-    assert _entity_id(hass, "sensor", "SA1234G123_status") is None
-    assert _entity_id(hass, "sensor", "SA1234G123_p_load_demand") is None
+    # Retired: inverter controls, the broken derived sensor, the dropped aggregate.
     assert _entity_id(hass, "switch", "SA1234G123_enable_charge") is None
     assert _entity_id(hass, "number", "SA1234G123_charge_target_soc") is None
     assert _entity_id(hass, "select", "SA1234G123_battery_power_mode") is None
     assert _entity_id(hass, "time", "SA1234G123_charge_slot_1_start") is None
-    # Coordinator diagnostic and EMS telemetry survive.
+    assert _entity_id(hass, "sensor", "SA1234G123_e_consumption_today") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_ems_status") is None
+    # Retained: meaningful inverter sensor + coordinator diagnostic.
+    assert _entity_id(hass, "sensor", "SA1234G123_status") is not None
     assert _entity_id(hass, "sensor", "SA1234G123_total_failures") is not None
-    assert _entity_id(hass, "sensor", "SA1234G123_ems_grid_meter_power") is not None
 
 
 # ---------------------------------------------------------------------------
@@ -428,7 +427,6 @@ async def test_upgrade_removes_retired_inverter_entities_on_ems(
 
 async def test_ems_sensors_created_and_read(hass, ems_setup):
     """The EMS aggregate telemetry surfaces on the controller device."""
-    assert hass.states.get(_entity_id(hass, "sensor", "SA1234G123_ems_status")).state == "normal"
     assert hass.states.get(_entity_id(hass, "sensor", "SA1234G123_ems_inverter_count")).state == "2"
     grid = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_ems_grid_meter_power"))
     assert grid.state == "-500"
@@ -443,4 +441,19 @@ async def test_ems_sensors_created_and_read(hass, ems_setup):
 async def test_no_ems_sensors_for_non_ems_plant(hass, setup_integration):
     """A non-EMS plant must not get the EMS aggregate sensors."""
     assert _entity_id(hass, "sensor", "SA1234G123_ems_grid_meter_power") is None
-    assert _entity_id(hass, "sensor", "SA1234G123_ems_status") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_ems_inverter_count") is None
+
+
+def test_house_consumption_gated_skip_if_ems():
+    """House Consumption Today is the one derived inverter sensor gated off on EMS;
+    the EMS gate leaves it out only when is_ems is set."""
+    from custom_components.givenergy_local.sensor import (
+        INVERTER_SENSORS,
+        _include_inverter_sensor,
+    )
+
+    desc = next(d for d in INVERTER_SENSORS if d.key == "e_consumption_today")
+    assert desc.skip_if_ems is True
+    inv = MagicMock()
+    assert _include_inverter_sensor(desc, inv, False, False, True) is False
+    assert _include_inverter_sensor(desc, inv, False, False, False) is True

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -363,13 +363,15 @@ async def test_managed_inverter_dedup_duplicate_serial(
 # ---------------------------------------------------------------------------
 
 
-async def test_inverter_sensors_kept_on_ems_except_house_consumption(hass, ems_setup):
+async def test_inverter_sensors_kept_on_ems_except_local_load(hass, ems_setup):
     """The EMS controller's 0x11 block carries real plant data (PV/grid/battery/AC),
-    so the inverter sensors stay (#201). Only the derived House Consumption, which
-    computes a wrong per-controller figure, is gated off via skip_if_ems."""
+    so the inverter sensors stay (#201). Only the controller-local load figures —
+    House Consumption and the inverter busbar Load Power — are gated off via
+    skip_if_ems; the EMS load aggregates supersede them."""
     assert _entity_id(hass, "sensor", "SA1234G123_status") is not None
     assert _entity_id(hass, "sensor", "SA1234G123_battery_soc") is not None
     assert _entity_id(hass, "sensor", "SA1234G123_e_consumption_today") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_p_load_demand") is None
 
 
 async def test_inverter_controls_suppressed_on_ems_plant(hass, ems_setup):
@@ -444,16 +446,18 @@ async def test_no_ems_sensors_for_non_ems_plant(hass, setup_integration):
     assert _entity_id(hass, "sensor", "SA1234G123_ems_inverter_count") is None
 
 
-def test_house_consumption_gated_skip_if_ems():
-    """House Consumption Today is the one derived inverter sensor gated off on EMS;
-    the EMS gate leaves it out only when is_ems is set."""
+def test_controller_local_load_gated_skip_if_ems():
+    """Exactly the controller-local load figures are gated off on EMS — House
+    Consumption and the inverter busbar Load Power. Pins the boundary so a future
+    change can't silently widen or narrow it; the gate drops them only on EMS."""
     from custom_components.givenergy_local.sensor import (
         INVERTER_SENSORS,
         _include_inverter_sensor,
     )
 
-    desc = next(d for d in INVERTER_SENSORS if d.key == "e_consumption_today")
-    assert desc.skip_if_ems is True
+    gated = {d.key for d in INVERTER_SENSORS if d.skip_if_ems}
+    assert gated == {"e_consumption_today", "p_load_demand"}
+    desc = next(d for d in INVERTER_SENSORS if d.key == "p_load_demand")
     inv = MagicMock()
     assert _include_inverter_sensor(desc, inv, False, False, True) is False
     assert _include_inverter_sensor(desc, inv, False, False, False) is True


### PR DESCRIPTION
Narrows #205 (shipped in v1.3.11), which over-suppressed.

## The regression
#205 dropped the **entire** inverter sensor set on EMS controllers, on the premise they were "mostly unavailable." That premise was a **CRC artifact** — the mock's `0x11` frames CRC-fail and tester plants are comms-noisy, so the sensors *read* as unavailable but aren't inapplicable. Loading the committed `ems_2_inv_3_bat_a/ems_arm1036_30min.log` capture, the inverter facade over the `0x11` cache carries real plant data:

`e_pv_generation_today=14.1`, `e_pv_generation_total=24172.3`, `p_grid_out=94`, grid totals 12122/28618, `battery_soc=45`, `v_battery=52.68`, `v_ac1=242.7`, `f_ac1=49.9`, `t_inverter_heatsink=45.6`, `status=NORMAL`.

Corroborated by dewet22's #175 comment ("the EMS device has the real PV total") and @njhcarroll's #52 ("inverter SOC readings broadly match the portal"). So v1.3.11 removed genuinely useful data.

## The narrowing
- **Keep the inverter sensors on EMS.** The inverter loop runs regardless of EMS again.
- **Gate only the broken derived sensor** — House Consumption Today (`e_consumption_today`) computes a wrong per-controller figure on an EMS (e.g. −9.8), so it gets a new per-description `skip_if_ems` flag (same shape as `skip_if_aio`). `Ems.e_active_generation_total` (583) ≠ the PV total, so it can't substitute — the PV figures must come from the inverter sensors.
- **Keep the inverter-control suppression** (EMS slots are authoritative; #188 shows the inverter-level writes are rejected anyway).
- **Drop the duplicate `ems_status`** EMS aggregate — the restored inverter "Status" sensor covers it.
- **Narrow `_reconcile_ems_entities`** to remove only the controls + House Consumption + `ems_status` on upgrade, retaining (and re-creating) the inverter sensors.

## Test plan
- [x] `uv run pytest -q` — 479 passed (EMS tests rewritten: inverter sensors kept on EMS except House Consumption; upgrade reconciliation narrowed; `skip_if_ems` flag unit test)
- [x] ruff + mypy + pre-commit clean
- [x] Verified against the EMS capture: kept sensors read real values; `e_consumption_today` is the −9.8 being gated
- Live confirmation from Nick on #52 to follow once v1.3.12 ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined how inverter-level entities are managed when the system is part of an EMS plant installation.
  * Inverter sensors are now handled with finer granularity—only specific derived sensors are suppressed rather than all inverter sensors.
  * Fixed incorrect sensor readings on EMS controllers by properly suppressing the "House Consumption Today" sensor on EMS plant installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->