### PR TITLE
fix: target the EMS controller on the auto-dashboard (#175)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -71,7 +71,7 @@ _STRATEGY_URL = f"/{DOMAIN}/{_STRATEGY_FILENAME}"
 # served from the same package dir so they resolve offline without a CDN.
 _FONTS_DIRNAME = "fonts"
 _FONTS_URL = f"/{DOMAIN}/{_FONTS_DIRNAME}"
-_STRATEGY_VERSION = "9"
+_STRATEGY_VERSION = "10"
 
 # Per-config-entry topology cache. PlantCapabilities is persisted as
 # `to_dict()` directly (no envelope) following HA Core's Store convention —

--- a/custom_components/givenergy_local/www/ge-strategy.js
+++ b/custom_components/givenergy_local/www/ge-strategy.js
@@ -173,7 +173,13 @@
         }) || null;
       if (!target) unmatchedSerial = opts.serial;
     } else {
-      target = inverters[0] || null;
+      // On an EMS plant prefer the controller (it carries the plant-level
+      // aggregates and the real PV/grid/battery telemetry); a plain multi-inverter
+      // plant still takes the first inverter by serial.
+      var emsTarget = inverters.find(function (p) {
+        return p.isEms;
+      });
+      target = emsTarget || inverters[0] || null;
     }
 
     // batteries belonging to the target inverter (by via_device). Only fall
@@ -243,6 +249,11 @@
       inv: function (key) {
         return invKeys.get(key) || null;
       },
+      // Plant load: prefer the EMS aggregate (the controller's own p_load_demand is
+      // gated off on EMS), falling back to the inverter key on a plain plant.
+      load: function () {
+        return invKeys.get("ems_calc_load_power") || invKeys.get("p_load_demand") || null;
+      },
       bat: function (rec, key) {
         return rec.keys.get(key) || null;
       },
@@ -257,6 +268,12 @@
     var a = makeAccessors(plant);
     var views = [];
     if (plant.target && plant.target.isEms) {
+      // The EMS controller carries real plant telemetry (#206), so it gets the
+      // Overview + Energy views. Batteries hang off the managed inverters and the
+      // inverter-level controls are suppressed on EMS, so those views are replaced
+      // by the EMS controls (slots) + diagnostics.
+      views.push(overviewView(plant, a, opts));
+      views.push(energyView(plant, a));
       views.push(emsControlsView(plant, a));
       views.push(emsDiagnosticsView(plant, a));
       return views;
@@ -501,10 +518,27 @@
         if (a.inv("battery_soc")) ents.battery.state_of_charge = a.inv("battery_soc");
       }
       if (a.inv("grid_power")) ents.grid = { entity: a.inv("grid_power") };
