### PR TITLE
feat: gate firmware-variable controls on register readability (#207)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -478,6 +478,48 @@ def _reconcile_ems_entities(hass: HomeAssistant, entry: ConfigEntry, serial: str
             registry.async_remove(ent.entity_id)
 
 
+def _remove_stale_control(registry: er.EntityRegistry, serial: str, domain: str, key: str) -> None:
+    """Remove a readability-gated control's stale registry row, if present (#207)."""
+    entity_id = registry.async_get_entity_id(domain, DOMAIN, f"{serial}_{key}")
+    if entity_id is not None:
+        _LOGGER.info(
+            "Removing control %s: register absent on this device/firmware (#207)", entity_id
+        )
+        registry.async_remove(entity_id)
+
+
+def _reconcile_readability_gated_controls(
+    hass: HomeAssistant, coordinator: GivEnergyUpdateCoordinator
+) -> None:
+    """Remove control rows whose register is absent on this device/firmware (#207).
+
+    The control platforms skip creating a skip_if_none control when its register
+    reads None, but on an upgraded entry HA keeps the pre-existing row — an
+    orphaned, unavailable control the readability gate is meant to remove. Mirror
+    the EMS reconciliation: remove exactly those rows pre-platform, reusing each
+    platform's own gate so the readability logic isn't duplicated here.
+    """
+    # Local imports: the platforms import from this package, so importing them at
+    # module scope risks a load-order cycle. The gate helpers are the single source
+    # of truth for "is this control's register present".
+    from .number import AC_COUPLED_NUMBER_DESCRIPTIONS, _include_number
+    from .select import SELECT_DESCRIPTIONS, _include_select
+    from .time import TIME_DESCRIPTIONS, _include_time
+
+    inverter = coordinator.data.inverter
+    serial = coordinator.data.inverter_serial_number
+    registry = er.async_get(hass)
+    for number_desc in AC_COUPLED_NUMBER_DESCRIPTIONS:
+        if not _include_number(number_desc, inverter):
+            _remove_stale_control(registry, serial, "number", number_desc.key)
+    for select_desc in SELECT_DESCRIPTIONS:
+        if not _include_select(select_desc, inverter):
+            _remove_stale_control(registry, serial, "select", select_desc.key)
+    for time_desc in TIME_DESCRIPTIONS:
+        if not _include_time(time_desc, inverter):
+            _remove_stale_control(registry, serial, "time", time_desc.key)
+
+
 async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload the entry when its options change (registered as an update listener)."""
     await hass.config_entries.async_reload(entry.entry_id)
@@ -618,6 +660,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # keeping them as orphaned/unavailable rows. Fresh installs match nothing.
     if coordinator.data.ems is not None:
         _reconcile_ems_entities(hass, entry, coordinator.data.inverter_serial_number)
+
+    # Remove control rows whose register is absent on this device/firmware (#207):
+    # the platforms skip creating them, but an upgraded entry keeps the stale row.
+    _reconcile_readability_gated_controls(hass, coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -506,6 +506,13 @@ def _reconcile_readability_gated_controls(
     from .select import SELECT_DESCRIPTIONS, _include_select
     from .time import TIME_DESCRIPTIONS, _include_time
 
+    # A partial seed poll serves last-good with last_partial_failures set, so a None
+    # read may be a transient bank failure rather than structural absence. Removing
+    # rows now would lose history/customisation and the controls until a reload —
+    # reconcile only on a clean seed (#208 review).
+    if coordinator.last_partial_failures:
+        return
+
     inverter = coordinator.data.inverter
     serial = coordinator.data.inverter_serial_number
     registry = er.async_get(hass)

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -17,11 +18,17 @@ from .const import CONF_BATTERY_DATA_ONLY, DOMAIN
 from .coordinator import GivEnergyUpdateCoordinator, InverterModel
 from .sensor import _device_kind
 
+_LOGGER = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True, kw_only=True)
 class GivEnergyNumberEntityDescription(NumberEntityDescription):
     value_fn: Callable[[InverterModel], float | None] = field(default=lambda _: None)
     set_value_cmd: Callable[[float], list] = field(default=lambda _: [])
+    # If True, the control isn't created when value_fn reads None at setup — the
+    # register isn't present on this device/firmware (e.g. HR313/314 on older
+    # firmware). The control-side of the sensor skip_if_none (#207).
+    skip_if_none: bool = False
 
 
 NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
@@ -119,6 +126,7 @@ AC_COUPLED_NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
         mode=NumberMode.BOX,
         value_fn=lambda inv: inv.battery_charge_limit_ac,
         set_value_cmd=lambda v: commands.set_battery_charge_limit_ac(int(v)),
+        skip_if_none=True,  # HR313 absent on older firmware (#207)
         entity_category=EntityCategory.CONFIG,
     ),
     GivEnergyNumberEntityDescription(
@@ -131,6 +139,7 @@ AC_COUPLED_NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
         mode=NumberMode.BOX,
         value_fn=lambda inv: inv.battery_discharge_limit_ac,
         set_value_cmd=lambda v: commands.set_battery_discharge_limit_ac(int(v)),
+        skip_if_none=True,  # HR314 absent on older firmware (#207)
         entity_category=EntityCategory.CONFIG,
     ),
 )
@@ -196,6 +205,23 @@ EMS_NUMBER_DESCRIPTIONS: tuple[GivEnergyEmsNumberEntityDescription, ...] = (
 )
 
 
+def _include_number(description: GivEnergyNumberEntityDescription, inverter: InverterModel) -> bool:
+    """Whether to create a number control at setup (#207).
+
+    A skip_if_none control is dropped when its register reads None — absent on this
+    device/firmware (e.g. HR313/314 on older firmware). Guarded so a value_fn that
+    raises (a field renamed in givenergy-modbus) skips just that control, not the
+    whole platform.
+    """
+    if not description.skip_if_none:
+        return True
+    try:
+        return description.value_fn(inverter) is not None
+    except Exception:  # noqa: BLE001
+        _LOGGER.warning("Skipping number %s: value_fn raised at setup", description.key)
+        return False
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -219,9 +245,11 @@ async def async_setup_entry(
         )
         caps = coordinator.data.capabilities
         if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
+            inverter = coordinator.data.inverter
             entities.extend(
                 GivEnergyNumberEntity(coordinator, description)
                 for description in AC_COUPLED_NUMBER_DESCRIPTIONS
+                if _include_number(description, inverter)
             )
     async_add_entities(entities)
 

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -205,7 +205,9 @@ EMS_NUMBER_DESCRIPTIONS: tuple[GivEnergyEmsNumberEntityDescription, ...] = (
 )
 
 
-def _include_number(description: GivEnergyNumberEntityDescription, inverter: InverterModel) -> bool:
+def _include_number(
+    description: GivEnergyNumberEntityDescription, inverter: InverterModel, clean: bool = True
+) -> bool:
     """Whether to create a number control at setup (#207).
 
     A skip_if_none control is dropped when its register reads None — absent on this
@@ -214,6 +216,10 @@ def _include_number(description: GivEnergyNumberEntityDescription, inverter: Inv
     whole platform.
     """
     if not description.skip_if_none:
+        return True
+    # On a partial seed poll a None may be a transient bank failure, not structural
+    # absence — keep the control so a later clean poll recovers it (#208 review).
+    if not clean:
         return True
     try:
         value = description.value_fn(inverter)
@@ -253,10 +259,11 @@ async def async_setup_entry(
         caps = coordinator.data.capabilities
         if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
             inverter = coordinator.data.inverter
+            clean = not coordinator.last_partial_failures
             entities.extend(
                 GivEnergyNumberEntity(coordinator, description)
                 for description in AC_COUPLED_NUMBER_DESCRIPTIONS
-                if _include_number(description, inverter)
+                if _include_number(description, inverter, clean)
             )
     async_add_entities(entities)
 

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -216,10 +216,17 @@ def _include_number(description: GivEnergyNumberEntityDescription, inverter: Inv
     if not description.skip_if_none:
         return True
     try:
-        return description.value_fn(inverter) is not None
+        value = description.value_fn(inverter)
     except Exception:  # noqa: BLE001
         _LOGGER.warning("Skipping number %s: value_fn raised at setup", description.key)
         return False
+    if value is None:
+        # Expected: the register isn't present on this device/firmware. DEBUG, not
+        # WARNING — this is the gate working as designed and recurs every restart,
+        # unlike the duplicate/garbled anomalies that warrant a warning.
+        _LOGGER.debug("Skipping number %s: register reads None at setup", description.key)
+        return False
+    return True
 
 
 async def async_setup_entry(

--- a/custom_components/givenergy_local/select.py
+++ b/custom_components/givenergy_local/select.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -18,11 +19,17 @@ from .const import CONF_BATTERY_DATA_ONLY, DOMAIN
 from .coordinator import GivEnergyUpdateCoordinator, InverterModel
 from .sensor import _device_kind
 
+_LOGGER = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True, kw_only=True)
 class GivEnergySelectEntityDescription(SelectEntityDescription):
     current_option_fn: Callable[[InverterModel], str | None] = field(default=lambda _: None)
     select_option_cmd: Callable[[str], list] = field(default=lambda _: [])
+    # If True, the control isn't created when current_option_fn reads None at setup —
+    # the register isn't present on this device/firmware (e.g. battery pause mode,
+    # firmware-gated). The control-side of the sensor skip_if_none (#207).
+    skip_if_none: bool = False
 
 
 def _battery_power_mode_cmd(option: str) -> list:
@@ -71,6 +78,7 @@ SELECT_DESCRIPTIONS: tuple[GivEnergySelectEntityDescription, ...] = (
         options=list(_PAUSE_MODE_BY_LABEL.keys()),
         current_option_fn=_battery_pause_current_option,
         select_option_cmd=_battery_pause_mode_cmd,
+        skip_if_none=True,  # battery pause is firmware-gated (#207)
         entity_category=EntityCategory.CONFIG,
     ),
 )
@@ -110,6 +118,22 @@ AC_COUPLED_SELECT_DESCRIPTIONS: tuple[GivEnergySelectEntityDescription, ...] = (
 )
 
 
+def _include_select(description: GivEnergySelectEntityDescription, inverter: InverterModel) -> bool:
+    """Whether to create a select control at setup (#207).
+
+    A skip_if_none control is dropped when its register reads None — absent on this
+    device/firmware (e.g. battery pause mode on firmware without it). Guarded so a
+    raising accessor skips just that control, not the whole platform.
+    """
+    if not description.skip_if_none:
+        return True
+    try:
+        return description.current_option_fn(inverter) is not None
+    except Exception:  # noqa: BLE001
+        _LOGGER.warning("Skipping select %s: current_option_fn raised at setup", description.key)
+        return False
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -123,8 +147,11 @@ async def async_setup_entry(
     if coordinator.data.ems is None:
         # Inverter-level selects (battery power/pause mode) are redundant on an EMS
         # plant (#201); there are no EMS-specific selects, so the controller gets none.
+        inverter = coordinator.data.inverter
         entities.extend(
-            GivEnergySelectEntity(coordinator, description) for description in SELECT_DESCRIPTIONS
+            GivEnergySelectEntity(coordinator, description)
+            for description in SELECT_DESCRIPTIONS
+            if _include_select(description, inverter)
         )
         caps = coordinator.data.capabilities
         if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:

--- a/custom_components/givenergy_local/select.py
+++ b/custom_components/givenergy_local/select.py
@@ -128,10 +128,17 @@ def _include_select(description: GivEnergySelectEntityDescription, inverter: Inv
     if not description.skip_if_none:
         return True
     try:
-        return description.current_option_fn(inverter) is not None
+        value = description.current_option_fn(inverter)
     except Exception:  # noqa: BLE001
         _LOGGER.warning("Skipping select %s: current_option_fn raised at setup", description.key)
         return False
+    if value is None:
+        # Expected: the register isn't present on this device/firmware. DEBUG, not
+        # WARNING — this is the gate working as designed and recurs every restart,
+        # unlike the duplicate/garbled anomalies that warrant a warning.
+        _LOGGER.debug("Skipping select %s: register reads None at setup", description.key)
+        return False
+    return True
 
 
 async def async_setup_entry(

--- a/custom_components/givenergy_local/select.py
+++ b/custom_components/givenergy_local/select.py
@@ -118,7 +118,9 @@ AC_COUPLED_SELECT_DESCRIPTIONS: tuple[GivEnergySelectEntityDescription, ...] = (
 )
 
 
-def _include_select(description: GivEnergySelectEntityDescription, inverter: InverterModel) -> bool:
+def _include_select(
+    description: GivEnergySelectEntityDescription, inverter: InverterModel, clean: bool = True
+) -> bool:
     """Whether to create a select control at setup (#207).
 
     A skip_if_none control is dropped when its register reads None — absent on this
@@ -126,6 +128,10 @@ def _include_select(description: GivEnergySelectEntityDescription, inverter: Inv
     raising accessor skips just that control, not the whole platform.
     """
     if not description.skip_if_none:
+        return True
+    # On a partial seed poll a None may be a transient bank failure, not structural
+    # absence — keep the control so a later clean poll recovers it (#208 review).
+    if not clean:
         return True
     try:
         value = description.current_option_fn(inverter)
@@ -155,10 +161,11 @@ async def async_setup_entry(
         # Inverter-level selects (battery power/pause mode) are redundant on an EMS
         # plant (#201); there are no EMS-specific selects, so the controller gets none.
         inverter = coordinator.data.inverter
+        clean = not coordinator.last_partial_failures
         entities.extend(
             GivEnergySelectEntity(coordinator, description)
             for description in SELECT_DESCRIPTIONS
-            if _include_select(description, inverter)
+            if _include_select(description, inverter, clean)
         )
         caps = coordinator.data.capabilities
         if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:

--- a/custom_components/givenergy_local/time.py
+++ b/custom_components/givenergy_local/time.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import time as dt_time
@@ -19,6 +20,8 @@ from .const import CONF_BATTERY_DATA_ONLY, DOMAIN
 from .coordinator import GivEnergyUpdateCoordinator, InverterModel
 from .sensor import _device_kind
 
+_LOGGER = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True, kw_only=True)
 class GivEnergyTimeEntityDescription(TimeEntityDescription):
@@ -28,6 +31,10 @@ class GivEnergyTimeEntityDescription(TimeEntityDescription):
     # current inverter — charge/discharge setters dispatch on inverter.slot_map
     # to handle extended-slot models; the pause setter ignores the inverter.
     setter_fn: Callable[[dt_time, InverterModel], list] = field(default=lambda _, __: [])
+    # If True, the control isn't created when slot_fn reads None at setup — the
+    # register isn't present on this device/firmware (e.g. the battery pause slot,
+    # firmware-gated). The control-side of the sensor skip_if_none (#207).
+    skip_if_none: bool = False
 
 
 TIME_DESCRIPTIONS: tuple[GivEnergyTimeEntityDescription, ...] = (
@@ -101,6 +108,7 @@ TIME_DESCRIPTIONS: tuple[GivEnergyTimeEntityDescription, ...] = (
         slot_fn=lambda inv: inv.battery_pause_slot_1,
         is_start=True,
         setter_fn=lambda value, _inv: commands.set_pause_slot_start(value),
+        skip_if_none=True,  # battery pause slot is firmware-gated (#207)
         entity_category=EntityCategory.CONFIG,
     ),
     GivEnergyTimeEntityDescription(
@@ -109,6 +117,7 @@ TIME_DESCRIPTIONS: tuple[GivEnergyTimeEntityDescription, ...] = (
         slot_fn=lambda inv: inv.battery_pause_slot_1,
         is_start=False,
         setter_fn=lambda value, _inv: commands.set_pause_slot_end(value),
+        skip_if_none=True,  # battery pause slot is firmware-gated (#207)
         entity_category=EntityCategory.CONFIG,
     ),
 )
@@ -201,6 +210,22 @@ def _ems_time_descriptions() -> tuple[GivEnergyEmsTimeEntityDescription, ...]:
 EMS_TIME_DESCRIPTIONS: tuple[GivEnergyEmsTimeEntityDescription, ...] = _ems_time_descriptions()
 
 
+def _include_time(description: GivEnergyTimeEntityDescription, inverter: InverterModel) -> bool:
+    """Whether to create a time control at setup (#207).
+
+    A skip_if_none control is dropped when its slot reads None — absent on this
+    device/firmware (e.g. the battery pause slot on firmware without it). Guarded so
+    a raising accessor skips just that control, not the whole platform.
+    """
+    if not description.skip_if_none:
+        return True
+    try:
+        return description.slot_fn(inverter) is not None
+    except Exception:  # noqa: BLE001
+        _LOGGER.warning("Skipping time %s: slot_fn raised at setup", description.key)
+        return False
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -222,8 +247,11 @@ async def async_setup_entry(
             for description in EMS_TIME_DESCRIPTIONS
         )
     else:
+        inverter = coordinator.data.inverter
         entities.extend(
-            GivEnergyTimeEntity(coordinator, description) for description in TIME_DESCRIPTIONS
+            GivEnergyTimeEntity(coordinator, description)
+            for description in TIME_DESCRIPTIONS
+            if _include_time(description, inverter)
         )
         entities.extend(
             GivEnergyTimeEntity(coordinator, description)

--- a/custom_components/givenergy_local/time.py
+++ b/custom_components/givenergy_local/time.py
@@ -31,10 +31,16 @@ class GivEnergyTimeEntityDescription(TimeEntityDescription):
     # current inverter — charge/discharge setters dispatch on inverter.slot_map
     # to handle extended-slot models; the pause setter ignores the inverter.
     setter_fn: Callable[[dt_time, InverterModel], list] = field(default=lambda _, __: [])
-    # If True, the control isn't created when slot_fn reads None at setup — the
-    # register isn't present on this device/firmware (e.g. the battery pause slot,
-    # firmware-gated). The control-side of the sensor skip_if_none (#207).
+    # If True, the control isn't created when its readability signal reads None at
+    # setup — the register isn't present on this device/firmware (e.g. the battery
+    # pause slot, firmware-gated). The control-side of the sensor skip_if_none (#207).
     skip_if_none: bool = False
+    # The readability signal for skip_if_none. A decoded TimeSlot is NOT a presence
+    # signal — it's None for a valid-but-unset slot (raw-60 sentinel, shown as
+    # "--:--") as well as for an absent register — so gate on a separate register
+    # (e.g. the pause-mode register as a proxy for the pause feature) rather than
+    # slot_fn (#208 review). Defaults to slot_fn when unset.
+    readable_fn: Callable[[InverterModel], object] | None = None
 
 
 TIME_DESCRIPTIONS: tuple[GivEnergyTimeEntityDescription, ...] = (
@@ -108,7 +114,10 @@ TIME_DESCRIPTIONS: tuple[GivEnergyTimeEntityDescription, ...] = (
         slot_fn=lambda inv: inv.battery_pause_slot_1,
         is_start=True,
         setter_fn=lambda value, _inv: commands.set_pause_slot_start(value),
-        skip_if_none=True,  # battery pause slot is firmware-gated (#207)
+        skip_if_none=True,  # firmware-gated (#207)
+        # Gate on the pause-mode register's presence, not the slot: an unset slot
+        # also decodes to None, but the control must stay so it can be set (#208).
+        readable_fn=lambda inv: inv.battery_pause_mode,
         entity_category=EntityCategory.CONFIG,
     ),
     GivEnergyTimeEntityDescription(
@@ -117,7 +126,10 @@ TIME_DESCRIPTIONS: tuple[GivEnergyTimeEntityDescription, ...] = (
         slot_fn=lambda inv: inv.battery_pause_slot_1,
         is_start=False,
         setter_fn=lambda value, _inv: commands.set_pause_slot_end(value),
-        skip_if_none=True,  # battery pause slot is firmware-gated (#207)
+        skip_if_none=True,  # firmware-gated (#207)
+        # Gate on the pause-mode register's presence, not the slot: an unset slot
+        # also decodes to None, but the control must stay so it can be set (#208).
+        readable_fn=lambda inv: inv.battery_pause_mode,
         entity_category=EntityCategory.CONFIG,
     ),
 )
@@ -213,22 +225,24 @@ EMS_TIME_DESCRIPTIONS: tuple[GivEnergyEmsTimeEntityDescription, ...] = _ems_time
 def _include_time(description: GivEnergyTimeEntityDescription, inverter: InverterModel) -> bool:
     """Whether to create a time control at setup (#207).
 
-    A skip_if_none control is dropped when its slot reads None — absent on this
-    device/firmware (e.g. the battery pause slot on firmware without it). Guarded so
-    a raising accessor skips just that control, not the whole platform.
+    A skip_if_none control is dropped when its readability signal reads None —
+    absent on this device/firmware. The decoded slot is NOT that signal (it's None
+    for a valid-but-unset slot too), so use readable_fn when given (#208 review).
+    Guarded so a raising accessor skips just that control, not the whole platform.
     """
     if not description.skip_if_none:
         return True
+    read = description.readable_fn or description.slot_fn
     try:
-        value = description.slot_fn(inverter)
+        value = read(inverter)
     except Exception:  # noqa: BLE001
-        _LOGGER.warning("Skipping time %s: slot_fn raised at setup", description.key)
+        _LOGGER.warning("Skipping time %s: readability check raised at setup", description.key)
         return False
     if value is None:
-        # Expected: the slot register isn't present on this device/firmware. DEBUG,
-        # not WARNING — this is the gate working as designed and recurs every restart,
-        # unlike the duplicate/garbled anomalies that warrant a warning.
-        _LOGGER.debug("Skipping time %s: slot_fn reads None at setup", description.key)
+        # Expected: the register isn't present on this device/firmware. DEBUG, not
+        # WARNING — the gate working as designed, recurring every restart, unlike the
+        # duplicate/garbled anomalies that warrant a warning.
+        _LOGGER.debug("Skipping time %s: readability signal reads None at setup", description.key)
         return False
     return True
 

--- a/custom_components/givenergy_local/time.py
+++ b/custom_components/givenergy_local/time.py
@@ -220,10 +220,17 @@ def _include_time(description: GivEnergyTimeEntityDescription, inverter: Inverte
     if not description.skip_if_none:
         return True
     try:
-        return description.slot_fn(inverter) is not None
+        value = description.slot_fn(inverter)
     except Exception:  # noqa: BLE001
         _LOGGER.warning("Skipping time %s: slot_fn raised at setup", description.key)
         return False
+    if value is None:
+        # Expected: the slot register isn't present on this device/firmware. DEBUG,
+        # not WARNING — this is the gate working as designed and recurs every restart,
+        # unlike the duplicate/garbled anomalies that warrant a warning.
+        _LOGGER.debug("Skipping time %s: slot_fn reads None at setup", description.key)
+        return False
+    return True
 
 
 async def async_setup_entry(

--- a/custom_components/givenergy_local/time.py
+++ b/custom_components/givenergy_local/time.py
@@ -222,7 +222,9 @@ def _ems_time_descriptions() -> tuple[GivEnergyEmsTimeEntityDescription, ...]:
 EMS_TIME_DESCRIPTIONS: tuple[GivEnergyEmsTimeEntityDescription, ...] = _ems_time_descriptions()
 
 
-def _include_time(description: GivEnergyTimeEntityDescription, inverter: InverterModel) -> bool:
+def _include_time(
+    description: GivEnergyTimeEntityDescription, inverter: InverterModel, clean: bool = True
+) -> bool:
     """Whether to create a time control at setup (#207).
 
     A skip_if_none control is dropped when its readability signal reads None —
@@ -231,6 +233,10 @@ def _include_time(description: GivEnergyTimeEntityDescription, inverter: Inverte
     Guarded so a raising accessor skips just that control, not the whole platform.
     """
     if not description.skip_if_none:
+        return True
+    # On a partial seed poll a None may be a transient bank failure, not structural
+    # absence — keep the control so a later clean poll recovers it (#208 review).
+    if not clean:
         return True
     read = description.readable_fn or description.slot_fn
     try:
@@ -269,10 +275,11 @@ async def async_setup_entry(
         )
     else:
         inverter = coordinator.data.inverter
+        clean = not coordinator.last_partial_failures
         entities.extend(
             GivEnergyTimeEntity(coordinator, description)
             for description in TIME_DESCRIPTIONS
-            if _include_time(description, inverter)
+            if _include_time(description, inverter, clean)
         )
         entities.extend(
             GivEnergyTimeEntity(coordinator, description)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -860,3 +860,41 @@ async def test_expose_recommended_entities_honours_custom_assistants_list(
     # Two assistants × N entities → 2N total exposure calls.
     assistants_called = {call.args[1] for call in expose_mock.call_args_list}
     assert assistants_called == {"conversation", "cloud.alexa"}
+
+
+async def test_upgrade_removes_unreadable_control_rows(
+    hass, mock_client, mock_plant, mock_inverter, mock_config_entry
+):
+    """#207: on upgrade, orphaned rows for readability-gated controls whose register
+    reads None are removed pre-platform — suppressing creation alone leaves them."""
+    mock_inverter.battery_charge_limit_ac = None
+    mock_inverter.battery_discharge_limit_ac = None
+    mock_inverter.battery_pause_mode = None  # pause absent → mode + slots gated
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    # Rows a prior version created: readability-gated controls + one readable control.
+    seeded = (
+        ("number", "SA1234G123_battery_charge_limit_ac"),
+        ("number", "SA1234G123_battery_discharge_limit_ac"),
+        ("select", "SA1234G123_battery_pause_mode"),
+        ("time", "SA1234G123_battery_pause_slot_start"),
+        ("time", "SA1234G123_battery_pause_slot_end"),
+        ("select", "SA1234G123_battery_power_mode"),  # readable → must survive
+    )
+    for domain, unique_id in seeded:
+        registry.async_get_or_create(domain, DOMAIN, unique_id, config_entry=mock_config_entry)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    def _present(domain: str, key: str) -> bool:
+        return registry.async_get_entity_id(domain, DOMAIN, f"SA1234G123_{key}") is not None
+
+    # Readability-gated controls whose register reads None are removed.
+    assert not _present("number", "battery_charge_limit_ac")
+    assert not _present("number", "battery_discharge_limit_ac")
+    assert not _present("select", "battery_pause_mode")
+    assert not _present("time", "battery_pause_slot_start")
+    assert not _present("time", "battery_pause_slot_end")
+    # A readable control is untouched.
+    assert _present("select", "battery_power_mode")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -898,3 +898,25 @@ async def test_upgrade_removes_unreadable_control_rows(
     assert not _present("time", "battery_pause_slot_end")
     # A readable control is untouched.
     assert _present("select", "battery_power_mode")
+
+
+async def test_reconcile_keeps_controls_on_partial_seed(hass, mock_client, setup_integration):
+    """#208: a partial seed poll (last_partial_failures set) must NOT remove control
+    rows — a None read could be a transient bank failure, recoverable on a later poll."""
+    from custom_components.givenergy_local import _reconcile_readability_gated_controls
+
+    coordinator = hass.data[DOMAIN][setup_integration.entry_id]
+    coordinator.last_partial_failures = [object()]  # partial seed
+    coordinator.data.inverter.battery_charge_limit_ac = None  # reads None (transient)
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "number", DOMAIN, "SA1234G123_battery_charge_limit_ac", config_entry=setup_integration
+    )
+
+    _reconcile_readability_gated_controls(hass, coordinator)
+
+    # Partial seed → reconciliation is a no-op; the row is retained.
+    assert (
+        registry.async_get_entity_id("number", DOMAIN, "SA1234G123_battery_charge_limit_ac")
+        is not None
+    )

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -96,6 +96,28 @@ async def test_ac_limits_present_on_ac_coupled_plant(hass, ac_coupled_setup):
     assert state.attributes["max"] == 100
 
 
+async def test_ac_limits_absent_when_register_unreadable(
+    hass, mock_client, mock_plant, mock_inverter, mock_config_entry
+):
+    """#207: on an AC-coupled plant whose firmware doesn't carry HR313/314 (they read
+    None), the AC-limit controls aren't created — no broken slider."""
+    mock_plant.capabilities = PlantCapabilities(
+        device_type=Model.AC,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    mock_inverter.battery_charge_limit_ac = None
+    mock_inverter.battery_discharge_limit_ac = None
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert _maybe_entity_id(hass, "SA1234G123_battery_charge_limit_ac") is None
+    assert _maybe_entity_id(hass, "SA1234G123_battery_discharge_limit_ac") is None
+
+
 async def test_set_ac_charge_limit_sends_command(hass, mock_client, ac_coupled_setup):
     entity_id = _entity_id(hass, "SA1234G123_battery_charge_limit_ac")
     await hass.services.async_call(

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -118,6 +118,20 @@ async def test_ac_limits_absent_when_register_unreadable(
     assert _maybe_entity_id(hass, "SA1234G123_battery_discharge_limit_ac") is None
 
 
+def test_ac_limit_kept_on_partial_seed(mock_inverter):
+    """#208: on a partial seed poll (clean=False) a None read may be a transient bank
+    failure, so the control is kept rather than gated."""
+    from custom_components.givenergy_local.number import (
+        AC_COUPLED_NUMBER_DESCRIPTIONS,
+        _include_number,
+    )
+
+    desc = next(d for d in AC_COUPLED_NUMBER_DESCRIPTIONS if d.key == "battery_charge_limit_ac")
+    mock_inverter.battery_charge_limit_ac = None
+    assert _include_number(desc, mock_inverter, clean=True) is False  # clean + None → gated
+    assert _include_number(desc, mock_inverter, clean=False) is True  # partial → kept
+
+
 async def test_set_ac_charge_limit_sends_command(hass, mock_client, ac_coupled_setup):
     entity_id = _entity_id(hass, "SA1234G123_battery_charge_limit_ac")
     await hass.services.async_call(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -67,6 +67,17 @@ async def test_battery_pause_mode_options(hass, setup_integration):
     }
 
 
+async def test_battery_pause_mode_absent_when_register_unreadable(
+    hass, mock_client, mock_plant, mock_inverter, mock_config_entry
+):
+    """#207: firmware without battery pause (it reads None) gets no pause-mode control."""
+    mock_inverter.battery_pause_mode = None
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert _maybe_entity_id(hass, "SA1234G123_battery_pause_mode") is None
+
+
 async def test_select_pause_both_sends_command(hass, mock_client, setup_integration):
     entity_id = _entity_id(hass, "SA1234G123_battery_pause_mode")
     await hass.services.async_call(

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -80,17 +80,32 @@ async def test_all_time_slot_entities_created(hass, setup_integration):
         assert state is not None, f"Entity SA1234G123_{key} has no state"
 
 
-async def test_battery_pause_slot_absent_when_register_unreadable(
+async def test_battery_pause_slot_absent_when_pause_unsupported(
     hass, mock_client, mock_plant, mock_inverter, mock_config_entry
 ):
-    """#207: firmware without the battery pause slot (it reads None) gets no
-    pause-slot controls."""
-    mock_inverter.battery_pause_slot_1 = None
+    """#207/#208: firmware without battery pause (the pause-mode register reads None)
+    gets no pause-slot controls. They're gated on the mode register's presence, not
+    the decoded slot."""
+    mock_inverter.battery_pause_mode = None
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
     assert _maybe_entity_id(hass, "SA1234G123_battery_pause_slot_start") is None
     assert _maybe_entity_id(hass, "SA1234G123_battery_pause_slot_end") is None
+
+
+async def test_battery_pause_slot_kept_when_slot_unset(
+    hass, mock_client, mock_plant, mock_inverter, mock_config_entry
+):
+    """#208 review: a valid-but-unset slot decodes to None (raw-60 sentinel) but the
+    pause feature is present — the controls must stay so the user can set them."""
+    mock_inverter.battery_pause_slot_1 = None  # unset slot decodes to None
+    # battery_pause_mode keeps its default (present) — the feature exists.
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert _maybe_entity_id(hass, "SA1234G123_battery_pause_slot_start") is not None
+    assert _maybe_entity_id(hass, "SA1234G123_battery_pause_slot_end") is not None
 
 
 async def test_set_battery_pause_slot_start_sends_command(hass, mock_client, setup_integration):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -12,6 +12,10 @@ def _entity_id(hass, unique_id: str) -> str:
     return entity_id
 
 
+def _maybe_entity_id(hass, unique_id: str) -> str | None:
+    return er.async_get(hass).async_get_entity_id("time", DOMAIN, unique_id)
+
+
 async def test_charge_slot_1_start_initial_value(hass, setup_integration):
     state = hass.states.get(_entity_id(hass, "SA1234G123_charge_slot_1_start"))
     assert state.state == "00:30:00"
@@ -74,6 +78,19 @@ async def test_all_time_slot_entities_created(hass, setup_integration):
         entity_id = _entity_id(hass, f"SA1234G123_{key}")
         state = hass.states.get(entity_id)
         assert state is not None, f"Entity SA1234G123_{key} has no state"
+
+
+async def test_battery_pause_slot_absent_when_register_unreadable(
+    hass, mock_client, mock_plant, mock_inverter, mock_config_entry
+):
+    """#207: firmware without the battery pause slot (it reads None) gets no
+    pause-slot controls."""
+    mock_inverter.battery_pause_slot_1 = None
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert _maybe_entity_id(hass, "SA1234G123_battery_pause_slot_start") is None
+    assert _maybe_entity_id(hass, "SA1234G123_battery_pause_slot_end") is None
 
 
 async def test_set_battery_pause_slot_start_sends_command(hass, mock_client, setup_integration):


### PR DESCRIPTION
Closes #207. The readability rubric from the #188 discussion: a control should only appear if its register actually reads on this device/firmware.

## Problem
Control entities (number/select/time) were created from capability gates alone, so a control could appear for a register the device/firmware doesn't carry — a non-functional slider, or one whose write the library rejects (cf. #188's HR313/314 on older firmware, and battery pause mode on systems that lack it).

## Change
Add a `skip_if_none` flag to the control description dataclasses — the control-side of the sensor `skip_if_none`. A flagged control is dropped when its value accessor (`value_fn`/`current_option_fn`/`slot_fn`) reads `None` at setup, guarded so a raising accessor (e.g. a field renamed in givenergy-modbus) skips just that control rather than aborting the platform (the same failure mode `_include_inverter_sensor` guards for sensors).

**Opt-in** to the genuinely firmware/device-variable controls:
- `battery_charge_limit_ac` / `battery_discharge_limit_ac` (HR313/314) — absent on older firmware (writability tracked in dewet22/givenergy-modbus#295).
- `battery_pause_mode` + `battery_pause_slot_start`/`_end` — the library notes pause is firmware-gated.

Core controls (charge slots, enable-charge, etc.) are deliberately **not** flagged — they should never vanish on a transient setup read-miss. The flag is there to extend to any control later.

## Test plan
- [x] `uv run pytest -q` — 482 passed (per-platform absent-when-`None` tests + the existing present-case coverage)
- [x] ruff + mypy + pre-commit clean
- The default fixtures set these registers to valid values, so existing control tests are unaffected; the gate only fires when a register reads `None`.