### PR TITLE
feat: experimental-features mechanism for opt-in modbus client flags

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -48,6 +48,7 @@ from .const import (
     SERVICE_REBOOT_INVERTER,
     SERVICE_REDETECT_PLANT,
     SERVICE_SET_SYSTEM_DATETIME,
+    resolve_experimental_client_kwargs,
 )
 from .coordinator import GivEnergyUpdateCoordinator, missing_devices
 from .http import (
@@ -644,12 +645,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
             hass.config_entries.async_schedule_reload(entry.entry_id)
 
+    # Resolve opt-in experimental client flags from options into Client(...) kwargs.
+    # Empty for the default-off case, so the construction is unchanged.
+    experimental_client_kwargs = resolve_experimental_client_kwargs(entry.options)
+
     coordinator = GivEnergyUpdateCoordinator(
         hass=hass,
         host=entry.data[CONF_HOST],
         port=entry.data[CONF_PORT],
         scan_interval=entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
         passive=entry.data.get(CONF_PASSIVE, DEFAULT_PASSIVE),
+        experimental_client_kwargs=experimental_client_kwargs,
         prior_capabilities=prior_capabilities,
         on_topology_changed=_on_topology_changed,
         on_devices_missing=_on_devices_missing,

--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -173,10 +173,18 @@ class GivEnergyLocalOptionsFlow(OptionsFlow):
         # Surface the collapsed "Experimental features" group only once at least one
         # flag exists, so the header never appears empty (the registry ships empty).
         if EXPERIMENTAL_FEATURES:
-            schema_dict[vol.Optional(CONF_EXPERIMENTAL, default={})] = section(
+            # Use currently-saved values as the schema default for each feature so
+            # that a collapsed/omitted section (which HA fills with the default
+            # rather than re-submitting the current values) falls back to what was
+            # already enabled rather than all-off feature defaults.
+            existing_exp: dict[str, Any] = self.config_entry.options.get(CONF_EXPERIMENTAL, {})
+            schema_dict[vol.Optional(CONF_EXPERIMENTAL, default=existing_exp)] = section(
                 vol.Schema(
                     {
-                        vol.Required(feature.conf_key, default=feature.default): bool
+                        vol.Required(
+                            feature.conf_key,
+                            default=existing_exp.get(feature.conf_key, feature.default),
+                        ): bool
                         for feature in EXPERIMENTAL_FEATURES
                     }
                 ),

--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -14,9 +14,11 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import SectionConfig, section
 
 from .const import (
     CONF_BATTERY_DATA_ONLY,
+    CONF_EXPERIMENTAL,
     CONF_PASSIVE,
     CONF_SCAN_INTERVAL,
     DEFAULT_BATTERY_DATA_ONLY,
@@ -24,6 +26,7 @@ from .const import (
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    EXPERIMENTAL_FEATURES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -159,12 +162,27 @@ class GivEnergyLocalOptionsFlow(OptionsFlow):
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         if user_input is not None:
+            # user_input carries battery_data_only flat, plus — when any experimental
+            # feature is registered — the section's toggles nested under
+            # CONF_EXPERIMENTAL. Persisted as-is; resolve_experimental_client_kwargs
+            # reads that nested shape at coordinator construction.
             return self.async_create_entry(data=user_input)
-        schema = vol.Schema(
-            {
-                vol.Required(CONF_BATTERY_DATA_ONLY, default=DEFAULT_BATTERY_DATA_ONLY): bool,
-            }
-        )
+        schema_dict: dict[Any, Any] = {
+            vol.Required(CONF_BATTERY_DATA_ONLY, default=DEFAULT_BATTERY_DATA_ONLY): bool,
+        }
+        # Surface the collapsed "Experimental features" group only once at least one
+        # flag exists, so the header never appears empty (the registry ships empty).
+        if EXPERIMENTAL_FEATURES:
+            schema_dict[vol.Required(CONF_EXPERIMENTAL)] = section(
+                vol.Schema(
+                    {
+                        vol.Required(feature.conf_key, default=feature.default): bool
+                        for feature in EXPERIMENTAL_FEATURES
+                    }
+                ),
+                SectionConfig(collapsed=True),
+            )
+        schema = vol.Schema(schema_dict)
         return self.async_show_form(
             step_id="init",
             data_schema=self.add_suggested_values_to_schema(schema, self.config_entry.options),

--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -173,10 +173,15 @@ class GivEnergyLocalOptionsFlow(OptionsFlow):
         # Surface the collapsed "Experimental features" group only once at least one
         # flag exists, so the header never appears empty (the registry ships empty).
         if EXPERIMENTAL_FEATURES:
-            # Use currently-saved values as the schema default for each feature so
-            # that a collapsed/omitted section (which HA fills with the default
-            # rather than re-submitting the current values) falls back to what was
-            # already enabled rather than all-off feature defaults.
+            # Seed schema defaults from the currently-saved values so that a
+            # collapsed or omitted section round-trips correctly.  This works
+            # because HA's frontend either (a) submits the rendered (pre-filled)
+            # values for a collapsed section, in which case the submitted value
+            # wins, or (b) omits the section key entirely, in which case the
+            # vol.Optional / inner vol.Required defaults fill in the existing
+            # values.  The two cases are indistinguishable if the frontend sends
+            # base defaults (all False) for untouched collapsed sections — but
+            # HA keeps section inputs in the DOM, so (a) is what happens.
             existing_exp: dict[str, Any] = self.config_entry.options.get(CONF_EXPERIMENTAL, {})
             schema_dict[vol.Optional(CONF_EXPERIMENTAL, default=existing_exp)] = section(
                 vol.Schema(

--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -173,7 +173,7 @@ class GivEnergyLocalOptionsFlow(OptionsFlow):
         # Surface the collapsed "Experimental features" group only once at least one
         # flag exists, so the header never appears empty (the registry ships empty).
         if EXPERIMENTAL_FEATURES:
-            schema_dict[vol.Required(CONF_EXPERIMENTAL)] = section(
+            schema_dict[vol.Optional(CONF_EXPERIMENTAL, default={})] = section(
                 vol.Schema(
                     {
                         vol.Required(feature.conf_key, default=feature.default): bool

--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -99,7 +99,13 @@ class ExperimentalFeature:
     default: bool = False  # MUST stay False — enforced by test.
 
 
-EXPERIMENTAL_FEATURES: tuple[ExperimentalFeature, ...] = ()
+EXPERIMENTAL_FEATURES: tuple[ExperimentalFeature, ...] = (
+    ExperimentalFeature(
+        conf_key="splice_reject_heal",
+        client_kwarg="splice_reject_heal_seconds",
+        client_value=300,
+    ),
+)
 
 
 def resolve_experimental_client_kwargs(

--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -1,3 +1,7 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
 DOMAIN = "givenergy_local"
 
 DEFAULT_PORT = 8899
@@ -58,3 +62,60 @@ EXPOSE_RECOMMENDED_ENTITY_KEYS = (
     # the translation_key, which is not what's in the unique_id suffix.
     "status",
 )
+
+
+# --- Experimental features (opt-in givenergy-modbus client flags) -------------
+# A grouped, collapsed "Experimental features" section in the options flow. Each
+# entry forwards one optional kwarg into Client(...) when its toggle is on.
+#
+# Adding a feature = ONE entry below + a label in strings.json /
+# translations/en.json under options.step.init.sections.experimental.data, and
+# (when the kwarg ships) bumping the givenergy-modbus floor in pyproject.toml and
+# manifest.json. No version-guard code is needed: the pin bump is committed
+# together with the kwarg-passing entry, so any build that can pass the kwarg
+# already depends on a client that accepts it.
+#
+# Worked example (uncomment + set the real kwarg name when the modbus release
+# lands; client_value matches the kwarg's type — e.g. a float for a tunable):
+#   EXPERIMENTAL_FEATURES = (
+#       ExperimentalFeature(
+#           conf_key="splice_heal",
+#           client_kwarg="splice_heal_seconds",
+#           client_value=5.0,
+#       ),
+#   )
+CONF_EXPERIMENTAL = "experimental"
+
+
+@dataclass(frozen=True)
+class ExperimentalFeature:
+    """One opt-in client flag. The UI toggle is boolean; `client_value` is what
+    gets passed to Client(...) when the toggle is on (True for a bool flag, or a
+    concrete value like a float for a tunable)."""
+
+    conf_key: str
+    client_kwarg: str
+    client_value: Any = True
+    default: bool = False  # MUST stay False — enforced by test.
+
+
+EXPERIMENTAL_FEATURES: tuple[ExperimentalFeature, ...] = ()
+
+
+def resolve_experimental_client_kwargs(
+    options: Mapping[str, Any],
+    features: tuple[ExperimentalFeature, ...] = EXPERIMENTAL_FEATURES,
+) -> dict[str, Any]:
+    """Map enabled experimental toggles in `options` to Client(...) kwargs.
+
+    Reads the nested section dict (options[CONF_EXPERIMENTAL]); returns {} when
+    nothing is enabled, so an all-off entry constructs Client() identically to
+    before this mechanism existed. Unknown section keys (e.g. a removed feature)
+    are ignored.
+    """
+    section = options.get(CONF_EXPERIMENTAL, {}) or {}
+    return {
+        feature.client_kwarg: feature.client_value
+        for feature in features
+        if section.get(feature.conf_key, feature.default)
+    }

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
+from typing import Any
 
 from givenergy_modbus.client.client import Client
 from givenergy_modbus.exceptions import (
@@ -133,6 +134,7 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         port: int,
         scan_interval: int,
         passive: bool = False,
+        experimental_client_kwargs: dict[str, Any] | None = None,
         timeout_tolerance: int = 3,
         retries: int = 1,
         prior_capabilities: PlantCapabilities | None = None,
@@ -149,6 +151,9 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         self.host = host
         self.port = port
         self.passive = passive
+        # Resolved opt-in givenergy-modbus client kwargs (empty by default, so
+        # Client(host, port) is unchanged). Splatted at every (re)connect.
+        self._experimental_client_kwargs = experimental_client_kwargs or {}
         self.timeout_tolerance = timeout_tolerance
         self.retries = retries
         # Keep the prior across reconnects (transient TCP drops re-enter
@@ -500,7 +505,7 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         refresh_plant() calls dispatch via model-aware load_config()/refresh()
         — required for three-phase, AIO-HV, EMS and other non-default topologies.
         """
-        self._client = Client(host=self.host, port=self.port)
+        self._client = Client(host=self.host, port=self.port, **self._experimental_client_kwargs)
         # A fresh Client means a fresh Plant with its comms counters zeroed, so
         # drop the per-device last-seen baselines: the next poll then captures
         # the full post-reconnect value as the delta. Without this, a counter

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.5.10,<3.0.0"
+    "givenergy-modbus>=2.5.11,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/strings.json
+++ b/custom_components/givenergy_local/strings.json
@@ -41,6 +41,18 @@
         "description": "Battery-data-only mode suppresses all control entities and inverter-level system sensors (PV, grid, load, derived consumption), leaving only the battery pack, HV stack, AIO module, and diagnostic data. Use this when this unit is controlled by a Gateway in a parallel group, where its per-unit controls and derived figures are misleading.",
         "data": {
           "battery_data_only": "Battery data only (suppress controls and system sensors)"
+        },
+        "sections": {
+          "experimental": {
+            "name": "Experimental features",
+            "description": "Leave these off unless a maintainer has asked you to enable them.",
+            "data": {
+              "splice_reject_heal": "Enable splice-guard heal window"
+            },
+            "data_description": {
+              "splice_reject_heal": "Allows the battery splice-guard to recover from legitimate LiFePO4 charge-knee surges (voltage/capacity class, multi-poll streak gate) rather than keeping the battery permanently offline. Enable only if you see repeated battery disconnects near full charge and a maintainer has confirmed this is the right path."
+            }
+          }
         }
       }
     }

--- a/custom_components/givenergy_local/translations/en.json
+++ b/custom_components/givenergy_local/translations/en.json
@@ -39,6 +39,18 @@
         "description": "Battery-data-only mode suppresses all control entities and inverter-level system sensors (PV, grid, load, derived consumption), leaving only the battery pack, HV stack, AIO module, and diagnostic data. Use this when this unit is controlled by a Gateway in a parallel group, where its per-unit controls and derived figures are misleading.",
         "data": {
           "battery_data_only": "Battery data only (suppress controls and system sensors)"
+        },
+        "sections": {
+          "experimental": {
+            "name": "Experimental features",
+            "description": "Leave these off unless a maintainer has asked you to enable them.",
+            "data": {
+              "splice_reject_heal": "Enable splice-guard heal window"
+            },
+            "data_description": {
+              "splice_reject_heal": "Allows the battery splice-guard to recover from legitimate LiFePO4 charge-knee surges (voltage/capacity class, multi-poll streak gate) rather than keeping the battery permanently offline. Enable only if you see repeated battery disconnects near full charge and a maintainer has confirmed this is the right path."
+            }
+          }
         }
       }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.5.10,<3.0.0",
+    "givenergy-modbus>=2.5.11,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -301,8 +301,12 @@ async def test_options_flow_persists_experimental_toggle(hass, mock_client, setu
 
 
 async def test_options_flow_omits_section_when_no_features(hass, mock_client, setup_integration):
-    """The shipped empty registry => no experimental section, battery_data_only intact."""
-    result = await hass.config_entries.options.async_init(setup_integration.entry_id)
+    """An empty registry => no experimental section in the form."""
+    with patch(
+        "custom_components.givenergy_local.config_flow.EXPERIMENTAL_FEATURES",
+        (),
+    ):
+        result = await hass.config_entries.options.async_init(setup_integration.entry_id)
     top_keys = {marker.schema for marker in result["data_schema"].schema}
     assert CONF_EXPERIMENTAL not in top_keys
     assert CONF_BATTERY_DATA_ONLY in top_keys

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -254,3 +254,57 @@ async def test_options_flow_prefills_existing_value(hass, mock_client, setup_int
     markers = {marker.schema: marker for marker in result["data_schema"].schema}
     suggested = markers[CONF_BATTERY_DATA_ONLY].description.get("suggested_value")
     assert suggested is True
+
+
+# --- Experimental features section (client feature-flagging) ------------------
+
+from unittest.mock import patch  # noqa: E402
+
+from custom_components.givenergy_local.const import (  # noqa: E402
+    CONF_EXPERIMENTAL,
+    ExperimentalFeature,
+)
+
+_DEMO_FEATURE = ExperimentalFeature(conf_key="demo", client_kwarg="demo_kwarg")
+
+
+async def test_options_flow_renders_experimental_section_when_features_exist(
+    hass, mock_client, setup_integration
+):
+    """With a feature registered, the options form carries a collapsed
+    'experimental' section alongside the battery-data-only toggle."""
+    with patch(
+        "custom_components.givenergy_local.config_flow.EXPERIMENTAL_FEATURES",
+        (_DEMO_FEATURE,),
+    ):
+        result = await hass.config_entries.options.async_init(setup_integration.entry_id)
+
+    assert result["type"] == "form"
+    top_keys = {marker.schema for marker in result["data_schema"].schema}
+    assert CONF_EXPERIMENTAL in top_keys
+    assert CONF_BATTERY_DATA_ONLY in top_keys
+
+
+async def test_options_flow_persists_experimental_toggle(hass, mock_client, setup_integration):
+    """Submitting the nested section dict lands under entry.options[experimental]."""
+    with patch(
+        "custom_components.givenergy_local.config_flow.EXPERIMENTAL_FEATURES",
+        (_DEMO_FEATURE,),
+    ):
+        result = await hass.config_entries.options.async_init(setup_integration.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {CONF_BATTERY_DATA_ONLY: False, CONF_EXPERIMENTAL: {"demo": True}},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "create_entry"
+    assert setup_integration.options[CONF_EXPERIMENTAL] == {"demo": True}
+
+
+async def test_options_flow_omits_section_when_no_features(hass, mock_client, setup_integration):
+    """The shipped empty registry => no experimental section, battery_data_only intact."""
+    result = await hass.config_entries.options.async_init(setup_integration.entry_id)
+    top_keys = {marker.schema for marker in result["data_schema"].schema}
+    assert CONF_EXPERIMENTAL not in top_keys
+    assert CONF_BATTERY_DATA_ONLY in top_keys

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -331,6 +331,36 @@ async def test_options_flow_preserves_experimental_when_section_omitted(
     assert setup_integration.options[CONF_EXPERIMENTAL] == {"demo": True}
 
 
+async def test_options_flow_explicit_false_disables_experimental_flag(
+    hass, mock_client, setup_integration
+):
+    """Explicitly submitting {"demo": False} after the flag was enabled must disable it.
+    Pins the complement of test_options_flow_preserves_experimental_when_section_omitted:
+    section omitted => preserve; section submitted with false => disable."""
+    with patch(
+        "custom_components.givenergy_local.config_flow.EXPERIMENTAL_FEATURES",
+        (_DEMO_FEATURE,),
+    ):
+        # First save: enable the flag.
+        result = await hass.config_entries.options.async_init(setup_integration.entry_id)
+        await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {CONF_BATTERY_DATA_ONLY: False, CONF_EXPERIMENTAL: {"demo": True}},
+        )
+        await hass.async_block_till_done()
+
+        # Second save: explicitly submit the section with demo=False.
+        result = await hass.config_entries.options.async_init(setup_integration.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {CONF_BATTERY_DATA_ONLY: False, CONF_EXPERIMENTAL: {"demo": False}},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "create_entry"
+    assert setup_integration.options[CONF_EXPERIMENTAL] == {"demo": False}
+
+
 async def test_options_flow_omits_section_when_no_features(hass, mock_client, setup_integration):
     """An empty registry => no experimental section in the form."""
     with patch(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -300,6 +300,37 @@ async def test_options_flow_persists_experimental_toggle(hass, mock_client, setu
     assert setup_integration.options[CONF_EXPERIMENTAL] == {"demo": True}
 
 
+async def test_options_flow_preserves_experimental_when_section_omitted(
+    hass, mock_client, setup_integration
+):
+    """Changing battery_data_only without touching the collapsed experimental section
+    must not silently disable a previously-enabled flag."""
+    with patch(
+        "custom_components.givenergy_local.config_flow.EXPERIMENTAL_FEATURES",
+        (_DEMO_FEATURE,),
+    ):
+        # First save: enable the experimental flag.
+        result = await hass.config_entries.options.async_init(setup_integration.entry_id)
+        await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {CONF_BATTERY_DATA_ONLY: False, CONF_EXPERIMENTAL: {"demo": True}},
+        )
+        await hass.async_block_till_done()
+
+        # Second save: change battery_data_only, omit the collapsed section entirely.
+        result = await hass.config_entries.options.async_init(setup_integration.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {CONF_BATTERY_DATA_ONLY: True},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "create_entry"
+    assert setup_integration.options[CONF_BATTERY_DATA_ONLY] is True
+    # The experimental flag must survive the second save unmodified.
+    assert setup_integration.options[CONF_EXPERIMENTAL] == {"demo": True}
+
+
 async def test_options_flow_omits_section_when_no_features(hass, mock_client, setup_integration):
     """An empty registry => no experimental section in the form."""
     with patch(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,14 +1,18 @@
 """Tests for the GivEnergy Local config flow."""
 
+from unittest.mock import patch
+
 from givenergy_modbus.exceptions import RefreshFailed, RefreshPartiallySucceeded
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 
 from custom_components.givenergy_local.const import (
     CONF_BATTERY_DATA_ONLY,
+    CONF_EXPERIMENTAL,
     CONF_PASSIVE,
     CONF_SCAN_INTERVAL,
     DOMAIN,
+    ExperimentalFeature,
 )
 
 VALID_USER_INPUT = {
@@ -258,12 +262,6 @@ async def test_options_flow_prefills_existing_value(hass, mock_client, setup_int
 
 # --- Experimental features section (client feature-flagging) ------------------
 
-from unittest.mock import patch  # noqa: E402
-
-from custom_components.givenergy_local.const import (  # noqa: E402
-    CONF_EXPERIMENTAL,
-    ExperimentalFeature,
-)
 
 _DEMO_FEATURE = ExperimentalFeature(conf_key="demo", client_kwarg="demo_kwarg")
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1489,3 +1489,41 @@ async def test_loss_retry_surfacing_add_falls_through(hass, mock_plant):
     on_missing.assert_not_awaited()
     on_healed.assert_not_awaited()
     assert coordinator._prior_capabilities is add_actual
+
+
+async def test_default_passes_only_host_port_to_client(hass):
+    """Backward-compat: with no experimental flags, Client is built with host/port only."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = False
+        client.connect.side_effect = OSError("connection refused")  # stop after construction
+        client.close = AsyncMock()
+        mock_cls.return_value = client
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    assert mock_cls.call_args.kwargs == {"host": "192.168.1.1", "port": 8899}
+
+
+async def test_experimental_kwargs_forwarded_to_client(hass):
+    """Resolved experimental kwargs are splatted into the Client(...) construction."""
+    coordinator = GivEnergyUpdateCoordinator(
+        hass, "192.168.1.1", 8899, 30, experimental_client_kwargs={"demo_kwarg": 5.0}
+    )
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = False
+        client.connect.side_effect = OSError("connection refused")
+        client.close = AsyncMock()
+        mock_cls.return_value = client
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    assert mock_cls.call_args.kwargs == {
+        "host": "192.168.1.1",
+        "port": 8899,
+        "demo_kwarg": 5.0,
+    }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -983,3 +983,81 @@ async def test_dc_limit_rows_retained_on_hybrid(
 
     assert _present("battery_charge_limit")
     assert _present("battery_discharge_limit")
+
+
+# --- Experimental-features registry + resolver (client feature-flagging) ------
+
+
+def test_all_experimental_features_default_off():
+    """Off-by-default invariant: an all-off entry must pass no client kwargs."""
+    from custom_components.givenergy_local.const import EXPERIMENTAL_FEATURES
+
+    assert all(f.default is False for f in EXPERIMENTAL_FEATURES)
+
+
+def test_experimental_feature_conf_keys_unique():
+    from custom_components.givenergy_local.const import EXPERIMENTAL_FEATURES
+
+    keys = [f.conf_key for f in EXPERIMENTAL_FEATURES]
+    assert len(keys) == len(set(keys))
+
+
+def test_resolve_empty_options_returns_no_kwargs():
+    from custom_components.givenergy_local.const import (
+        CONF_EXPERIMENTAL,
+        resolve_experimental_client_kwargs,
+    )
+
+    assert resolve_experimental_client_kwargs({}) == {}
+    assert resolve_experimental_client_kwargs({CONF_EXPERIMENTAL: {}}) == {}
+
+
+def test_resolve_ignores_unknown_section_keys():
+    """A stale key from a removed feature must not leak through as a kwarg."""
+    from custom_components.givenergy_local.const import (
+        CONF_EXPERIMENTAL,
+        resolve_experimental_client_kwargs,
+    )
+
+    assert resolve_experimental_client_kwargs({CONF_EXPERIMENTAL: {"no_such_feature": True}}) == {}
+
+
+def test_resolve_maps_enabled_feature_to_client_kwarg():
+    from custom_components.givenergy_local.const import (
+        CONF_EXPERIMENTAL,
+        ExperimentalFeature,
+        resolve_experimental_client_kwargs,
+    )
+
+    feat = ExperimentalFeature(conf_key="demo", client_kwarg="demo_kwarg", client_value=5.0)
+    result = resolve_experimental_client_kwargs(
+        {CONF_EXPERIMENTAL: {"demo": True}}, features=(feat,)
+    )
+    assert result == {"demo_kwarg": 5.0}
+
+
+def test_resolve_off_feature_passes_nothing():
+    from custom_components.givenergy_local.const import (
+        CONF_EXPERIMENTAL,
+        ExperimentalFeature,
+        resolve_experimental_client_kwargs,
+    )
+
+    feat = ExperimentalFeature(conf_key="demo", client_kwarg="demo_kwarg")
+    assert (
+        resolve_experimental_client_kwargs({CONF_EXPERIMENTAL: {"demo": False}}, features=(feat,))
+        == {}
+    )
+
+
+def test_resolve_bool_feature_defaults_client_value_true():
+    from custom_components.givenergy_local.const import (
+        CONF_EXPERIMENTAL,
+        ExperimentalFeature,
+        resolve_experimental_client_kwargs,
+    )
+
+    feat = ExperimentalFeature(conf_key="demo", client_kwarg="demo_kwarg")
+    assert resolve_experimental_client_kwargs(
+        {CONF_EXPERIMENTAL: {"demo": True}}, features=(feat,)
+    ) == {"demo_kwarg": True}

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.10,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.11,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.5.10"
+version = "2.5.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/b5/272d4863d5fbb99d5584a96e5e9a1cc8aba07423363f994f4756fdeec2a4/givenergy_modbus-2.5.10.tar.gz", hash = "sha256:7fb0af5952dd9183bc9291f1810916bb56d020e41d3afd88c9748d912fa30e2c", size = 447440, upload-time = "2026-06-25T19:15:28.327Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/b0/821c49f3928ec3fcc36088a19512099f785250f9a90267d76e2a85a751c0/givenergy_modbus-2.5.11.tar.gz", hash = "sha256:5bcebf6e96c5c0d4be0481c4a46ace54cde5f10f53b8d808409fdcb319c29c40", size = 454707, upload-time = "2026-06-25T20:19:32.071Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/5f/f2834a8bbbd28025129feb30890ce052908c7b6ffe67772e5d0e68d46d85/givenergy_modbus-2.5.10-py3-none-any.whl", hash = "sha256:da0a3957e1ad49cc6bd7219d5cd6922905c3120a5d17edd25dbce89473463712", size = 170328, upload-time = "2026-06-25T19:15:26.89Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/82/a65bf13710fc26d5858fac973892285b112c2463aef78db705c503c36bfd/givenergy_modbus-2.5.11-py3-none-any.whl", hash = "sha256:06e2e4637aa710ed58e5ecd948ad0068a71e8fb0bfaa9929ce6737d1e8798376", size = 173498, upload-time = "2026-06-25T20:19:30.366Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Adds a registry-driven **"Experimental features"** options group so opt-in givenergy-modbus *client* flags can be toggled from Home Assistant and forwarded into the `Client(...)` construction. Built ahead of a 2.5.11 opt-in feature so the first flag is a one-line addition.

The mechanism mirrors the modbus client's own `splice_heal_seconds` idiom (an off-by-default optional kwarg acted on only when set), and reuses the existing `CONF_BATTERY_DATA_ONLY` config/options plumbing plus the options-reload listener.

## How it works
- **`const.py`** — `ExperimentalFeature` frozen dataclass + `EXPERIMENTAL_FEATURES` registry (**ships empty**) + `resolve_experimental_client_kwargs(options)`. The resolver reads the nested options section and returns `{}` when nothing is enabled, so an all-off entry constructs `Client(host, port)` byte-identically to before.
- **`config_flow.py`** — a collapsed HA `section()` in the OptionsFlow, added **only when the registry is non-empty**, so no empty "Experimental features" header appears before any flag ships. Section values persist nested under `entry.options["experimental"]`.
- **`__init__.py` / `coordinator.py`** — resolve from `entry.options` at setup and splat the kwargs into the single live `Client(...)` call. The existing `add_update_listener` reload already rebuilds the client on any options change — no new reload wiring.

## Zero user-facing effect today
The registry is empty, so the section never renders and `Client(...)` is unchanged. **Adding the first flag** = one `ExperimentalFeature(...)` registry line + its `strings.json`/`translations` row + (when the kwarg ships) bumping the `givenergy-modbus` pin — all in a single commit. No runtime version-guard is needed because the pin bump is atomic with the kwarg-passing entry. Translations are intentionally deferred to that commit (the section doesn't render while empty, so adding section copy now would be unused/hassfest-flaggable).

## Decisions
- **Options-only** (post-setup Configure), not initial setup — experimental client flags only affect transport and take effect on reload, so there's no first-run-only window (unlike `battery_data_only`, which gates entity creation).
- **`client_value: Any`** (not bool-only) on the registry — the template kwarg `splice_heal_seconds` is a float; the UI toggle stays boolean, `client_value` is what's sent when on.

## Tests
520 Python tests green (+12 new): resolver invariants (default-off, unknown-key-ignored, enabled→kwarg, bool default-True), options section (renders/persists/prefills with a patched one-feature registry; **omitted** when empty), and client-kwarg forwarding (enabled flag splatted; default-off passes only host/port). ruff, mypy, prek all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional **Experimental features** section in the options flow, with settings that can be enabled or preserved across saves.
  * Experimental settings now carry through to the integration setup automatically.

* **Bug Fixes**
  * Improved handling of saved options so previously enabled experimental settings are not lost when re-opening the configuration.

* **Chores**
  * Updated the bundled `givenergy-modbus` dependency to a newer compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->