### PR TITLE
feat: add PV Direct Today sensor (modbus 2.5.13)

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.5.12,<3.0.0"
+    "givenergy-modbus>=2.5.13,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -774,7 +774,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         monotonic=True,
-        value_fn=lambda inv: getattr(inv, "e_pv_direct_today", None),
+        value_fn=lambda inv: inv.e_pv_direct_today,
         skip_if_none=True,
         skip_if_ems=True,
     ),

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -761,6 +761,24 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         skip_if_ems=True,
     ),
     GivEnergyInverterSensorDescription(
+        # PV that reached load directly (bypassing battery and grid), modbus 2.5.13.
+        # DC-coupled hybrids only — returns None on AC-coupled/AIO (IR44/45-46
+        # mislabelled on those units, #293) and on non-GEN1 DC hybrids until the
+        # battery-charge routing map widens (modbus #184). skip_if_none=True means
+        # the sensor simply won't appear where None is the only value ever returned.
+        # Not monotonic intraday (an export burst can dip it), so carries a daily
+        # monotonic clamp — same contract as e_self_consumption_today.
+        key="e_pv_direct_today",
+        name="PV Direct Today",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        monotonic=True,
+        value_fn=lambda inv: getattr(inv, "e_pv_direct_today", None),
+        skip_if_none=True,
+        skip_if_ems=True,
+    ),
+    GivEnergyInverterSensorDescription(
         # Renamed from "Load Energy Today" / e_load_day (givenergy-modbus #174):
         # IR35 was a GivTCP-era mislabel — it has always been AC charge, not house
         # load. A unique_id migration in __init__.py carries the existing history

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.5.12,<3.0.0",
+    "givenergy-modbus>=2.5.13,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,8 @@ def mock_inverter() -> MagicMock:
     # above (11.2 - 2.1, 5100.2 - 892.4) so the mock mirrors the real derivation.
     inv.e_self_consumption_today = 9.1
     inv.e_self_consumption_total = 4207.8
+    # PV direct to load (givenergy-modbus 2.5.13, DC-coupled GEN1 only).
+    inv.e_pv_direct_today = 5.3
     # Native load registers (IR 1396-1399) exist only on three-phase models —
     # mirror the real model so the mock can't fabricate fields the sensors
     # then break on. Three-phase tests set these (and delete the derived

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -438,6 +438,7 @@ async def test_inverter_sensors_kept_on_ems_except_gated(hass, ems_setup):
     assert _entity_id(hass, "sensor", "SA1234G123_e_battery_discharge_day") is None
     assert _entity_id(hass, "sensor", "SA1234G123_e_self_consumption_today") is None
     assert _entity_id(hass, "sensor", "SA1234G123_e_self_consumption_total") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_e_pv_direct_today") is None
 
 
 async def test_inverter_controls_suppressed_on_ems_plant(hass, ems_setup):
@@ -545,6 +546,8 @@ def test_inverter_sensors_gated_off_ems():
         # Derived PV-minus-export figures, gated until validated on EMS (#223).
         "e_self_consumption_today",
         "e_self_consumption_total",
+        # DC-coupled GEN1 only; not validated on EMS controllers.
+        "e_pv_direct_today",
     }
     desc = next(d for d in INVERTER_SENSORS if d.key == "p_load_demand")
     inv = MagicMock()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -719,6 +719,28 @@ async def test_self_consumption_sensors_absent_when_field_missing(
     )
 
 
