### PR TITLE
fix: suppress Battery Charge/Discharge Today on EMS controllers (#221)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -426,10 +426,12 @@ def _retired_inverter_unique_ids(serial: str) -> set[str]:
     """Unique IDs of the entities retired on an EMS plant (#201).
 
     On an EMS controller the inverter-level *controls* are suppressed (the EMS
-    slots are authoritative) and a few *derived* inverter sensors are gated via
-    `skip_if_ems` (House Consumption), plus the dropped duplicate `ems_status`
-    aggregate. The rest of the inverter sensors stay — the 0x11 block carries real
-    plant data (PV/grid/battery/AC) — so they are deliberately NOT in this set.
+    slots are authoritative) and a few inverter sensors are gated via
+    `skip_if_ems` (the controller-local load figures plus Battery Charge/Discharge
+    Today, which the 0x11 controller doesn't populate), plus the dropped duplicate
+    `ems_status` aggregate. The rest of the inverter sensors stay — the 0x11 block
+    carries real plant data (PV/grid/battery/AC) — so they are deliberately NOT in
+    this set.
     Keyed by the controller serial; coordinator, battery, AIO and managed-inverter
     entities use different keys or their own serials, so they're excluded.
     """
@@ -453,7 +455,7 @@ def _retired_inverter_unique_ids(serial: str) -> set[str]:
         *SMART_LOAD_TIME_DESCRIPTIONS,
     )
     keys = {d.key for d in controls}
-    # Derived inverter sensors gated on EMS (House Consumption).
+    # Inverter sensors gated on EMS (controller-local load + Battery Charge/Discharge Today).
     keys.update(d.key for d in INVERTER_SENSORS if d.skip_if_ems)
     # Duplicate EMS aggregate dropped in favour of the retained inverter Status sensor.
     keys.add("ems_status")
