### PR TITLE
feat: raise repair when inverter clock drifts from HA

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.components.persistent_notification import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.const import __version__ as HA_VERSION
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
@@ -33,12 +33,16 @@ from homeassistant.loader import async_get_integration
 from homeassistant.util import dt as dt_util
 
 from .const import (
+    CONF_BATTERY_DATA_ONLY,
     CONF_PASSIVE,
     CONF_RETRIES,
     CONF_SCAN_INTERVAL,
     CONF_TIMEOUT_TOLERANCE,
+    CONF_WARN_CLOCK_DRIFT,
+    DEFAULT_BATTERY_DATA_ONLY,
     DEFAULT_PASSIVE,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_WARN_CLOCK_DRIFT,
     DOMAIN,
     EXPOSE_RECOMMENDED_ENTITY_KEYS,
     PLATFORMS,
@@ -48,7 +52,9 @@ from .const import (
     SERVICE_REBOOT_INVERTER,
     SERVICE_REDETECT_PLANT,
     SERVICE_SET_SYSTEM_DATETIME,
+    SYSTEM_TIME_DRIFT_THRESHOLD,
     resolve_experimental_client_kwargs,
+    system_time_drift,
 )
 from .coordinator import GivEnergyUpdateCoordinator, missing_devices
 from .http import (
@@ -573,6 +579,56 @@ async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     await hass.config_entries.async_reload(entry.entry_id)
 
 
+@callback
+def _check_system_time_drift(
+    hass: HomeAssistant, entry: ConfigEntry, coordinator: GivEnergyUpdateCoordinator
+) -> None:
+    """Raise/clear a repair when the inverter clock drifts from HA's time (#219).
+
+    Runs each coordinator update (and once at setup). Idempotent: re-raising an
+    existing issue updates it; deleting an absent one is a no-op. Each guard clears
+    any standing issue before returning so a now-resolved condition self-heals.
+    """
+    issue_id = f"system_time_drift_{entry.entry_id}"
+
+    def clear() -> None:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+    # Opt-out for users who deliberately run the inverter in another zone (e.g. UTC),
+    # and skip battery-data-only entries (no clock surfaced — mirrors datetime setup).
+    if not entry.options.get(CONF_WARN_CLOCK_DRIFT, DEFAULT_WARN_CLOCK_DRIFT):
+        clear()
+        return
+    if entry.options.get(CONF_BATTERY_DATA_ONLY, DEFAULT_BATTERY_DATA_ONLY):
+        clear()
+        return
+
+    system_time = coordinator.data.inverter.system_time
+    now = dt_util.now()
+    drift = system_time_drift(system_time, now)
+    # drift is None when the clock register reads None (transient) — don't fire.
+    if drift is None or drift < SYSTEM_TIME_DRIFT_THRESHOLD:
+        clear()
+        return
+
+    placeholders = {
+        "drift_minutes": str(int(drift.total_seconds() // 60)),
+        "system_time": system_time.strftime("%Y-%m-%d %H:%M"),
+        "ha_time": now.strftime("%Y-%m-%d %H:%M"),
+    }
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=True,
+        is_persistent=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="system_time_drift",
+        translation_placeholders=placeholders,
+        data={"entry_id": entry.entry_id, **placeholders},
+    )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Clear any legacy dashboard_outdated issues left by the now-removed
     # generate_dashboard service so the Repairs UI doesn't show a broken Fix button.
@@ -702,6 +758,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # #95), so the platforms re-enumerate with the new filter. No listener exists
     # otherwise, so an options change would have no effect until a manual reload.
     entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
+
+    # Watch the inverter clock each poll and raise a repair when it drifts (#219).
+    @callback
+    def _system_time_drift_listener() -> None:
+        _check_system_time_drift(hass, entry, coordinator)
+
+    entry.async_on_unload(coordinator.async_add_listener(_system_time_drift_listener))
+    _system_time_drift_listener()  # evaluate immediately rather than after one poll
 
     # Re-point any entities under renamed unique_ids before the platforms create
     # them, so the existing entity (and its history) is reused rather than orphaned.

--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -21,10 +21,12 @@ from .const import (
     CONF_EXPERIMENTAL,
     CONF_PASSIVE,
     CONF_SCAN_INTERVAL,
+    CONF_WARN_CLOCK_DRIFT,
     DEFAULT_BATTERY_DATA_ONLY,
     DEFAULT_PASSIVE,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_WARN_CLOCK_DRIFT,
     DOMAIN,
     EXPERIMENTAL_FEATURES,
 )
@@ -169,6 +171,7 @@ class GivEnergyLocalOptionsFlow(OptionsFlow):
             return self.async_create_entry(data=user_input)
         schema_dict: dict[Any, Any] = {
             vol.Required(CONF_BATTERY_DATA_ONLY, default=DEFAULT_BATTERY_DATA_ONLY): bool,
+            vol.Required(CONF_WARN_CLOCK_DRIFT, default=DEFAULT_WARN_CLOCK_DRIFT): bool,
         }
         # Surface the collapsed "Experimental features" group only once at least one
         # flag exists, so the header never appears empty (the registry ships empty).

--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -1,6 +1,9 @@
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Any
+
+from homeassistant.util import dt as dt_util
 
 DOMAIN = "givenergy_local"
 
@@ -15,6 +18,14 @@ CONF_PASSIVE = "passive"
 # per-unit controls and derived consumption figures are misleading (#95).
 CONF_BATTERY_DATA_ONLY = "battery_data_only"
 DEFAULT_BATTERY_DATA_ONLY = False
+# Raise an HA repair when the inverter's onboard clock drifts more than
+# SYSTEM_TIME_DRIFT_THRESHOLD from HA's time — a drifted clock silently breaks the
+# inverter's own time-of-use slots and Predbat scheduling. Gated by this toggle so
+# users who deliberately run their inverter in another zone (e.g. UTC) can switch it
+# off. See _check_system_time_drift (__init__) and SystemTimeDriftRepairFlow (repairs).
+CONF_WARN_CLOCK_DRIFT = "warn_clock_drift"
+DEFAULT_WARN_CLOCK_DRIFT = True
+SYSTEM_TIME_DRIFT_THRESHOLD = timedelta(minutes=10)
 # Retained only for migrating older config entries — see async_migrate_entry.
 # The current defaults live as constructor defaults on GivEnergyUpdateCoordinator.
 CONF_TIMEOUT_TOLERANCE = "timeout_tolerance"
@@ -125,3 +136,16 @@ def resolve_experimental_client_kwargs(
         for feature in features
         if section.get(feature.conf_key, feature.default)
     }
+
+
+def system_time_drift(system_time: datetime | None, now: datetime) -> timedelta | None:
+    """Absolute drift between the inverter's naive local wall-clock and `now`.
+
+    The inverter reports a timezone-naive local time; interpret it in HA's
+    configured zone (matching the System Time entity's native_value) and compare to
+    `now` (pass dt_util.now()). Returns None when the clock register reads None.
+    """
+    if system_time is None:
+        return None
+    localised = system_time.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    return abs(localised - now)

--- a/custom_components/givenergy_local/repairs.py
+++ b/custom_components/givenergy_local/repairs.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import voluptuous as vol
+from givenergy_modbus.client import commands
 from homeassistant.components.repairs import RepairsFlow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
 
 
 async def async_create_fix_flow(
@@ -15,6 +20,8 @@ async def async_create_fix_flow(
 ) -> RepairsFlow:
     if issue_id.startswith("expected_devices_missing_"):
         return ExpectedDevicesMissingRepairFlow(data)
+    if issue_id.startswith("system_time_drift_"):
+        return SystemTimeDriftRepairFlow(data)
     raise ValueError(f"Unknown fixable issue: {issue_id}")
 
 
@@ -45,5 +52,37 @@ class ExpectedDevicesMissingRepairFlow(RepairsFlow):
             data_schema=vol.Schema({}),
             description_placeholders={
                 "devices": str(self._data.get("devices", "a device")),
+            },
+        )
+
+
+class SystemTimeDriftRepairFlow(RepairsFlow):
+    """Fix flow for a drifted inverter clock.
+
+    Confirming writes the current Home Assistant time to the inverter's RTC — the
+    same operation as the set_system_datetime service — then requests a refresh, so
+    the drift re-evaluates and the standing repair clears on the next read.
+    """
+
+    def __init__(self, data: dict | None) -> None:
+        self._data = data or {}
+
+    async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
+        if user_input is not None:
+            entry_id = self._data.get("entry_id")
+            coordinator = self.hass.data.get(DOMAIN, {}).get(entry_id) if entry_id else None
+            client = getattr(coordinator, "_client", None)
+            if coordinator is None or client is None or not client.connected:
+                raise HomeAssistantError("GivEnergy inverter is not currently connected")
+            await client.one_shot_command(commands.set_system_date_time(dt_util.now()))
+            await coordinator.async_request_refresh()
+            return self.async_create_entry(data={})
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "drift_minutes": str(self._data.get("drift_minutes", "")),
+                "system_time": str(self._data.get("system_time", "")),
+                "ha_time": str(self._data.get("ha_time", "")),
             },
         )

--- a/custom_components/givenergy_local/strings.json
+++ b/custom_components/givenergy_local/strings.json
@@ -40,7 +40,8 @@
         "title": "GivEnergy Local options",
         "description": "Battery-data-only mode suppresses all control entities and inverter-level system sensors (PV, grid, load, derived consumption), leaving only the battery pack, HV stack, AIO module, and diagnostic data. Use this when this unit is controlled by a Gateway in a parallel group, where its per-unit controls and derived figures are misleading.",
         "data": {
-          "battery_data_only": "Battery data only (suppress controls and system sensors)"
+          "battery_data_only": "Battery data only (suppress controls and system sensors)",
+          "warn_clock_drift": "Warn when the inverter clock drifts from Home Assistant"
         },
         "sections": {
           "experimental": {
@@ -65,6 +66,17 @@
           "init": {
             "title": "A known GivEnergy device stopped responding",
             "description": "These device(s) were part of your system last time but did not respond on the latest connection: {devices}.\n\nThe integration has NOT removed them — it is still serving the rest of your system, and the affected entities show as unavailable. This is usually a transient comms issue (for example a slow battery BMS); the previous layout is kept and retried, so it normally clears on its own.\n\nIf the device has come back, or if you have genuinely removed it, click Fix to clear the cached layout and run a fresh hardware detection. Otherwise you can dismiss this — the integration picks the device back up automatically on its next successful detection."
+          }
+        }
+      }
+    },
+    "system_time_drift": {
+      "title": "GivEnergy inverter clock has drifted (~{drift_minutes} min)",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Inverter clock is out by about {drift_minutes} minutes",
+            "description": "The inverter's clock reads {system_time} but Home Assistant's time is {ha_time} — a drift of about {drift_minutes} minutes. The inverter runs its charge/discharge time-of-use slots from its own clock, so a drift this large can make those slots (and Predbat scheduling) act at the wrong time.\n\nClick **Submit** to set the inverter clock to Home Assistant's current time.\n\nIf you deliberately keep your inverter in a different time zone (for example UTC), turn this warning off instead: open the integration's **Configure** dialog and untick *Warn when the inverter clock drifts from Home Assistant*."
           }
         }
       }

