### PR TITLE
fix(deps): bump givenergy-modbus to 2.5.8, widen DC + AC battery limits to 0–100

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -527,6 +527,39 @@ def _reconcile_readability_gated_controls(
             _remove_stale_control(registry, serial, "time", time_desc.key)
 
 
+def _reconcile_ac_coupled_dc_limits(
+    hass: HomeAssistant, coordinator: GivEnergyUpdateCoordinator
+) -> None:
+    """Remove the DC battery-limit rows on AC-coupled / AIO plants (#52).
+
+    Battery power on these plants is controlled via the AC pair (HR313/314); the
+    number platform suppresses the DC pair (HR111/112) there. But on an upgraded
+    entry HA keeps the pre-existing DC rows when the platform stops adding them, so
+    the bundled dashboard would still resolve the now-orphaned DC controls from the
+    registry. Mirror the other reconcilers and remove exactly those rows pre-platform.
+    DC-coupled hybrids don't enter this branch and keep their DC controls.
+    """
+    # Local import: the platform imports from this package, so a module-scope import
+    # risks a load-order cycle. The key set is the same one the platform suppresses on.
+    from .number import _DC_BATTERY_LIMIT_KEYS
+
+    # The gate is structural (plant capability), not a register read, so — like the
+    # EMS reconciliation — it needs no partial-poll guard: a None/incomplete
+    # capabilities simply fails the positive check and removes nothing.
+    caps = coordinator.data.capabilities
+    if caps is None or not caps.has_ac_config_block or caps.is_three_phase:
+        return
+    serial = coordinator.data.inverter_serial_number
+    registry = er.async_get(hass)
+    for key in _DC_BATTERY_LIMIT_KEYS:
+        entity_id = registry.async_get_entity_id("number", DOMAIN, f"{serial}_{key}")
+        if entity_id is not None:
+            _LOGGER.info(
+                "Removing DC control %s: AC-coupled plant uses the AC pair (#52)", entity_id
+            )
+            registry.async_remove(entity_id)
+
+
 async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload the entry when its options change (registered as an update listener)."""
     await hass.config_entries.async_reload(entry.entry_id)
@@ -671,6 +704,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Remove control rows whose register is absent on this device/firmware (#207):
     # the platforms skip creating them, but an upgraded entry keeps the stale row.
     _reconcile_readability_gated_controls(hass, coordinator)
+
+    # On AC-coupled / AIO plants the DC battery-limit controls are suppressed in
+    # favour of the AC pair; remove the stale DC rows an upgraded entry would keep (#52).
+    _reconcile_ac_coupled_dc_limits(hass, coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.5.6,<3.0.0"
+    "givenergy-modbus>=2.5.8,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -109,6 +109,11 @@ NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
 
 # --- AC-config-block controls (AC-coupled inverters + single-phase All-in-One) ---
 
+# DC battery power-limit controls (HR111/112) suppressed on plants that expose the
+# AC-config block — there the AC pair (HR313/314) is the battery-power control and the
+# DC pair targets a different register (modbus #301/#302).
+_DC_BATTERY_LIMIT_KEYS = frozenset({"battery_charge_limit", "battery_discharge_limit"})
+
 # The AC charge/discharge power limits (HR313/314) are distinct from the DC-side
 # limits above (HR111/112) and are only meaningful on models that expose the
 # AC-config register block (HR300+). Gated via PlantCapabilities.has_ac_config_block
@@ -253,11 +258,22 @@ async def async_setup_entry(
             for description in EMS_NUMBER_DESCRIPTIONS
         )
     else:
-        entities.extend(
-            GivEnergyNumberEntity(coordinator, description) for description in NUMBER_DESCRIPTIONS
-        )
         caps = coordinator.data.capabilities
-        if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
+        ac_battery_control = (
+            caps is not None and caps.has_ac_config_block and not caps.is_three_phase
+        )
+        descriptions: tuple[GivEnergyNumberEntityDescription, ...] = NUMBER_DESCRIPTIONS
+        if ac_battery_control:
+            # On AC-coupled / AIO plants battery power is controlled via the AC pair
+            # (HR313/314) created below; the DC pair (HR111/112) targets a different
+            # register here and would mislead, so suppress it (modbus #301/#302).
+            descriptions = tuple(
+                d for d in NUMBER_DESCRIPTIONS if d.key not in _DC_BATTERY_LIMIT_KEYS
+            )
+        entities.extend(
+            GivEnergyNumberEntity(coordinator, description) for description in descriptions
+        )
+        if ac_battery_control:
             inverter = coordinator.data.inverter
             clean = not coordinator.last_partial_failures
             entities.extend(

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -61,7 +61,7 @@ NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
         name="Battery Charge Limit",
         native_unit_of_measurement=PERCENTAGE,
         native_min_value=0,
-        native_max_value=50,
+        native_max_value=100,
         native_step=1,
         mode=NumberMode.BOX,
         value_fn=lambda inv: inv.battery_charge_limit,
@@ -73,7 +73,7 @@ NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
         name="Battery Discharge Limit",
         native_unit_of_measurement=PERCENTAGE,
         native_min_value=0,
-        native_max_value=50,
+        native_max_value=100,
         native_step=1,
         mode=NumberMode.BOX,
         value_fn=lambda inv: inv.battery_discharge_limit,
@@ -113,14 +113,14 @@ NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
 # limits above (HR111/112) and are only meaningful on models that expose the
 # AC-config register block (HR300+). Gated via PlantCapabilities.has_ac_config_block
 # (and not is_three_phase — three-phase AC remaps the read-back to different registers
-# than the command writes; see modbus#75). The setter rejects values below 1, hence the
-# 1–100 range.
+# than the command writes; see modbus#75). Range is 0–100% to match the GivEnergy
+# app and the DC-side pair.
 AC_COUPLED_NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
     GivEnergyNumberEntityDescription(
         key="battery_charge_limit_ac",
         name="Inverter Charge Power Percentage",
         native_unit_of_measurement=PERCENTAGE,
-        native_min_value=1,
+        native_min_value=0,
         native_max_value=100,
         native_step=1,
         mode=NumberMode.BOX,
@@ -133,7 +133,7 @@ AC_COUPLED_NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
         key="battery_discharge_limit_ac",
         name="Inverter Discharge Power Percentage",
         native_unit_of_measurement=PERCENTAGE,
-        native_min_value=1,
+        native_min_value=0,
         native_max_value=100,
         native_step=1,
         mode=NumberMode.BOX,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.5.6,<3.0.0",
+    "givenergy-modbus>=2.5.8,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -920,3 +920,58 @@ async def test_reconcile_keeps_controls_on_partial_seed(hass, mock_client, setup
         registry.async_get_entity_id("number", DOMAIN, "SA1234G123_battery_charge_limit_ac")
         is not None
     )
+
+
+async def test_upgrade_removes_dc_limit_rows_on_ac_coupled(
+    hass, mock_client, mock_plant, mock_inverter, mock_config_entry
+):
+    """#52: on an AC-coupled / AIO plant the DC battery-limit controls are suppressed
+    in favour of the AC pair. On upgrade, the orphaned DC rows a prior version created
+    are removed pre-platform — suppressing creation alone would leave them behind."""
+    mock_plant.capabilities = PlantCapabilities(
+        device_type=Model.AC,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    mock_inverter.battery_charge_limit_ac = 50
+    mock_inverter.battery_discharge_limit_ac = 60
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    for unique_id in ("SA1234G123_battery_charge_limit", "SA1234G123_battery_discharge_limit"):
+        registry.async_get_or_create("number", DOMAIN, unique_id, config_entry=mock_config_entry)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    def _present(key: str) -> bool:
+        return registry.async_get_entity_id("number", DOMAIN, f"SA1234G123_{key}") is not None
+
+    # The DC pair is the wrong register here, so its stale rows are removed...
+    assert not _present("battery_charge_limit")
+    assert not _present("battery_discharge_limit")
+    # ...while the AC pair remains the battery-power control.
+    assert _present("battery_charge_limit_ac")
+    assert _present("battery_discharge_limit_ac")
+
+
+async def test_dc_limit_rows_retained_on_hybrid(
+    hass, mock_client, mock_plant, mock_inverter, mock_config_entry
+):
+    """Regression guard: a DC-coupled hybrid keeps its DC battery-limit rows on
+    upgrade — the AC-coupled suppression must not touch them."""
+    # mock_plant defaults to device_type=Model.HYBRID (no AC-config block).
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    for unique_id in ("SA1234G123_battery_charge_limit", "SA1234G123_battery_discharge_limit"):
+        registry.async_get_or_create("number", DOMAIN, unique_id, config_entry=mock_config_entry)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    def _present(key: str) -> bool:
+        return registry.async_get_entity_id("number", DOMAIN, f"SA1234G123_{key}") is not None
+
+    assert _present("battery_charge_limit")
+    assert _present("battery_discharge_limit")

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -189,3 +189,22 @@ async def test_ac_limits_present_on_all_in_one_plant(hass, aio_setup):
     """AIO exposes the AC-config block, so the AC limits must be created."""
     _entity_id(hass, "SA1234G123_battery_charge_limit_ac")
     _entity_id(hass, "SA1234G123_battery_discharge_limit_ac")
+
+
+async def test_dc_limits_suppressed_on_ac_coupled_plant(hass, ac_coupled_setup):
+    """The DC pair (HR111/112) is the wrong battery-power register on AC-coupled
+    plants, so it's suppressed in favour of the AC pair (modbus #301/#302)."""
+    assert _maybe_entity_id(hass, "SA1234G123_battery_charge_limit") is None
+    assert _maybe_entity_id(hass, "SA1234G123_battery_discharge_limit") is None
+
+
+async def test_dc_limits_suppressed_on_all_in_one_plant(hass, aio_setup):
+    """AIO exposes the AC-config block, so the DC battery limits are suppressed too."""
+    assert _maybe_entity_id(hass, "SA1234G123_battery_charge_limit") is None
+    assert _maybe_entity_id(hass, "SA1234G123_battery_discharge_limit") is None
+
+
+async def test_dc_limits_present_on_hybrid_plant(hass, setup_integration):
+    """Regression guard: the DC-coupled hybrid keeps its DC battery-limit controls."""
+    _entity_id(hass, "SA1234G123_battery_charge_limit")
+    _entity_id(hass, "SA1234G123_battery_discharge_limit")

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -140,23 +140,28 @@ async def test_set_ac_charge_limit_sends_command(hass, mock_client, ac_coupled_s
     mock_client.one_shot_command.assert_called_once()
 
 
+@pytest.mark.parametrize("limit", ["battery_charge_limit", "battery_discharge_limit"])
 @pytest.mark.parametrize("value", [0, 100])
-async def test_dc_limit_write_accepts_full_range(hass, mock_client, setup_integration, value):
-    """The slider advertises 0-100; the boundary writes must reach the modbus setter
-    without raising. givenergy-modbus <2.5.8 rejected >50, so this guards the
-    cross-repo write contract that the pin (>=2.5.8) now satisfies (#52)."""
-    entity_id = _entity_id(hass, "SA1234G123_battery_charge_limit")
+async def test_dc_limit_write_accepts_full_range(
+    hass, mock_client, setup_integration, limit, value
+):
+    """The DC sliders advertise 0-100; both boundary writes must reach the modbus
+    setter without raising. givenergy-modbus <2.5.8 rejected >50, so this guards the
+    cross-repo write contract that the pin (>=2.5.8) now satisfies, for the charge
+    and discharge setters alike (#52)."""
+    entity_id = _entity_id(hass, f"SA1234G123_{limit}")
     await hass.services.async_call(
         "number", "set_value", {"entity_id": entity_id, "value": value}, blocking=True
     )
     mock_client.one_shot_command.assert_called_once()
 
 
+@pytest.mark.parametrize("limit", ["battery_charge_limit_ac", "battery_discharge_limit_ac"])
 @pytest.mark.parametrize("value", [0, 100])
-async def test_ac_limit_write_accepts_full_range(hass, mock_client, ac_coupled_setup, value):
-    """The AC slider dropped its 1-floor to 0-100; both boundaries must reach the
-    modbus AC setter without raising (#52, modbus #301/#302)."""
-    entity_id = _entity_id(hass, "SA1234G123_battery_charge_limit_ac")
+async def test_ac_limit_write_accepts_full_range(hass, mock_client, ac_coupled_setup, limit, value):
+    """The AC sliders dropped their 1-floor to 0-100; both charge and discharge
+    boundaries must reach the modbus AC setter without raising (#52, modbus #301/#302)."""
+    entity_id = _entity_id(hass, f"SA1234G123_{limit}")
     await hass.services.async_call(
         "number", "set_value", {"entity_id": entity_id, "value": value}, blocking=True
     )

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -92,7 +92,7 @@ async def test_ac_limits_present_on_ac_coupled_plant(hass, ac_coupled_setup):
     state = hass.states.get(_entity_id(hass, "SA1234G123_battery_charge_limit_ac"))
     assert state is not None
     assert float(state.state) == 50.0
-    assert state.attributes["min"] == 1
+    assert state.attributes["min"] == 0
     assert state.attributes["max"] == 100
 
 
@@ -136,6 +136,29 @@ async def test_set_ac_charge_limit_sends_command(hass, mock_client, ac_coupled_s
     entity_id = _entity_id(hass, "SA1234G123_battery_charge_limit_ac")
     await hass.services.async_call(
         "number", "set_value", {"entity_id": entity_id, "value": 40}, blocking=True
+    )
+    mock_client.one_shot_command.assert_called_once()
+
+
+@pytest.mark.parametrize("value", [0, 100])
+async def test_dc_limit_write_accepts_full_range(hass, mock_client, setup_integration, value):
+    """The slider advertises 0-100; the boundary writes must reach the modbus setter
+    without raising. givenergy-modbus <2.5.8 rejected >50, so this guards the
+    cross-repo write contract that the pin (>=2.5.8) now satisfies (#52)."""
+    entity_id = _entity_id(hass, "SA1234G123_battery_charge_limit")
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": entity_id, "value": value}, blocking=True
+    )
+    mock_client.one_shot_command.assert_called_once()
+
+
+@pytest.mark.parametrize("value", [0, 100])
+async def test_ac_limit_write_accepts_full_range(hass, mock_client, ac_coupled_setup, value):
+    """The AC slider dropped its 1-floor to 0-100; both boundaries must reach the
+    modbus AC setter without raising (#52, modbus #301/#302)."""
+    entity_id = _entity_id(hass, "SA1234G123_battery_charge_limit_ac")
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": entity_id, "value": value}, blocking=True
     )
     mock_client.one_shot_command.assert_called_once()
 

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.6,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.8,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.5.6"
+version = "2.5.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/41/8d690ca4fbc0068382fbe17b6a82f8ec21b3fd511e3414401152c0710c34/givenergy_modbus-2.5.6.tar.gz", hash = "sha256:5d95530ba8ac4f42c54f318f08066eb58b59c71fce9e6c4fde7fe8da4b2d9b9e", size = 441978, upload-time = "2026-06-24T03:06:46.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8b/b0fb6badb970acbdb2586284a70247cf81783e2f230e09ae23c8cee5719a/givenergy_modbus-2.5.8.tar.gz", hash = "sha256:1fc65670aae285e42ae5f09a8b1d69200c045b24b89a6536df2483544c515f08", size = 444924, upload-time = "2026-06-24T19:18:55.914Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/3a/3484ab8a61929082e77f053f46a7b3a5a39ca328550336d6d53f0f2c41da/givenergy_modbus-2.5.6-py3-none-any.whl", hash = "sha256:e7934b7c1e9fc5106a02ccf9c07461d22e9ff793bcf2a53a3cddd27d7a8b108d", size = 168643, upload-time = "2026-06-24T03:06:44.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/65/60d5192ce25bff47e29142b60ededabcd429916c0b20b71a7e865af625b6/givenergy_modbus-2.5.8-py3-none-any.whl", hash = "sha256:5b2f0c4f305f6a58fe260070f2cde14cb75f0440bee4d8d21996820fff07757c", size = 169485, upload-time = "2026-06-24T19:18:54.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Bumps the modbus pin to 2.5.8 and gets the battery power-limit controls right for every plant topology. Three commits:

**1. Bump to 2.5.8, widen both limit pairs to 0–100.** 2.5.7 fixed a splice-guard false positive that froze battery SOC/cell sensors near full charge; 2.5.8 widens the DC (HR111/112) and AC (HR313/314) charge/discharge setters to accept 0–100 (modbus #301/#302). The DC sliders (capped at 50) and AC sliders (1-floor) both move to 0–100 in lockstep with the setter contract.

**2. Route AC-coupled battery control to the AC pair.** On plants exposing the AC-config block (AC-coupled inverters and single-phase All-in-One), battery power is controlled via the AC pair (HR313/314); the DC pair (HR111/112) targets a different register there and was misleadingly shown alongside it. The DC battery-limit controls are now suppressed on those plants. DC-coupled hybrids are unaffected. *Effect on existing AC-coupled/AIO installs: the `Battery Charge/Discharge Limit` entities are removed (wrong register); the `Inverter Charge/Discharge Power Percentage` controls remain.*

**3. Boundary write tests** for charge and discharge, DC and AC, at 0 and 100 — guarding that the slider range never advertises a write the library rejects.

## Follow-up (hardware verification)
modbus dropped the AC pair's 1-floor to 0, but the "0 disables charge/discharge" semantics on HR313/314 are unverified (the firmware doc is hybrid-scoped). Asking Nick to write 0 to HR313/314 on his AC/EMS plant and confirm it disables AC charge/discharge — closes the loop on the AC 0-floor (modbus #302).

## Tests
500 Python + 40 JS tests, parity guard, mypy, ruff — all green.