### PR TITLE
feat: expose the inverter system clock as a datetime entity (#219)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -502,6 +502,7 @@ def _reconcile_readability_gated_controls(
     # Local imports: the platforms import from this package, so importing them at
     # module scope risks a load-order cycle. The gate helpers are the single source
     # of truth for "is this control's register present".
+    from .datetime import SYSTEM_TIME_DESCRIPTION
     from .number import AC_COUPLED_NUMBER_DESCRIPTIONS, _include_number
     from .select import SELECT_DESCRIPTIONS, _include_select
     from .time import TIME_DESCRIPTIONS, _include_time
@@ -525,6 +526,10 @@ def _reconcile_readability_gated_controls(
     for time_desc in TIME_DESCRIPTIONS:
         if not _include_time(time_desc, inverter):
             _remove_stale_control(registry, serial, "time", time_desc.key)
+    # The System Time datetime (HR35-40) follows the same readability gate — remove
+    # its row when the clock register is absent on this device/firmware (#219).
+    if inverter.system_time is None:
+        _remove_stale_control(registry, serial, "datetime", SYSTEM_TIME_DESCRIPTION.key)
 
 
 def _reconcile_ac_coupled_dc_limits(

--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -18,7 +18,7 @@ CONF_RETRIES = "retries"
 
 DEFAULT_PASSIVE = False
 
-PLATFORMS = ["binary_sensor", "sensor", "switch", "number", "select", "time"]
+PLATFORMS = ["binary_sensor", "sensor", "switch", "number", "select", "time", "datetime"]
 
 SERVICE_REBOOT_INVERTER = "reboot_inverter"
 SERVICE_CALIBRATE_BATTERY_SOC = "calibrate_battery_soc"

--- a/custom_components/givenergy_local/datetime.py
+++ b/custom_components/givenergy_local/datetime.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from givenergy_modbus.client import commands
+from homeassistant.components.datetime import DateTimeEntity, DateTimeEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from .const import CONF_BATTERY_DATA_ONLY, DOMAIN
+from .coordinator import GivEnergyUpdateCoordinator
+from .sensor import _device_kind
+
+_LOGGER = logging.getLogger(__name__)
+
+SYSTEM_TIME_DESCRIPTION = DateTimeEntityDescription(
+    key="system_time",
+    name="System Time",
+    entity_category=EntityCategory.CONFIG,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: GivEnergyUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    if entry.options.get(CONF_BATTERY_DATA_ONLY, False):
+        # Battery-data-only (#95): this unit's controls are owned by its Gateway.
+        return
+    # The inverter clock (HR35-40) is present on both directly-connected inverters
+    # and EMS controllers, so create it unconditionally — but skip if the register
+    # reads None on a clean poll (absent on this device/firmware). A partial seed
+    # may read None transiently, so keep it then and let a later poll recover (#219).
+    clean = not coordinator.last_partial_failures
+    if clean and coordinator.data.inverter.system_time is None:
+        _LOGGER.debug("Skipping System Time: register reads None at setup")
+        return
+    async_add_entities([GivEnergyDateTimeEntity(coordinator, SYSTEM_TIME_DESCRIPTION)])
+
+
+class GivEnergyDateTimeEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], DateTimeEntity):
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: GivEnergyUpdateCoordinator,
+        description: DateTimeEntityDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        serial = coordinator.data.inverter_serial_number
+        self._attr_unique_id = f"{serial}_{description.key}"
+        model = coordinator.data.inverter.model
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy {_device_kind(model)} {serial}",
+        )
+
+    @property
+    def native_value(self) -> datetime | None:
+        # The inverter reports a naive local wall-clock time; HA's DateTimeEntity
+        # requires a timezone-aware value, so interpret it in HA's configured zone
+        # (the zone its clock is synced from). None on a bad poll -> unavailable.
+        system_time = self.coordinator.data.inverter.system_time
+        if system_time is None:
+            return None
+        return system_time.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+
+    async def async_set_value(self, value: datetime) -> None:
+        client = self.coordinator._client
+        if client is None or not client.connected:
+            return
+        # HA passes a timezone-aware datetime; the inverter clock is local wall-clock,
+        # matching what the set_system_datetime service writes (it passes dt_util.now()).
+        await client.one_shot_command(commands.set_system_date_time(dt_util.as_local(value)))
+        await self.coordinator.async_request_refresh()

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,0 +1,61 @@
+"""Tests for the GivEnergy Local datetime platform (the inverter system clock, #219)."""
+
+from datetime import UTC, datetime
+
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from custom_components.givenergy_local.const import DOMAIN
+
+
+def _entity_id(hass, unique_id: str) -> str:
+    entity_id = er.async_get(hass).async_get_entity_id("datetime", DOMAIN, unique_id)
+    assert entity_id is not None, f"No datetime entity for unique_id={unique_id!r}"
+    return entity_id
+
+
+def _maybe_entity_id(hass, unique_id: str) -> str | None:
+    return er.async_get(hass).async_get_entity_id("datetime", DOMAIN, unique_id)
+
+
+async def test_system_time_reads_inverter_clock(hass, setup_integration):
+    """The naive inverter clock (fixture 2026-05-10 12:00) is surfaced as a
+    timezone-aware value interpreted in HA's configured zone."""
+    state = hass.states.get(_entity_id(hass, "SA1234G123_system_time"))
+    # HA stores the datetime state as a UTC ISO string; compare instants so the
+    # assertion is independent of the test runner's timezone.
+    expected = datetime(2026, 5, 10, 12, 0, 0, tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    assert dt_util.parse_datetime(state.state) == expected
+
+
+async def test_set_system_time_writes_local_wall_clock(hass, mock_client, setup_integration):
+    """Setting the entity converts HA's tz-aware value to local wall-clock and writes
+    the six RTC registers (year stored as year-2000)."""
+    entity_id = _entity_id(hass, "SA1234G123_system_time")
+    target_utc = datetime(2026, 6, 1, 8, 30, 15, tzinfo=UTC)
+    await hass.services.async_call(
+        "datetime",
+        "set_value",
+        {"entity_id": entity_id, "datetime": target_utc.isoformat()},
+        blocking=True,
+    )
+    mock_client.one_shot_command.assert_called_once()
+    year, month, day, hour, minute, second = mock_client.one_shot_command.call_args[0][0]
+    local = dt_util.as_local(target_utc)
+    assert year.value == local.year - 2000
+    assert month.value == local.month
+    assert day.value == local.day
+    assert hour.value == local.hour
+    assert minute.value == local.minute
+    assert second.value == local.second
+
+
+async def test_system_time_absent_when_register_none(
+    hass, mock_client, mock_plant, mock_inverter, mock_config_entry
+):
+    """If the clock register reads None on a clean poll, the entity isn't created."""
+    mock_inverter.system_time = None
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert _maybe_entity_id(hass, "SA1234G123_system_time") is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -870,6 +870,7 @@ async def test_upgrade_removes_unreadable_control_rows(
     mock_inverter.battery_charge_limit_ac = None
     mock_inverter.battery_discharge_limit_ac = None
     mock_inverter.battery_pause_mode = None  # pause absent → mode + slots gated
+    mock_inverter.system_time = None  # clock register absent → datetime gated (#219)
     mock_config_entry.add_to_hass(hass)
     registry = er.async_get(hass)
     # Rows a prior version created: readability-gated controls + one readable control.
@@ -879,6 +880,7 @@ async def test_upgrade_removes_unreadable_control_rows(
         ("select", "SA1234G123_battery_pause_mode"),
         ("time", "SA1234G123_battery_pause_slot_start"),
         ("time", "SA1234G123_battery_pause_slot_end"),
+        ("datetime", "SA1234G123_system_time"),
         ("select", "SA1234G123_battery_power_mode"),  # readable → must survive
     )
     for domain, unique_id in seeded:
@@ -896,6 +898,7 @@ async def test_upgrade_removes_unreadable_control_rows(
     assert not _present("select", "battery_pause_mode")
     assert not _present("time", "battery_pause_slot_start")
     assert not _present("time", "battery_pause_slot_end")
+    assert not _present("datetime", "system_time")
     # A readable control is untouched.
     assert _present("select", "battery_power_mode")
 
@@ -908,18 +911,23 @@ async def test_reconcile_keeps_controls_on_partial_seed(hass, mock_client, setup
     coordinator = hass.data[DOMAIN][setup_integration.entry_id]
     coordinator.last_partial_failures = [object()]  # partial seed
     coordinator.data.inverter.battery_charge_limit_ac = None  # reads None (transient)
+    coordinator.data.inverter.system_time = None  # reads None (transient)
     registry = er.async_get(hass)
     registry.async_get_or_create(
         "number", DOMAIN, "SA1234G123_battery_charge_limit_ac", config_entry=setup_integration
     )
+    registry.async_get_or_create(
+        "datetime", DOMAIN, "SA1234G123_system_time", config_entry=setup_integration
+    )
 
     _reconcile_readability_gated_controls(hass, coordinator)
 
-    # Partial seed → reconciliation is a no-op; the row is retained.
+    # Partial seed → reconciliation is a no-op; the rows are retained.
     assert (
         registry.async_get_entity_id("number", DOMAIN, "SA1234G123_battery_charge_limit_ac")
         is not None
     )
+    assert registry.async_get_entity_id("datetime", DOMAIN, "SA1234G123_system_time") is not None
 
 
 async def test_upgrade_removes_dc_limit_rows_on_ac_coupled(


### PR DESCRIPTION
## Summary
Adds a `datetime` platform exposing the inverter's system clock (modbus `system_time`, HR35-40) as a single read/write **System Time** entity per inverter (#219).

The read is the headline: Predbat (and anyone) can compare the inverter clock against the host clock to detect drift — the GE cloud API and GivTCP both surface this, and it was the one piece missing here. The write reuses the same `set_system_date_time` command as the existing `set_system_datetime` service, which stays as a one-shot "sync to now" button — the two coexist (one-shot sync vs. a persistent, settable field).

## Timezone handling
The inverter reports a **naive** local wall-clock, but HA's `DateTimeEntity` requires a timezone-aware value. So the entity:
- **read:** interprets `system_time` in HA's configured zone (the zone its clock is synced from);
- **write:** converts HA's tz-aware value back to local wall-clock before encoding the RTC registers.

The write test pins this end-to-end (UTC input → local-wall-clock register values, year stored as year-2000).

## Scope / gating
- One entity per non-battery-only unit; works on directly-connected inverters **and** EMS controllers (both carry HR35-40).
- Skipped if the clock register reads `None` on a clean poll (absent on this device/firmware); kept through a transient partial seed.
- `EntityCategory.CONFIG`, matching the other writable temporal controls.

## Tests
New `tests/test_datetime.py`: read, write (full tz round-trip), and skip-when-absent. 505 Python tests green; ruff, mypy, prek hooks all clean. No JS change.