--- a/custom_components/givenergy_local/translations/en.json
+++ b/custom_components/givenergy_local/translations/en.json
@@ -38,7 +38,8 @@
         "title": "GivEnergy Local options",
         "description": "Battery-data-only mode suppresses all control entities and inverter-level system sensors (PV, grid, load, derived consumption), leaving only the battery pack, HV stack, AIO module, and diagnostic data. Use this when this unit is controlled by a Gateway in a parallel group, where its per-unit controls and derived figures are misleading.",
         "data": {
-          "battery_data_only": "Battery data only (suppress controls and system sensors)"
+          "battery_data_only": "Battery data only (suppress controls and system sensors)",
+          "warn_clock_drift": "Warn when the inverter clock drifts from Home Assistant"
         },
         "sections": {
           "experimental": {
@@ -63,6 +64,17 @@
           "init": {
             "title": "A known GivEnergy device stopped responding",
             "description": "These device(s) were part of your system last time but did not respond on the latest connection: {devices}.\n\nThe integration has NOT removed them — it is still serving the rest of your system, and the affected entities show as unavailable. This is usually a transient comms issue (for example a slow battery BMS); the previous layout is kept and retried, so it normally clears on its own.\n\nIf the device has come back, or if you have genuinely removed it, click Fix to clear the cached layout and run a fresh hardware detection. Otherwise you can dismiss this — the integration picks the device back up automatically on its next successful detection."
+          }
+        }
+      }
+    },
+    "system_time_drift": {
+      "title": "GivEnergy inverter clock has drifted (~{drift_minutes} min)",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Inverter clock is out by about {drift_minutes} minutes",
+            "description": "The inverter's clock reads {system_time} but Home Assistant's time is {ha_time} — a drift of about {drift_minutes} minutes. The inverter runs its charge/discharge time-of-use slots from its own clock, so a drift this large can make those slots (and Predbat scheduling) act at the wrong time.\n\nClick **Submit** to set the inverter clock to Home Assistant's current time.\n\nIf you deliberately keep your inverter in a different time zone (for example UTC), turn this warning off instead: open the integration's **Configure** dialog and untick *Warn when the inverter clock drifts from Home Assistant*."
           }
         }
       }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -11,6 +11,7 @@ from custom_components.givenergy_local.const import (
     CONF_EXPERIMENTAL,
     CONF_PASSIVE,
     CONF_SCAN_INTERVAL,
+    CONF_WARN_CLOCK_DRIFT,
     DOMAIN,
     ExperimentalFeature,
 )