@@ -466,7 +468,7 @@ def _reconcile_ems_entities(hass: HomeAssistant, entry: ConfigEntry, serial: str
     Suppressing creation only affects fresh installs: on an upgraded EMS entry HA
     keeps the existing registry rows when a platform stops adding those entities,
     so the controller would otherwise keep orphaned rows for the entities no longer
-    created on EMS (inverter controls, the EMS-gated House Consumption, the dropped
+    created on EMS (inverter controls, the EMS-gated inverter sensors, the dropped
     ems_status). Remove exactly those (matched by the controller serial + a retired
     key), leaving the retained inverter sensors and all coordinator, battery, AIO,
     managed-inverter and EMS-specific entities untouched.

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -474,6 +474,11 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda inv: inv.e_battery_charge_today,
+        # The EMS controller (Model.EMS_COMMERCIAL) isn't in givenergy-modbus's
+        # per-model battery-energy source map, so this computed field resolves to
+        # None there and the sensor renders "unknown" — it's an inverter-level
+        # register the 0x11 controller doesn't populate. Gate it off EMS (#221).
+        skip_if_ems=True,
     ),
     GivEnergyInverterSensorDescription(
         key="e_battery_discharge_day",
@@ -482,6 +487,9 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda inv: inv.e_battery_discharge_today,
+        # Same as Battery Charge Today: None on the EMS controller, so gate it
+        # off to avoid a permanently-"unknown" sensor on that device (#221).
+        skip_if_ems=True,
     ),
     GivEnergyInverterSensorDescription(
         key="e_battery_throughput",

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -424,15 +424,18 @@ async def test_managed_inverter_namespaced_against_same_serial(
 # ---------------------------------------------------------------------------
 
 
-async def test_inverter_sensors_kept_on_ems_except_local_load(hass, ems_setup):
+async def test_inverter_sensors_kept_on_ems_except_gated(hass, ems_setup):
     """The EMS controller's 0x11 block carries real plant data (PV/grid/battery/AC),
-    so the inverter sensors stay (#201). Only the controller-local load figures —
-    House Consumption and the inverter busbar Load Power — are gated off via
-    skip_if_ems; the EMS load aggregates supersede them."""
+    so the inverter sensors stay (#201). Gated off via skip_if_ems: the
+    controller-local load figures — House Consumption and the inverter busbar Load
+    Power — which the EMS load aggregates supersede, plus Battery Charge/Discharge
+    Today, which the controller doesn't populate (would read "unknown", #221)."""
     assert _entity_id(hass, "sensor", "SA1234G123_status") is not None
     assert _entity_id(hass, "sensor", "SA1234G123_battery_soc") is not None
     assert _entity_id(hass, "sensor", "SA1234G123_e_consumption_today") is None
     assert _entity_id(hass, "sensor", "SA1234G123_p_load_demand") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_e_battery_charge_day") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_e_battery_discharge_day") is None
 
 
 async def test_inverter_controls_suppressed_on_ems_plant(hass, ems_setup):
@@ -462,6 +465,8 @@ async def test_upgrade_narrows_retired_entities_on_ems(
         ("select", "SA1234G123_battery_power_mode"),
         ("time", "SA1234G123_charge_slot_1_start"),
         ("sensor", "SA1234G123_e_consumption_today"),
+        ("sensor", "SA1234G123_e_battery_charge_day"),
+        ("sensor", "SA1234G123_e_battery_discharge_day"),
         ("sensor", "SA1234G123_ems_status"),
         ("sensor", "SA1234G123_status"),
         ("sensor", "SA1234G123_total_failures"),
@@ -477,6 +482,8 @@ async def test_upgrade_narrows_retired_entities_on_ems(
     assert _entity_id(hass, "select", "SA1234G123_battery_power_mode") is None
     assert _entity_id(hass, "time", "SA1234G123_charge_slot_1_start") is None
     assert _entity_id(hass, "sensor", "SA1234G123_e_consumption_today") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_e_battery_charge_day") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_e_battery_discharge_day") is None
     assert _entity_id(hass, "sensor", "SA1234G123_ems_status") is None
     # Retained: meaningful inverter sensor + coordinator diagnostic.
     assert _entity_id(hass, "sensor", "SA1234G123_status") is not None
@@ -516,17 +523,24 @@ def test_ems_measured_load_power_hidden_by_default():
     assert desc.entity_registry_visible_default is False
 
 
-def test_controller_local_load_gated_skip_if_ems():
-    """Exactly the controller-local load figures are gated off on EMS — House
-    Consumption and the inverter busbar Load Power. Pins the boundary so a future
-    change can't silently widen or narrow it; the gate drops them only on EMS."""
+def test_inverter_sensors_gated_off_ems():
+    """Exactly these inverter sensors are gated off on EMS: the controller-local
+    load figures (House Consumption, inverter busbar Load Power) which the EMS
+    aggregates supersede, plus Battery Charge/Discharge Today which the controller
+    doesn't populate (they'd otherwise read "unknown", #221). Pins the boundary so
+    a future change can't silently widen or narrow it; the gate drops them on EMS."""
     from custom_components.givenergy_local.sensor import (
         INVERTER_SENSORS,
         _include_inverter_sensor,
     )
 
     gated = {d.key for d in INVERTER_SENSORS if d.skip_if_ems}
-    assert gated == {"e_consumption_today", "p_load_demand"}
+    assert gated == {
+        "e_consumption_today",
+        "p_load_demand",
+        "e_battery_charge_day",
+        "e_battery_discharge_day",
+    }
     desc = next(d for d in INVERTER_SENSORS if d.key == "p_load_demand")
     inv = MagicMock()
     assert _include_inverter_sensor(desc, inv, False, False, True) is False


### PR DESCRIPTION
Fixes #221 (in part — the "unknown" half).

On an EMS plant, **Battery Charge Today** and **Battery Discharge Today** read a
permanent `unknown` on the controller device. They're inverter-level sensors whose
computed values route through givenergy-modbus's per-model battery-energy source
map, and the EMS controller (`Model.EMS_COMMERCIAL`) has no entry there — so the
fields resolve to `None`. The 0x11 controller simply doesn't populate those
registers.

This gates both sensors off EMS via `skip_if_ems`, exactly as House Consumption and
the inverter busbar Load Power already are. The existing `_reconcile_ems_entities`
path collects every `skip_if_ems` inverter sensor, so orphaned rows are removed
automatically on upgrade — no new wiring. Directly-polled inverters (AC / HYBRID /
AIO, which *are* in the source map) are untouched and keep reporting real values.

Tests: extended the exhaustive `skip_if_ems` boundary assertion, the fresh-install
"gated off EMS" test, and the upgrade-removal test in `test_ems.py`.

The other half of #221 — the "remaining battery energy" question — is a separate
discussion (it's a direct firmware register, not SOC × capacity) and stays on the
issue pending a reading from the reporter.