-      if (a.inv("p_load_demand")) ents.home = { entity: a.inv("p_load_demand") };
+      if (a.load()) ents.home = { entity: a.load() };
       cards.push({ type: "custom:power-flow-card-plus", entities: ents });
     } else {
       cards.push(placeholder("power-flow-card-plus"));
+    }
+
+    if (plant.target && plant.target.isEms) {
+      // The controller's distinguishing plant-level aggregates (the inverter-keyed
+      // cards above show the real PV/grid/battery; these complement them). Measured
+      // load is omitted - it reads zero on current firmware.
+      cards.push({
+        type: "entities",
+        title: "EMS Plant",
+        entities: cleanRows([
+          row(a.inv("ems_calc_load_power"), "Calculated Load"),
+          row(a.inv("ems_grid_meter_power"), "Grid Meter Power"),
+          row(a.inv("ems_total_battery_power"), "Total Battery Power"),
+          row(a.inv("ems_remaining_battery_energy"), "Remaining Battery Energy"),
+          row(a.inv("ems_inverter_count"), "Managed Inverters"),
+        ]),
+      });
     }
 
     cards.push({
@@ -538,7 +572,7 @@
       { entity: a.inv("p_pv"), name: "PV", color: "#FFB300" },
       { entity: a.inv("p_battery"), name: "Battery", color: "#42A5F5" },
       { entity: a.inv("grid_power"), name: "Grid", color: "#66BB6A" },
-      { entity: a.inv("p_load_demand"), name: "Load", color: "#EF5350" },
+      { entity: a.load(), name: "Load", color: "#EF5350" },
     ].filter(function (s) {
       return s.entity;
     });

--- a/tests/js/ge-strategy.test.js
+++ b/tests/js/ge-strategy.test.js
@@ -189,14 +189,50 @@ describe("feature detection", () => {
 });
 
 describe("EMS plant", () => {
-  it("emits the EMS view set and resolves the plant switch", async () => {
+  it("emits telemetry views plus the EMS controls/diagnostics set", async () => {
     const hass = makeHass({ ems: true });
     const dash = await GE.generateDashboard({}, hass);
-    expect(titles(dash)).toEqual(["EMS Controls", "Diagnostics"]);
+    expect(titles(dash)).toEqual(["Overview", "Energy", "EMS Controls", "Diagnostics"]);
 
     const plant = card(view(dash, "EMS Controls"), byTitle("Plant"));
     const refs = collectRefs(plant);
     expect(refs.some((r) => r.endsWith("ems_plant_enable"))).toBe(true);
+  });
+
+  it("surfaces the controller's PV/grid/battery and the EMS load on the Overview", async () => {
+    await withCards(["power-flow-card-plus"], async () => {
+      const hass = makeHass({ ems: true });
+      const dash = await GE.generateDashboard({}, hass);
+      const overview = view(dash, "Overview");
+
+      const flow = card(overview, (c) => c.type === "custom:power-flow-card-plus");
+      const refs = collectRefs(flow);
+      expect(refs.some((r) => r.endsWith("_p_pv"))).toBe(true);
+      expect(refs.some((r) => r.endsWith("_grid_power"))).toBe(true);
+      expect(refs.some((r) => r.endsWith("_p_battery"))).toBe(true);
+      // Load uses the EMS aggregate (p_load_demand is gated off on the controller).
+      expect(refs.some((r) => r.endsWith("_ems_calc_load_power"))).toBe(true);
+
+      const emsPlant = card(overview, byTitle("EMS Plant"));
+      expect(emsPlant).toBeTruthy();
+      expect(collectRefs(emsPlant).some((r) => r.endsWith("_ems_grid_meter_power"))).toBe(true);
+    });
+  });
+});
+
+describe("EMS target selection", () => {
+  it("prefers the EMS controller over a lower-sorting plain inverter", async () => {
+    const hass = makeHass({ ems: true, inverterSerial: "ZZZ999", extraInverterSerial: "AAA111" });
+    const plant = await GE.buildPlant(hass, {});
+    expect(plant.target.isEms).toBe(true);
+    expect(plant.target.serial).toBe("ZZZ999");
+  });
+
+  it("still honours an explicit serial pin to a plain inverter on an EMS plant", async () => {
+    const hass = makeHass({ ems: true, inverterSerial: "ZZZ999", extraInverterSerial: "AAA111" });
+    const plant = await GE.buildPlant(hass, { serial: "AAA111" });
+    expect(plant.target.serial).toBe("AAA111");
+    expect(plant.target.isEms).toBe(false);
   });
 });
 
@@ -332,10 +368,11 @@ describe("flow mode", () => {
     expect(view(dash, "Flow")).toBeUndefined();
   });
 
-  it("does not emit a Flow panel for an EMS plant", async () => {
+  it("falls back to the classic EMS view set (no Flow panel) for an EMS plant", async () => {
     const hass = makeHass({ ems: true });
     const dash = await GE.generateDashboard({ mode: "flow" }, hass);
-    expect(titles(dash)).toEqual(["EMS Controls", "Diagnostics"]);
+    expect(titles(dash)).toEqual(["Overview", "Energy", "EMS Controls", "Diagnostics"]);
+    expect(view(dash, "Flow")).toBeUndefined();
   });
 });
 
@@ -388,10 +425,11 @@ describe("glance mode", () => {
     expect(hasNullEntity(c)).toBe(false);
   });
 
-  it("does not emit a Glance panel for an EMS plant", async () => {
+  it("falls back to the classic EMS view set (no Glance panel) for an EMS plant", async () => {
     const hass = makeHass({ ems: true });
     const dash = await GE.generateDashboard({ mode: "glance" }, hass);
-    expect(titles(dash)).toEqual(["EMS Controls", "Diagnostics"]);
+    expect(titles(dash)).toEqual(["Overview", "Energy", "EMS Controls", "Diagnostics"]);
+    expect(view(dash, "Glance")).toBeUndefined();
   });
 });
 
@@ -415,10 +453,10 @@ describe("all mode", () => {
     expect(view(dash, "Analyst").cards[0].type).toBe("custom:givenergy-analyst");
   });
 
-  it("falls back to classic for an EMS plant", async () => {
+  it("falls back to the classic EMS view set for an EMS plant", async () => {
     const hass = makeHass({ ems: true });
     const dash = await GE.generateDashboard({ mode: "all" }, hass);
-    expect(titles(dash)).toEqual(["EMS Controls", "Diagnostics"]);
+    expect(titles(dash)).toEqual(["Overview", "Energy", "EMS Controls", "Diagnostics"]);
   });
 });
 
@@ -486,9 +524,10 @@ describe("analyst mode", () => {
     expect(hasNullEntity(c)).toBe(false);
   });
 
-  it("does not emit an Analyst view for an EMS plant", async () => {
+  it("falls back to the classic EMS view set (no Analyst view) for an EMS plant", async () => {
     const hass = makeHass({ ems: true });
     const dash = await GE.generateDashboard({ mode: "analyst" }, hass);
-    expect(titles(dash)).toEqual(["EMS Controls", "Diagnostics"]);
+    expect(titles(dash)).toEqual(["Overview", "Energy", "EMS Controls", "Diagnostics"]);
+    expect(view(dash, "Analyst")).toBeUndefined();
   });
 });

--- a/tests/js/mock-hass.js
+++ b/tests/js/mock-hass.js
@@ -75,6 +75,35 @@ const AC_COUPLED_KEYS = [
   "export_priority", "enable_eps", "battery_charge_limit_ac", "battery_discharge_limit_ac",
 ];
 
+// On an EMS plant the 0x11 controller keeps its inverter SENSORS (PV/grid/battery/
+// AC/temps), but the inverter-level CONTROLS are suppressed and two controller-local
+// sensors are gated off (#201/#206): House Consumption (e_consumption_today) and Load
+// Power (p_load_demand) — the EMS load aggregates supersede them.
+const EMS_SUPPRESSED_KEYS = [
+  "p_load_demand", "e_consumption_today", "battery_pause_mode",
+  "battery_power_mode", "enable_rtc", "active_power_rate", "battery_calibration_stage",
+  "enable_charge", "charge_target_soc", "battery_soc_reserve", "battery_charge_limit",
+  "charge_slot_1_start", "charge_slot_1_end", "charge_slot_2_start", "charge_slot_2_end",
+  "enable_discharge", "battery_discharge_limit", "battery_discharge_min_power_reserve",
+  "discharge_slot_1_start", "discharge_slot_1_end", "discharge_slot_2_start",
+  "discharge_slot_2_end", "battery_maintenance_mode",
+];
+
+// Plant-level aggregates the EMS controller carries (sensor.py EMS_SENSORS).
+const EMS_AGGREGATE_KEYS = [
+  "ems_inverter_count", "ems_calc_load_power", "ems_measured_load_power",
+  "ems_grid_meter_power", "ems_total_battery_power", "ems_remaining_battery_energy",
+];
+
+// The full key set on an EMS controller device post-#206: the surviving inverter
+// sensors + the EMS slot controls/health (emsKeys) + the plant aggregates.
+function emsControllerKeys() {
+  const telemetry = INVERTER_KEYS.filter(function (k) {
+    return EMS_SUPPRESSED_KEYS.indexOf(k) === -1;
+  });
+  return telemetry.concat(emsKeys()).concat(EMS_AGGREGATE_KEYS);
+}
+
 // entity_id marker: includes the (optional) area prefix so tests can assert the
 // returned config used the registry's *current* id, not a reconstructed one.
 function entityId(prefix, serial, key) {
@@ -117,7 +146,10 @@ function makeHass(opts) {
       name: "GivEnergy EMS " + invSerial,
       via_device_id: null,
     });
-    entities.push.apply(entities, entitiesFor("dev_ems", invSerial, emsKeys(), prefix, opts.omitKeys));
+    entities.push.apply(
+      entities,
+      entitiesFor("dev_ems", invSerial, emsControllerKeys(), prefix, opts.omitKeys)
+    );
   } else {
     devices.push({
       id: "dev_inv",


### PR DESCRIPTION
## Summary
Fixes #175 — on an EMS plant the auto-generated dashboard recognised only one inverter and showed zero PV.

The dashboard is a Lovelace **strategy in JS** (`ge-strategy.js`). `buildPlant` pooled the EMS controller with every inverter and defaulted `target = inverters[0]` (alphabetical), so an EMS plant landed on an arbitrary managed inverter reporting no PV of its own. Even when it hit the controller, `classicViews` short-circuited EMS to `["EMS Controls", "Diagnostics"]` with no telemetry. #206 has since restored the controller's own PV/grid/battery/AC sensors, so the data is present on the controller.

## Fix (Level 1)
- **Target the EMS controller** when no `serial` is pinned (the pin still overrides).
- **Telemetry views for the controller** — Overview + Energy — then append EMS Controls + Diagnostics (batteries hang off the managed inverters; inverter-level controls are suppressed on EMS).
- **EMS-aware load accessor** `a.load()` = `ems_calc_load_power || p_load_demand` — `p_load_demand` is gated off on the controller (#206), so the power-flow home slot + 24h Load series use the EMS aggregate; plain plants are unchanged.
- **"EMS Plant" card** on the Overview surfacing the controller's aggregates (calc load, grid meter, total battery, remaining energy, managed-inverter count; measured load omitted — reads zero on current firmware).

Per-mode views (flow/glance/analyst/all) keep falling back to the now-useful classic EMS set — a deliberate Level-1 boundary.

## Out of scope (follow-ups)
- **Level 2:** a "Managed Inverters" view enumerating the `_managed` devices.
- Nick's other #52 items (control bugs + Predbat sensors) — separate issues.

## Tests
- `mock-hass.js`: the `ems:true` controller now models its post-#206 keys (inverter sensors minus the gated/suppressed ones, plus the EMS aggregates).
- `ge-strategy.test.js`: rewrote the 5 EMS cases to the new view set + Overview content, and added target-selection tests (controller preferred over a lower-sorting plain inverter; serial pin still honoured).
- 40 JS tests, parity guard, 487 Python tests, ruff + mypy — all green. Rendering needs Nick's plant to confirm.