@@ -242,6 +243,25 @@ async def test_options_flow_sets_battery_data_only(hass, mock_client, setup_inte
     assert setup_integration.options[CONF_BATTERY_DATA_ONLY] is True
     # The update listener reloaded the entry, so it's loaded and serving again.
     assert setup_integration.state is config_entries.ConfigEntryState.LOADED
+
+
+async def test_options_flow_warn_clock_drift_renders_and_persists(
+    hass, mock_client, setup_integration
+):
+    """The clock-drift toggle (default on) renders in the options form and persists
+    when switched off (the opt-out for users running the inverter in another zone)."""
+    result = await hass.config_entries.options.async_init(setup_integration.entry_id)
+    top_keys = {marker.schema for marker in result["data_schema"].schema}
+    assert CONF_WARN_CLOCK_DRIFT in top_keys
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_BATTERY_DATA_ONLY: False, CONF_WARN_CLOCK_DRIFT: False},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == "create_entry"
+    assert setup_integration.options[CONF_WARN_CLOCK_DRIFT] is False
 
 
 async def test_options_flow_prefills_existing_value(hass, mock_client, setup_integration):

--- a/tests/test_system_time_drift.py
+++ b/tests/test_system_time_drift.py
@@ -1,0 +1,179 @@
+"""Tests for the inverter system-clock drift repair (#219 follow-up)."""
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.util import dt as dt_util
+
+from custom_components.givenergy_local import _check_system_time_drift
+from custom_components.givenergy_local.const import (
+    CONF_BATTERY_DATA_ONLY,
+    CONF_WARN_CLOCK_DRIFT,
+    DOMAIN,
+    system_time_drift,
+)
+from custom_components.givenergy_local.repairs import (
+    SystemTimeDriftRepairFlow,
+    async_create_fix_flow,
+)
+
+
+def _drifted(minutes: int):
+    """A naive local wall-clock `minutes` ahead of now (the inverter clock shape)."""
+    return (dt_util.now() + timedelta(minutes=minutes)).replace(tzinfo=None)
+
+
+def _entry(entry_id: str = "entry-1", **options):
+    entry = MagicMock()
+    entry.entry_id = entry_id
+    entry.options = dict(options)
+    return entry
+
+
+def _coordinator(system_time):
+    coord = MagicMock()
+    coord.data.inverter.system_time = system_time
+    return coord
+
+
+def _issue(hass, entry_id: str):
+    return ir.async_get(hass).async_get_issue(DOMAIN, f"system_time_drift_{entry_id}")
+
+
+# --- pure helper -------------------------------------------------------------
+
+
+def test_system_time_drift_helper():
+    now = dt_util.now()
+    assert system_time_drift(None, now) is None
+    assert system_time_drift(now.replace(tzinfo=None), now) < timedelta(seconds=1)
+    assert system_time_drift(_drifted(15), now) >= timedelta(minutes=14)
+
+
+# --- _check_system_time_drift: raise / clear / guards ------------------------
+
+
+async def test_drift_beyond_threshold_raises_issue(hass):
+    entry = _entry()
+    _check_system_time_drift(hass, entry, _coordinator(_drifted(15)))
+    assert _issue(hass, entry.entry_id) is not None
+
+
+async def test_drift_within_threshold_no_issue(hass):
+    entry = _entry()
+    _check_system_time_drift(hass, entry, _coordinator(_drifted(2)))
+    assert _issue(hass, entry.entry_id) is None
+
+
+async def test_drift_issue_clears_when_back_in_window(hass):
+    entry = _entry()
+    coord = _coordinator(_drifted(15))
+    _check_system_time_drift(hass, entry, coord)
+    assert _issue(hass, entry.entry_id) is not None
+    coord.data.inverter.system_time = dt_util.now().replace(tzinfo=None)
+    _check_system_time_drift(hass, entry, coord)
+    assert _issue(hass, entry.entry_id) is None
+
+
+async def test_none_clock_does_not_raise(hass):
+    entry = _entry()
+    _check_system_time_drift(hass, entry, _coordinator(None))
+    assert _issue(hass, entry.entry_id) is None
+
+
+async def test_battery_data_only_entry_skipped(hass):
+    entry = _entry(**{CONF_BATTERY_DATA_ONLY: True})
+    _check_system_time_drift(hass, entry, _coordinator(_drifted(15)))
+    assert _issue(hass, entry.entry_id) is None
+
+
+async def test_toggle_off_does_not_raise(hass):
+    entry = _entry(**{CONF_WARN_CLOCK_DRIFT: False})
+    _check_system_time_drift(hass, entry, _coordinator(_drifted(15)))
+    assert _issue(hass, entry.entry_id) is None
+
+
+async def test_toggle_off_clears_standing_issue(hass):
+    entry = _entry()
+    coord = _coordinator(_drifted(15))
+    _check_system_time_drift(hass, entry, coord)
+    assert _issue(hass, entry.entry_id) is not None
+    entry.options = {CONF_WARN_CLOCK_DRIFT: False}
+    _check_system_time_drift(hass, entry, coord)
+    assert _issue(hass, entry.entry_id) is None
+
+
+# --- end-to-end: listener wired at setup -------------------------------------
+
+
+async def test_issue_raised_at_setup_when_drifted(
+    hass, mock_client, mock_inverter, mock_config_entry
+):
+    mock_inverter.system_time = _drifted(15)
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert _issue(hass, mock_config_entry.entry_id) is not None
+
+
+async def test_no_issue_at_setup_when_in_window(
+    hass, mock_client, mock_inverter, mock_config_entry
+):
+    mock_inverter.system_time = dt_util.now().replace(tzinfo=None)
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert _issue(hass, mock_config_entry.entry_id) is None
+
+
+# --- fix flow ----------------------------------------------------------------
+
+
+async def test_create_fix_flow_dispatches_to_drift_flow(hass):
+    flow = await async_create_fix_flow(hass, "system_time_drift_xyz", {"entry_id": "xyz"})
+    assert isinstance(flow, SystemTimeDriftRepairFlow)
+
+
+async def test_fix_flow_form_surfaces_drift(hass):
+    flow = SystemTimeDriftRepairFlow(
+        {"entry_id": "e", "drift_minutes": "15", "system_time": "a", "ha_time": "b"}
+    )
+    flow.hass = hass
+    result = await flow.async_step_init()
+    assert result["type"] == FlowResultType.FORM
+    assert result["description_placeholders"]["drift_minutes"] == "15"
+
+
+async def test_fix_flow_syncs_clock_to_now(hass, mock_client):
+    coord = MagicMock()
+    coord._client = mock_client  # connected=True, one_shot_command AsyncMock
+    coord.async_request_refresh = mock_client.refresh  # any AsyncMock
+    hass.data.setdefault(DOMAIN, {})["entry-1"] = coord
+
+    flow = SystemTimeDriftRepairFlow({"entry_id": "entry-1"})
+    flow.hass = hass
+    result = await flow.async_step_init({})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    mock_client.one_shot_command.assert_awaited_once()
+    # The write is set_system_date_time(now) → six RTC registers, year as year-2000.
+    year, month, day, hour, minute, second = mock_client.one_shot_command.call_args[0][0]
+    now_local = dt_util.now()
+    assert year.value == now_local.year - 2000
+    assert month.value == now_local.month
+    assert day.value == now_local.day
+
+
+async def test_fix_flow_raises_when_disconnected(hass, mock_client):
+    mock_client.connected = False
+    coord = MagicMock()
+    coord._client = mock_client
+    hass.data.setdefault(DOMAIN, {})["entry-1"] = coord
+    flow = SystemTimeDriftRepairFlow({"entry_id": "entry-1"})
+    flow.hass = hass
+    with pytest.raises(HomeAssistantError):
+        await flow.async_step_init({})


