### PR TITLE
fix: invert the power-flow-card-plus grid sign (#212)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -71,7 +71,7 @@ _STRATEGY_URL = f"/{DOMAIN}/{_STRATEGY_FILENAME}"
 # served from the same package dir so they resolve offline without a CDN.
 _FONTS_DIRNAME = "fonts"
 _FONTS_URL = f"/{DOMAIN}/{_FONTS_DIRNAME}"
-_STRATEGY_VERSION = "10"
+_STRATEGY_VERSION = "11"
 
 # Per-config-entry topology cache. PlantCapabilities is persisted as
 # `to_dict()` directly (no envelope) following HA Core's Store convention —

--- a/custom_components/givenergy_local/www/ge-strategy.js
+++ b/custom_components/givenergy_local/www/ge-strategy.js
@@ -517,7 +517,9 @@
         ents.battery = { entity: a.inv("p_battery") };
         if (a.inv("battery_soc")) ents.battery.state_of_charge = a.inv("battery_soc");
       }
-      if (a.inv("grid_power")) ents.grid = { entity: a.inv("grid_power") };
+      // grid_power is signed +ve=export (GE convention); power-flow-card-plus
+      // expects +ve=import, so invert or the grid bubble shows import as export (#212).
+      if (a.inv("grid_power")) ents.grid = { entity: a.inv("grid_power"), invert_state: true };
       if (a.load()) ents.home = { entity: a.load() };
       cards.push({ type: "custom:power-flow-card-plus", entities: ents });
     } else {

--- a/tests/js/ge-strategy.test.js
+++ b/tests/js/ge-strategy.test.js
@@ -175,6 +175,18 @@ describe("feature detection", () => {
     });
   });
 
+  it("inverts the grid sign for power-flow-card-plus (grid_power is +ve=export) (#212)", async () => {
+    await withCards(["power-flow-card-plus"], async () => {
+      const hass = makeHass({ batterySerials: ["BAT1"] });
+      const dash = await GE.generateDashboard({}, hass);
+      const overview = view(dash, "Overview");
+      const flow = card(overview, (c) => c.type === "custom:power-flow-card-plus");
+      // The card defaults to +ve=import; grid_power is +ve=export, so without the
+      // invert the grid bubble shows import as export and throws off the home flow.
+      expect(flow.entities.grid.invert_state).toBe(true);
+    });
+  });
+
   it("shows AC-coupled and Smart Load cards only when those entities exist", async () => {
     const plain = await GE.generateDashboard({}, makeHass({ smartLoad: false }));
     const controls = view(plain, "Controls");


### PR DESCRIPTION
## Summary
Fixes the Overview power-flow card showing grid **import as export** (Nick, #212).

The `custom:power-flow-card-plus` grid bubble was fed the raw signed `grid_power` sensor, which is **+ve = export** (GE convention). `power-flow-card-plus` treats a single grid entity as **+ve = import/consumption**, so the sign was backwards — an importing plant rendered as exporting, and the home bubble's flow was thrown off as a result.

The card exposes `invert_state`, which flips both the direction and the value. Setting it on the grid entity makes the card's convention match the sensor.

```js
ents.grid = { entity: a.inv("grid_power"), invert_state: true };
```

## Not EMS-specific
The same unguarded `grid_power` feeds the flow card on every plant type — Nick just hit it on the EMS Overview. The bundled custom flow (`givenergy-flow`) already decodes the sign correctly (+ = export, − = import); only this third-party card was unguarded. Battery and solar are left as-is — they render correctly and weren't reported.

## Changes
- `ge-strategy.js` — `invert_state: true` on the grid entity.
- `__init__.py` — `_STRATEGY_VERSION` 10 → 11 (cache-bust so browsers fetch the corrected strategy).
- `ge-strategy.test.js` — regression test asserting the grid entity carries `invert_state`.

## Tests
502 Python + 41 JS (incl. the new regression), all green.

## Out of scope
The per-battery SOC / charge-status feature request in the same issue is tracked separately.