+async def test_pv_direct_today_sensor_created(hass, setup_integration):
+    """PV direct to load (bypassing battery and grid) surfaces as a kWh energy sensor
+    on DC-coupled GEN1 hybrids (givenergy-modbus 2.5.13)."""
+    entity = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_e_pv_direct_today"))
+    assert entity.state == "5.3"
+    assert entity.attributes["unit_of_measurement"] == "kWh"
+    assert entity.attributes["device_class"] == "energy"
+
+
+async def test_pv_direct_today_absent_when_field_missing(hass, mock_client, mock_config_entry):
+    """AC-coupled / non-GEN1 DC units return None for e_pv_direct_today;
+    skip_if_none must drop the sensor rather than orphan it as unavailable."""
+    del mock_client.plant.inverter.e_pv_direct_today
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_e_pv_direct_today") is None
+
+
 async def test_ac_charge_today_sensor_replaces_load_energy(hass, setup_integration):
     """e_load_day was a mislabel (it's AC charge); the renamed sensor reads it, and
     nothing remains registered under the old unique_id."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -731,7 +731,7 @@ async def test_pv_direct_today_sensor_created(hass, setup_integration):
 async def test_pv_direct_today_absent_when_field_missing(hass, mock_client, mock_config_entry):
     """AC-coupled / non-GEN1 DC units return None for e_pv_direct_today;
     skip_if_none must drop the sensor rather than orphan it as unavailable."""
-    del mock_client.plant.inverter.e_pv_direct_today
+    mock_client.plant.inverter.e_pv_direct_today = None
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.12,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.13,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.5.12"
+version = "2.5.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/4a/c5c165546ddabba348f4a123aadf3417b2a6820cfa67b6c8beff00570f2a/givenergy_modbus-2.5.12.tar.gz", hash = "sha256:bd8febfd121fd2cbf421ac171f9374d952a55e3b391c3005d574977acd6f42c3", size = 456217, upload-time = "2026-06-25T23:23:05.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/31/d77032446cc8947fb99ba5989c119b0a4d7abdccfb3134df9787a80bdc15/givenergy_modbus-2.5.13.tar.gz", hash = "sha256:254438ba269ffaa9bc269de159d3e0a820b17d7b5c0d6ad9001245052ef4c1c0", size = 458474, upload-time = "2026-06-26T01:02:12.946Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/41/6b9d9ac65d89d5a242e67a408836d4f3ef3acf4cb1673633a61f472390eb/givenergy_modbus-2.5.12-py3-none-any.whl", hash = "sha256:bfe9f7bd50cc71c29d9a6d811c189fcd801ef96a7e2a71e4a8db222e3dfea89b", size = 173977, upload-time = "2026-06-25T23:23:03.473Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ee/afe5a065504f4299a5a4bc7bb1329d483b371c02239a4b279cdbcb0e9bac/givenergy_modbus-2.5.13-py3-none-any.whl", hash = "sha256:8ffc5efba2826ff34278d667b3115cdfc97d0387806ad32b6a154dcb2790c56d", size = 174936, upload-time = "2026-06-26T01:02:11.167Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `e_pv_direct_today` as a `TOTAL_INCREASING` energy sensor: PV energy that reached load directly, bypassing battery and grid (a subset of self-consumption)
- DC-coupled GEN1 hybrids only — AC-coupled/AIO units and non-GEN1 DC models return `None` (modbus enforces this via mislabelled IR44/45-46 on those units); `skip_if_none=True` drops the sensor cleanly on unsupported hardware
- Carries the same daily monotonic clamp as `e_self_consumption_today` (can dip intraday on export bursts)
- Gated off EMS controllers alongside the other derived PV figures
- Bumps `givenergy-modbus` requirement to `>=2.5.13`

## Test plan

- [x] `test_pv_direct_today_sensor_created` — sensor appears with correct value on a GEN1 DC hybrid fixture
- [x] `test_pv_direct_today_absent_when_field_missing` — sensor absent when `e_pv_direct_today` is not on the inverter object
- [x] EMS gate tests extended to cover the new key
- [x] Full suite: 542 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new inverter energy sensor, “PV Direct Today”, to show daily PV direct-to-load energy where supported.

* **Bug Fixes**
  * Improved sensor handling so the new reading is hidden when unavailable and omitted on EMS-based plants.

* **Chores**
  * Updated the required `givenergy-modbus` version to a newer release.

* **Tests**
  * Expanded test coverage for the new sensor’s display, availability, and EMS behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->