### PR TITLE
fix: namespace EMS managed-inverter identity to prevent serial collision (#203)

### DIFF
--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -2221,7 +2221,9 @@ class GivEnergyManagedInverterSensor(CoordinatorEntity[GivEnergyUpdateCoordinato
     manages appear only as blinded rollup summaries (status / power / SoC /
     heatsink temp — no per-string detail). Each managed inverter becomes its own
     HA device, parented to the controller via `via_device` and identified by its
-    own serial. The rollup lives in the EMS block on 0x11 (there's no per-inverter
+    own serial namespaced with a `_managed` marker — so the rollup can't collide
+    with a directly-connected inverter entry of the same serial (#203). The rollup
+    lives in the EMS block on 0x11 (there's no per-inverter
     register bank), so there's no stale gate: availability is simply whether the
     serial is still present in the latest poll.
     """
@@ -2241,9 +2243,15 @@ class GivEnergyManagedInverterSensor(CoordinatorEntity[GivEnergyUpdateCoordinato
         # is rebuilt each refresh and a dropped slot shifts the rest, so resolving
         # by serial keeps each entity tied to its own inverter.
         self._serial = serial
-        self._attr_unique_id = f"{serial}_{description.key}"
+        # Namespace the device + entity identity with a `_managed` marker so a rollup
+        # can't collide with a directly-connected inverter entry of the same serial
+        # (#203): both paths otherwise key off `(DOMAIN, serial)` / `{serial}_{key}`.
+        # Serials never contain "_managed", so this is collision-proof; the real
+        # serial still shows via the device name and serial_number.
+        managed_id = f"{serial}_managed"
+        self._attr_unique_id = f"{managed_id}_{description.key}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, serial)},
+            identifiers={(DOMAIN, managed_id)},
             name=f"GivEnergy Managed Inverter {serial}",
             manufacturer="GivEnergy",
             model="Managed Inverter (EMS)",

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -296,10 +296,10 @@ async def test_managed_inverter_devices_created_and_parented(hass, managed_ems_s
     controller = dev_registry.async_get_device(identifiers={(DOMAIN, "SA1234G123")})
     assert controller is not None
     for serial in ("SA1111A001", "SA2222A002"):
-        entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_power")
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_managed_power")
         assert entity_id is not None, f"{serial} has no power sensor"
         device = dev_registry.async_get(registry.async_get(entity_id).device_id)
-        assert (DOMAIN, serial) in device.identifiers
+        assert (DOMAIN, f"{serial}_managed") in device.identifiers
         assert device.name == f"GivEnergy Managed Inverter {serial}"
         assert device.model == "Managed Inverter (EMS)"
         assert device.via_device_id == controller.id
@@ -307,12 +307,14 @@ async def test_managed_inverter_devices_created_and_parented(hass, managed_ems_s
 
 async def test_managed_inverter_values(hass, managed_ems_setup):
     """The blinded summary fields surface on the child sensors."""
-    assert hass.states.get(_entity_id(hass, "sensor", "SA1111A001_power")).state == "1500"
-    assert hass.states.get(_entity_id(hass, "sensor", "SA1111A001_battery_soc")).state == "60"
-    temp = hass.states.get(_entity_id(hass, "sensor", "SA1111A001_temperature"))
+    assert hass.states.get(_entity_id(hass, "sensor", "SA1111A001_managed_power")).state == "1500"
+    assert (
+        hass.states.get(_entity_id(hass, "sensor", "SA1111A001_managed_battery_soc")).state == "60"
+    )
+    temp = hass.states.get(_entity_id(hass, "sensor", "SA1111A001_managed_temperature"))
     assert float(temp.state) == 30.5
     assert temp.attributes["unit_of_measurement"] == "°C"
-    assert hass.states.get(_entity_id(hass, "sensor", "SA2222A002_power")).state == "-200"
+    assert hass.states.get(_entity_id(hass, "sensor", "SA2222A002_managed_power")).state == "-200"
 
 
 async def test_managed_inverter_resolves_by_serial(hass, managed_ems_setup):
@@ -323,8 +325,11 @@ async def test_managed_inverter_resolves_by_serial(hass, managed_ems_setup):
     coordinator.async_set_updated_data(coordinator.data)
     await hass.async_block_till_done()
 
-    assert hass.states.get(_entity_id(hass, "sensor", "SA2222A002_power")).state == "-200"
-    assert hass.states.get(_entity_id(hass, "sensor", "SA1111A001_power")).state == "unavailable"
+    assert hass.states.get(_entity_id(hass, "sensor", "SA2222A002_managed_power")).state == "-200"
+    assert (
+        hass.states.get(_entity_id(hass, "sensor", "SA1111A001_managed_power")).state
+        == "unavailable"
+    )
 
 
 async def test_no_managed_inverter_devices_for_non_ems_plant(hass, setup_integration):
@@ -356,6 +361,44 @@ async def test_managed_inverter_dedup_duplicate_serial(
         if d.model == "Managed Inverter (EMS)"
     ]
     assert len(managed) == 1
+
+
+async def test_managed_inverter_namespaced_against_same_serial(
+    hass, mock_client, mock_plant, mock_inverter, mock_ems, mock_config_entry
+):
+    """#203: a managed-inverter rollup must not hijack a same-serial device.
+
+    The rollup here reports the controller's own serial — the in-one-entry repro of
+    the collision (a separately-configured direct inverter of a managed serial is
+    the cross-entry form). Pre-fix this merged the rollup's DeviceInfo onto
+    `(DOMAIN, serial)` and dropped the colliding status/SoC sensors; the `_managed`
+    namespace keeps the two identities distinct.
+    """
+    mock_ems.managed_inverters = [_managed("SA1234G123", power=1500, soc=60, temp=30.5)]
+    mock_plant.ems = mock_ems
+    mock_inverter.model = Model.EMS
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    dev_registry = dr.async_get(hass)
+
+    # The controller keeps its bare-serial device identity and its own status sensor.
+    controller = dev_registry.async_get_device(identifiers={(DOMAIN, "SA1234G123")})
+    assert controller is not None
+    assert controller.model != "Managed Inverter (EMS)"
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_status") is not None
+
+    # The rollup gets a distinct `_managed` device + namespaced sensors — no collision.
+    managed = dev_registry.async_get_device(identifiers={(DOMAIN, "SA1234G123_managed")})
+    assert managed is not None
+    assert managed.id != controller.id
+    assert managed.model == "Managed Inverter (EMS)"
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_managed_status") is not None
+    assert (
+        registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_managed_battery_soc") is not None
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes #203 — the EMS managed-inverter rollup devices (#199) collided by serial with a directly-connected inverter entry of the same serial.

Every device is identified as `(DOMAIN, serial)` with `unique_id = f"{serial}_{key}"`. The #199 rollup reused that shape with the managed inverter's serial, so running **both** an EMS controller entry and a direct connection to one of its managed inverters hit:
- **Device-identity hijack** — the rollup's `DeviceInfo` merged onto the real inverter's device, relabelling it "Managed Inverter (EMS)" and reparenting it under the controller.
- **Dropped sensors** — the rollup's `status`/`battery_soc` collided on `unique_id` and were dropped (2 of 4 rollup sensors vanished).

## Fix
Namespace the rollup device + entity identity with a `_managed` marker: `(DOMAIN, f"{serial}_managed")` / `f"{serial}_managed_{key}"`. Serials never contain `_managed`, so it can no longer collide; the real serial still shows via the device name and `serial_number`.

## Migration
No registry migration. The old `{serial}_{key}` ids are *ambiguous* — for a user with a direct entry they belong to the real inverter — so a blind rename would clobber the wrong entity (that ambiguity is the bug). Instead it self-heals: once the rollup stops claiming `(DOMAIN, serial)`, the direct inverter re-registers that device with its correct name/model on restart, leaving only the rollup's old rows orphaned (clearable via the device page). #199 shipped a day ago (v1.3.9) to very few EMS users, so the blast radius is minimal.

## Tests
- Updated the managed-inverter device/sensor tests to the `_managed` shape.
- Added `test_managed_inverter_namespaced_against_same_serial` — the in-one-entry repro (rollup reports the controller's own serial): the controller keeps its bare-serial identity and `status` sensor while the rollup gets a distinct `_managed` device + namespaced sensors.

487 passed; mypy + ruff clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed entity identity collisions when managed inverter rollup sensors share the same serial number with directly-connected inverter sensors. Each device now maintains a distinct identity in Home Assistant.

* **Tests**
  * Added regression test to verify managed inverters do not hijack identities of same-serial direct devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->