### PR DESCRIPTION
## Summary

Adds a fixable HA repair that fires when the inverter's RTC has drifted more than 10 minutes from Home Assistant's time. A drifted inverter clock silently breaks time-of-use charge/discharge scheduling (and Predbat) because the inverter acts on its own wall clock.

**What's new:**

- Raises a `WARNING`-severity repair, `system_time_drift_{entry_id}`, when `|inverter_clock − HA_time| ≥ 10 min`. Fires on every coordinator poll via a listener registered at entry setup; uses `ir.async_create_issue` / `async_delete_issue` (idempotent, no churn).
- **One-click Fix** writes the current HA time to the inverter RTC (`commands.set_system_date_time(dt_util.now())` — the same write as `set_system_datetime`) then triggers a refresh. The repair clears itself after the next poll confirms the clock is back in window.
- The repair description includes the opt-out instructions inline: open Configure and untick *Warn when the inverter clock drifts from Home Assistant*.
- New per-entry options toggle `warn_clock_drift` (default ON). Users who deliberately keep their inverter in UTC or another zone can switch it off; toggling it off also clears any standing repair.
- Battery-data-only entries are skipped (clock sensors aren't surfaced for those entries).

**Tests:** 14 new in `tests/test_system_time_drift.py` covering the pure helper, raise/clear/guard paths, end-to-end listener wiring at setup, fix flow (form render, clock write, disconnect guard), and the options toggle render/persist test in `test_config_flow.py`.

## Test plan
- [ ] CI green
- [ ] Manual: set inverter clock ~15 min out → repair appears naming the drift; click Fix → clock syncs, repair clears next poll
- [ ] Untick toggle → repair clears and stays away
- [ ] Battery-data-only entry: no repair raised