### PR TITLE
fix: EMS managed-inverter status crash + measured-load hide + AC-limit rename (#52)

### DIFF
--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -118,7 +118,7 @@ NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
 AC_COUPLED_NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
     GivEnergyNumberEntityDescription(
         key="battery_charge_limit_ac",
-        name="Battery AC Charge Limit",
+        name="Inverter Charge Power Percentage",
         native_unit_of_measurement=PERCENTAGE,
         native_min_value=1,
         native_max_value=100,
@@ -131,7 +131,7 @@ AC_COUPLED_NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
     ),
     GivEnergyNumberEntityDescription(
         key="battery_discharge_limit_ac",
-        name="Battery AC Discharge Limit",
+        name="Inverter Discharge Power Percentage",
         native_unit_of_measurement=PERCENTAGE,
         native_min_value=1,
         native_max_value=100,

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1391,9 +1391,10 @@ EMS_SENSORS: tuple[GivEnergyEmsSensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=_ems_attr("measured_load_power"),
-        # Reads a constant zero on current EMS firmware; the calculated load
-        # aggregate supersedes it. Hidden by default but still recorded, so it
-        # surfaces automatically if a future firmware starts populating it (#52).
+        # Reads a constant zero on current EMS firmware, where the calculated-load
+        # aggregate carries the real figure. Hidden by default on new installs
+        # (still recorded, like grid_power above) to declutter; existing installs
+        # keep it until hidden manually — the flag only applies at registration (#52).
         entity_registry_visible_default=False,
     ),
     GivEnergyEmsSensorDescription(

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1391,6 +1391,10 @@ EMS_SENSORS: tuple[GivEnergyEmsSensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=_ems_attr("measured_load_power"),
+        # Reads a constant zero on current EMS firmware; the calculated load
+        # aggregate supersedes it. Hidden by default but still recorded, so it
+        # surfaces automatically if a future firmware starts populating it (#52).
+        entity_registry_visible_default=False,
     ),
     GivEnergyEmsSensorDescription(
         key="ems_grid_meter_power",

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -148,6 +148,19 @@ def _summary_attr(name: str) -> Callable[[InverterSummary], Any]:
     return lambda summary: getattr(summary, name)
 
 
+def _managed_status(value: Any) -> str | None:
+    """Render an EMS managed inverter's status defensively.
+
+    Unlike a directly-reachable inverter's Status enum, the EMS rollup reports
+    each managed inverter's status as a raw string, so coerce instead of
+    assuming `.name` — calling `.name` on the string raised on every poll on
+    real EMS hardware (#52).
+    """
+    if value is None:
+        return None
+    return value.name if hasattr(value, "name") else str(value)
+
+
 def _battery_hex(name: str, width: int) -> Callable[[Battery], Any]:
     """Return a value_fn that renders the named attr as a fixed-width hex string.
 
@@ -1317,7 +1330,7 @@ MANAGED_INVERTER_SENSORS: tuple[GivEnergyManagedInverterSensorDescription, ...] 
         key="status",
         name="Status",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda summary: summary.status.name if summary.status is not None else None,
+        value_fn=lambda summary: _managed_status(summary.status),
     ),
     GivEnergyManagedInverterSensorDescription(
         key="power",

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -317,6 +317,24 @@ async def test_managed_inverter_values(hass, managed_ems_setup):
     assert hass.states.get(_entity_id(hass, "sensor", "SA2222A002_managed_power")).state == "-200"
 
 
+async def test_managed_inverter_status_string_does_not_crash(
+    hass, mock_client, mock_plant, mock_inverter, mock_ems, mock_config_entry
+):
+    """#52: the EMS rollup reports each managed inverter's status as a raw string,
+    not a Status enum. The status sensor must render it rather than blow up on
+    `.name` (which raised AttributeError on every poll on real EMS hardware)."""
+    mock_ems.managed_inverters = [_managed("SA1111A001", status="2")]
+    mock_plant.ems = mock_ems
+    mock_inverter.model = Model.EMS
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_entity_id(hass, "sensor", "SA1111A001_managed_status"))
+    assert state is not None
+    assert state.state == "2"
+
+
 async def test_managed_inverter_resolves_by_serial(hass, managed_ems_setup):
     """A managed inverter that drops out of the rollup goes unavailable while the
     survivor keeps reporting — entities track serial, not slot position."""

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -507,6 +507,15 @@ async def test_no_ems_sensors_for_non_ems_plant(hass, setup_integration):
     assert _entity_id(hass, "sensor", "SA1234G123_ems_inverter_count") is None
 
 
+def test_ems_measured_load_power_hidden_by_default():
+    """#52: EMS Measured Load Power reads a constant zero on current firmware, so
+    it ships hidden (still recorded) in favour of the calculated-load aggregate."""
+    from custom_components.givenergy_local.sensor import EMS_SENSORS
+
+    desc = next(d for d in EMS_SENSORS if d.key == "ems_measured_load_power")
+    assert desc.entity_registry_visible_default is False
+
+
 def test_controller_local_load_gated_skip_if_ems():
     """Exactly the controller-local load figures are gated off on EMS — House
     Consumption and the inverter busbar Load Power. Pins the boundary so a future


### PR DESCRIPTION
## Summary
Three hass-local fixes from Nick's #52 EMS cross-check, as atomic commits.

### 1. Managed-inverter Status sensor crash (the priority)
On an EMS plant the controller reports each managed inverter's status as a raw string, not a `Status` enum, so the rollup status sensor's `summary.status.name` raised `AttributeError: 'str' object has no attribute 'name'` on every poll — 350 occurrences in Nick's logs. A small `_managed_status` helper now coerces defensively (`.name` only when present, else `str(value)`). The existing tests passed only because the fixture defaulted `status=None`; added a regression with a string status.

### 2. Hide always-zero EMS Measured Load Power
The controller reports a constant zero for measured load on current firmware, where the calculated-load aggregate carries the real figure. Hidden by default on new installs (still recorded, matching the existing `grid_power` precedent) to declutter the default view. The flag only applies at first entity registration — existing installs keep the entity visible until hidden manually.

### 3. Rename the AC charge/discharge limits to the app names
HR313/314 are "Inverter Charge Power Percentage" / "Inverter Discharge Power Percentage" in the GivEnergy app; the integration called them "Battery AC Charge/Discharge Limit". The keys (and thus unique_ids / existing entity_ids) are unchanged, so existing installs keep their entity_ids and just see the new friendly name.

## Out of scope (routed/deferred)
- **DC battery limit 0–50 → 0–100 (HR111/112):** blocked on the modbus library, whose `set_battery_charge_limit`/`set_battery_discharge_limit` hard-raise outside 0–50. Filing a givenergy-modbus issue to widen the range; the one-line hass `native_max_value` bump follows once that releases and is pinned.
- The remaining #52 items (Export Priority read mismatch, Max Output Active Power write no-op, Predbat helper sensors, config-flow battery-only reconfigure, managed-inverter controls) — separate passes.

## Tests
- New regression for the string-status crash; guard test that Measured Load Power ships hidden.
- 489 Python + 40 JS tests, parity guard, mypy, ruff — all green. The rename touches only `name=`, so no entity-id churn and no parity-guard impact.

Rendering of the managed-inverter status on real EMS hardware still wants Nick's confirmation once v1.3.17 is out.