### PR TITLE
feat: expose self-consumption energy sensors (#223)

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.5.11,<3.0.0"
+    "givenergy-modbus>=2.5.12,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -76,6 +76,12 @@ class GivEnergyInverterSensorDescription(SensorEntityDescription):
     # session. Use for computed TOTAL_INCREASING sensors whose source value can
     # transiently dip due to multi-register polling skew.
     monotonic: bool = False
+    # Only meaningful with monotonic=True. True (default) runs the daily-counter
+    # clamp, which admits the genuine midnight reset back to ~0. False runs a pure
+    # high-water clamp for lifetime counters that never reset: it never re-baselines
+    # at the day boundary, so a midnight dip can't surface as a fake meter reset in
+    # HA statistics (#223).
+    monotonic_resets_daily: bool = True
     # Model field the value_fn actually reads, when it differs from `key` (the
     # key is pinned by unique_id stability). Without this, renamed direct-register
     # sensors resolve no IR source and silently miss the stale-bank availability
@@ -739,14 +745,17 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
     GivEnergyInverterSensorDescription(
         # Lifetime self-consumption (max(0, pv_total - export_total), modbus 2.5.12).
         # Also a difference of cumulative counters that can transiently dip / decrease
-        # on battery-to-grid export, so it carries the monotonic clamp too — unlike
-        # the single-register e_load_total above, which needs none.
+        # on battery-to-grid export, so it carries a monotonic clamp too — but the
+        # non-daily (pure high-water) variant: a lifetime counter never resets, so the
+        # daily clamp's midnight re-baseline would expose an overnight dip as a fake
+        # meter reset in HA statistics (#223).
         key="e_self_consumption_total",
         name="Self Consumption Total",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         monotonic=True,
+        monotonic_resets_daily=False,
         value_fn=lambda inv: getattr(inv, "e_self_consumption_total", None),
         skip_if_none=True,
         skip_if_ems=True,
@@ -1960,6 +1969,11 @@ class GivEnergyInverterSensor(
             restored = float(last_state.state)
         except ValueError, TypeError:
             return
+        if not self.entity_description.monotonic_resets_daily:
+            # Lifetime high-water clamp: always seed from the last persisted value,
+            # regardless of date, so a post-restart dip can't re-baseline below it.
+            self._monotonic_max = max(restored, 0.0)
+            return
         last_date = dt_util.as_local(last_state.last_updated).date()
         if last_date == dt_util.now().date():
             # Seed the intra-day max from the last persisted value so a
@@ -1992,6 +2006,15 @@ class GivEnergyInverterSensor(
     def native_value(self) -> Any:
         value = self.entity_description.value_fn(self.coordinator.data.inverter)
         if self.entity_description.monotonic and isinstance(value, (int, float)):
+            if not self.entity_description.monotonic_resets_daily:
+                # Lifetime counter: pure high-water clamp. Hold the maximum and
+                # never re-baseline (no daily reset to admit), so a transient skew
+                # dip or a real battery-to-grid decrease can't be exposed as a
+                # statistics-corrupting drop (#223). Floored at zero defensively.
+                candidate = max(value, 0.0)
+                if self._monotonic_max is None or candidate > self._monotonic_max:
+                    self._monotonic_max = candidate
+                return self._monotonic_max
             now = dt_util.now()
             today = now.date()
             last_read = self._monotonic_last_read

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -712,6 +712,46 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
+        # Self-consumption — PV generation used on-site, derived in givenergy-modbus
+        # 2.5.12 as max(0, pv_generation - grid_export) on SinglePhaseInverter only;
+        # skip_if_none drops it on three-phase, which lacks the field (#223).
+        # monotonic=True because it's a difference of two cumulative day counters
+        # (PV today, export today) read with poll skew, and genuinely dips when the
+        # battery exports to grid — either way a TOTAL_INCREASING daily counter must
+        # be clamped against the transient/real decrease (same rationale as House
+        # Consumption Today). The clamp holds the high-water mark, which slightly
+        # overstates self-consumption across a battery-to-grid window; that is the
+        # price of a monotonic Energy-dashboard total and is the library's documented
+        # contract for this field.
+        key="e_self_consumption_today",
+        name="Self Consumption Today",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        monotonic=True,
+        value_fn=lambda inv: getattr(inv, "e_self_consumption_today", None),
+        skip_if_none=True,
+        # Derived PV-minus-export figure; gate off EMS controllers where the
+        # per-controller derivation isn't validated, mirroring House Consumption
+        # Today (#201/#223). Revisit once confirmed on EMS hardware.
+        skip_if_ems=True,
+    ),
+    GivEnergyInverterSensorDescription(
+        # Lifetime self-consumption (max(0, pv_total - export_total), modbus 2.5.12).
+        # Also a difference of cumulative counters that can transiently dip / decrease
+        # on battery-to-grid export, so it carries the monotonic clamp too — unlike
+        # the single-register e_load_total above, which needs none.
+        key="e_self_consumption_total",
+        name="Self Consumption Total",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        monotonic=True,
+        value_fn=lambda inv: getattr(inv, "e_self_consumption_total", None),
+        skip_if_none=True,
+        skip_if_ems=True,
+    ),
+    GivEnergyInverterSensorDescription(
         # Renamed from "Load Energy Today" / e_load_day (givenergy-modbus #174):
         # IR35 was a GivTCP-era mislabel — it has always been AC charge, not house
         # load. A unique_id migration in __init__.py carries the existing history

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.5.11,<3.0.0",
+    "givenergy-modbus>=2.5.12,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,11 @@ def mock_inverter() -> MagicMock:
     # are PV generation. Consumption is derived. All entity keys renamed in 2.1.1/2.
     inv.e_ac_charge_today = 3.8
     inv.e_consumption_today = 21.4
+    # Self-consumption = max(0, PV generation - grid export), a SinglePhaseInverter
+    # computed_field (givenergy-modbus 2.5.12). Coherent with the PV/export values
+    # above (11.2 - 2.1, 5100.2 - 892.4) so the mock mirrors the real derivation.
+    inv.e_self_consumption_today = 9.1
+    inv.e_self_consumption_total = 4207.8
     # Native load registers (IR 1396-1399) exist only on three-phase models —
     # mirror the real model so the mock can't fabricate fields the sensors
     # then break on. Three-phase tests set these (and delete the derived

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -436,6 +436,8 @@ async def test_inverter_sensors_kept_on_ems_except_gated(hass, ems_setup):
     assert _entity_id(hass, "sensor", "SA1234G123_p_load_demand") is None
     assert _entity_id(hass, "sensor", "SA1234G123_e_battery_charge_day") is None
     assert _entity_id(hass, "sensor", "SA1234G123_e_battery_discharge_day") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_e_self_consumption_today") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_e_self_consumption_total") is None
 
 
 async def test_inverter_controls_suppressed_on_ems_plant(hass, ems_setup):
@@ -540,6 +542,9 @@ def test_inverter_sensors_gated_off_ems():
         "p_load_demand",
         "e_battery_charge_day",
         "e_battery_discharge_day",
+        # Derived PV-minus-export figures, gated until validated on EMS (#223).
+        "e_self_consumption_today",
+        "e_self_consumption_total",
     }
     desc = next(d for d in INVERTER_SENSORS if d.key == "p_load_demand")
     inv = MagicMock()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1716,6 +1716,42 @@ def test_monotonic_never_exposes_negative_baseline(mock_plant, freezer):
     assert _read(entity, mock_plant, -1.0) == 0.0
 
 
+def _lifetime_entity(mock_plant):
+    from datetime import timedelta
+
+    from custom_components.givenergy_local.sensor import GivEnergyInverterSensor
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.update_interval = timedelta(seconds=30)
+    coordinator.data = mock_plant
+    return GivEnergyInverterSensor(coordinator, _inverter_desc("e_self_consumption_total"))
+
+
+def _read_lifetime(entity, mock_plant, value):
+    mock_plant.inverter.e_self_consumption_total = value
+    return entity.native_value
+
+
+def test_lifetime_monotonic_holds_dip_and_never_resets_at_midnight(mock_plant, freezer):
+    """The lifetime self-consumption clamp is a pure high-water mark: it holds
+    through a battery-to-grid dip AND, unlike the daily clamp, never re-baselines at
+    the day boundary — a midnight dip must not surface as a fake meter reset in HA
+    statistics (#223, Codex review on #227)."""
+    freezer.move_to("2026-06-12 23:55:00+00:00")
+    entity = _lifetime_entity(mock_plant)
+
+    assert _read_lifetime(entity, mock_plant, 4207.8) == 4207.8
+    # Battery exports to grid: the lifetime difference dips — held, not exposed.
+    assert _read_lifetime(entity, mock_plant, 4205.3) == 4207.8
+    # Cross midnight with the dip still present: the daily clamp would re-baseline
+    # to 4205.3 here; the lifetime clamp holds the high-water mark instead.
+    freezer.tick(10 * 60)  # 2026-06-13 00:05
+    assert _read_lifetime(entity, mock_plant, 4205.3) == 4207.8
+    # Genuine growth resumes and is exposed as a plain increase.
+    assert _read_lifetime(entity, mock_plant, 4210.0) == 4210.0
+
+
 def test_monotonic_zero_baseline_small_dip(mock_plant, freezer):
     """Falsy-zero regression: with a 0.0 baseline, a sub-threshold dip used to
     slip through `self._monotonic_max or value` and expose a negative."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -682,6 +682,43 @@ async def test_house_consumption_total_absent_on_single_phase(hass, setup_integr
     assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_e_load_total") is None
 
 
+async def test_self_consumption_sensors_created(hass, setup_integration):
+    """Self-consumption today + lifetime total (PV used on-site) surface as kWh
+    energy sensors on a single-phase inverter (#223, givenergy-modbus 2.5.12)."""
+    today = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_e_self_consumption_today"))
+    assert today.state == "9.1"
+    assert today.attributes["unit_of_measurement"] == "kWh"
+    assert today.attributes["device_class"] == "energy"
+
+    total = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_e_self_consumption_total"))
+    assert total.state == "4207.8"
+    assert total.attributes["unit_of_measurement"] == "kWh"
+
+
+async def test_self_consumption_sensors_absent_when_field_missing(
+    hass, mock_client, mock_config_entry
+):
+    """Three-phase models lack the single-phase-only self-consumption fields, so
+    skip_if_none must drop both sensors rather than orphan them as unavailable."""
+    inv = mock_client.plant.inverter
+    del inv.e_self_consumption_today
+    del inv.e_self_consumption_total
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    assert (
+        registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_e_self_consumption_today")
+        is None
+    )
+    assert (
+        registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_e_self_consumption_total")
+        is None
+    )
+
+
 async def test_ac_charge_today_sensor_replaces_load_energy(hass, setup_integration):
     """e_load_day was a mislabel (it's AC charge); the renamed sensor reads it, and
     nothing remains registered under the old unique_id."""

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.11,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.12,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.5.11"
+version = "2.5.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/b0/821c49f3928ec3fcc36088a19512099f785250f9a90267d76e2a85a751c0/givenergy_modbus-2.5.11.tar.gz", hash = "sha256:5bcebf6e96c5c0d4be0481c4a46ace54cde5f10f53b8d808409fdcb319c29c40", size = 454707, upload-time = "2026-06-25T20:19:32.071Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/4a/c5c165546ddabba348f4a123aadf3417b2a6820cfa67b6c8beff00570f2a/givenergy_modbus-2.5.12.tar.gz", hash = "sha256:bd8febfd121fd2cbf421ac171f9374d952a55e3b391c3005d574977acd6f42c3", size = 456217, upload-time = "2026-06-25T23:23:05.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/82/a65bf13710fc26d5858fac973892285b112c2463aef78db705c503c36bfd/givenergy_modbus-2.5.11-py3-none-any.whl", hash = "sha256:06e2e4637aa710ed58e5ecd948ad0068a71e8fb0bfaa9929ce6737d1e8798376", size = 173498, upload-time = "2026-06-25T20:19:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/41/6b9d9ac65d89d5a242e67a408836d4f3ef3acf4cb1673633a61f472390eb/givenergy_modbus-2.5.12-py3-none-any.whl", hash = "sha256:bfe9f7bd50cc71c29d9a6d811c189fcd801ef96a7e2a71e4a8db222e3dfea89b", size = 173977, upload-time = "2026-06-25T23:23:03.473Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #223.

## Summary

Adds **Self Consumption Today** and **Self Consumption Total** sensors — PV generation used on-site (`max(0, PV − grid export)`), mirroring GivTCP's `self_consumption_energy`. These complete the "self-used vs exported" split that dashboards (the FR came from setting up `pv-energy-donut-card`) previously had to derive with template helpers.

Both are thin passthrough sensors over the `e_self_consumption_today` / `e_self_consumption_total` `@computed_field`s added in **givenergy-modbus 2.5.12**; the pin is bumped to `>=2.5.12` across `manifest.json`, `pyproject.toml`, and `uv.lock`.

## Design notes

- **`monotonic=True` on both.** The library fields are differences of two cumulative counters (PV vs export), so they dip transiently on poll skew *and* genuinely decrease when the battery exports to grid. A `TOTAL_INCREASING` energy sensor that decreases is misread by HA's recorder as a meter reset, so the existing monotonic clamp (same one House Consumption Today uses) holds the high-water mark. This slightly overstates self-consumption across a battery-to-grid window — that's the documented trade-off for a monotonic Energy-dashboard total, and matches the library's stated contract for these fields.
- **`skip_if_ems=True`** — mirrors House Consumption Today. It's the same kind of derived PV/grid figure whose per-controller semantics aren't yet validated on EMS hardware. Easily revisited once confirmed on an EMS plant.
- **`skip_if_none=True`** — the fields are `SinglePhaseInverter`-only; three-phase units don't expose them, so the sensors drop rather than orphan as unavailable.

The **PV-direct-to-load** sensor mentioned as a bonus in #223 is a different derivation (`load − import − battery_discharge`) and lower priority — left for a follow-up.

## Tests

- `test_self_consumption_sensors_created` — both surface as kWh energy sensors with the expected state on single-phase.
- `test_self_consumption_sensors_absent_when_field_missing` — `skip_if_none` drops both when the field is absent.
- Extended the EMS gate tests (`test_inverter_sensors_kept_on_ems_except_gated`, and the exact gated-set pin in `test_inverter_sensors_gated_off_ems`) to cover the two new keys.
- Mock fixture gains coherent values (`9.1 = 11.2 − 2.1`, `4207.8 = 5100.2 − 892.4`).

Full suite: 539 passing.

## Test plan
- [ ] CI green
- [ ] Manual: confirm both sensors appear with kWh / energy device class and feed the donut card's consumption ring