### PR TITLE
fix: suppress clock-drift repair on EMS controllers

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -616,14 +616,21 @@ def _check_system_time_drift(
         "system_time": system_time.strftime("%Y-%m-%d %H:%M"),
         "ha_time": now.strftime("%Y-%m-%d %H:%M"),
     }
+    # On an EMS plant the controller's clock can't be set locally: the modbus library
+    # models the controller as a non-inverter peer and refuses HR(35) writes, so the
+    # one-click fix would error. Surface the drift as a non-fixable notice that points
+    # to the GivEnergy app instead (the controller normally re-syncs from the cloud).
+    # Reading the clock still works, so detection — what Predbat consumes via the
+    # System Time entity — is unaffected.
+    is_ems = coordinator.data.ems is not None
     ir.async_create_issue(
         hass,
         DOMAIN,
         issue_id,
-        is_fixable=True,
+        is_fixable=not is_ems,
         is_persistent=False,
         severity=ir.IssueSeverity.WARNING,
-        translation_key="system_time_drift",
+        translation_key="system_time_drift_ems" if is_ems else "system_time_drift",
         translation_placeholders=placeholders,
         data={"entry_id": entry.entry_id, **placeholders},
     )

--- a/custom_components/givenergy_local/datetime.py
+++ b/custom_components/givenergy_local/datetime.py
@@ -8,6 +8,7 @@ from homeassistant.components.datetime import DateTimeEntity, DateTimeEntityDesc
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -75,6 +76,16 @@ class GivEnergyDateTimeEntity(CoordinatorEntity[GivEnergyUpdateCoordinator], Dat
         return system_time.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
 
     async def async_set_value(self, value: datetime) -> None:
+        # On an EMS plant the clock register is read-only to us: the modbus library
+        # models the controller as a non-inverter peer and refuses HR(35) writes
+        # (the controller re-syncs its clock from the GivEnergy cloud). The entity
+        # stays for visibility, but raise a clean error rather than letting the
+        # library's InvalidPduState surface as a traceback.
+        if self.coordinator.data.ems is not None:
+            raise HomeAssistantError(
+                "The EMS controller clock cannot be set locally — correct it from "
+                "the GivEnergy app or portal."
+            )
         client = self.coordinator._client
         if client is None or not client.connected:
             return

--- a/custom_components/givenergy_local/strings.json
+++ b/custom_components/givenergy_local/strings.json
@@ -81,6 +81,10 @@
         }
       }
     },
+    "system_time_drift_ems": {
+      "title": "GivEnergy EMS controller clock has drifted (~{drift_minutes} min)",
+      "description": "The EMS controller's clock reads {system_time} but Home Assistant's time is {ha_time} — a drift of about {drift_minutes} minutes. The controller runs its charge and export slots from its own clock, so a drift this large can make those slots (and Predbat scheduling) act at the wrong time.\n\nUnlike a directly-connected inverter, an EMS controller's clock cannot be set locally — correct it from the GivEnergy app or portal. The controller normally re-syncs its clock from the cloud, so this often clears on its own.\n\nIf you deliberately run your system in a different time zone (for example UTC), turn this warning off instead: open the integration's **Configure** dialog and untick *Warn when the inverter clock drifts from Home Assistant*."
+    },
     "plant_topology_changed": {
       "title": "GivEnergy plant topology has changed",
       "description": "The hardware layout of your GivEnergy system has changed since the last start — typically a battery was added or removed, or the inverter device type changed.\n\nThe integration has already accepted the new topology and reloaded itself; this notice is purely advisory and can be dismissed."

--- a/custom_components/givenergy_local/translations/en.json
+++ b/custom_components/givenergy_local/translations/en.json
@@ -79,6 +79,10 @@
         }
       }
     },
+    "system_time_drift_ems": {
+      "title": "GivEnergy EMS controller clock has drifted (~{drift_minutes} min)",
+      "description": "The EMS controller's clock reads {system_time} but Home Assistant's time is {ha_time} — a drift of about {drift_minutes} minutes. The controller runs its charge and export slots from its own clock, so a drift this large can make those slots (and Predbat scheduling) act at the wrong time.\n\nUnlike a directly-connected inverter, an EMS controller's clock cannot be set locally — correct it from the GivEnergy app or portal. The controller normally re-syncs its clock from the cloud, so this often clears on its own.\n\nIf you deliberately run your system in a different time zone (for example UTC), turn this warning off instead: open the integration's **Configure** dialog and untick *Warn when the inverter clock drifts from Home Assistant*."
+    },
     "plant_topology_changed": {
       "title": "GivEnergy plant topology has changed",
       "description": "The hardware layout of your GivEnergy system has changed since the last start — typically a battery was added or removed, or the inverter device type changed.\n\nThe integration has already accepted the new topology and reloaded itself; this notice is purely advisory and can be dismissed."

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,11 +1,18 @@
 """Tests for the GivEnergy Local datetime platform (the inverter system clock, #219)."""
 
 from datetime import UTC, datetime
+from unittest.mock import MagicMock
 
+import pytest
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from custom_components.givenergy_local.const import DOMAIN
+from custom_components.givenergy_local.datetime import (
+    SYSTEM_TIME_DESCRIPTION,
+    GivEnergyDateTimeEntity,
+)
 
 
 def _entity_id(hass, unique_id: str) -> str:
@@ -59,3 +66,15 @@ async def test_system_time_absent_when_register_none(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
     assert _maybe_entity_id(hass, "SA1234G123_system_time") is None
+
+
+async def test_set_system_time_rejected_on_ems():
+    """On an EMS plant the controller clock isn't locally writable (the modbus library
+    refuses HR(35) writes); setting the entity raises a clean error rather than letting
+    the library's InvalidPduState surface, and never reaches the client."""
+    coordinator = MagicMock()
+    coordinator.data.ems = MagicMock()  # EMS plant
+    entity = GivEnergyDateTimeEntity(coordinator, SYSTEM_TIME_DESCRIPTION)
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_value(datetime(2026, 6, 1, 8, 30, tzinfo=UTC))
+    coordinator._client.one_shot_command.assert_not_called()

--- a/tests/test_system_time_drift.py
+++ b/tests/test_system_time_drift.py
@@ -34,9 +34,10 @@ def _entry(entry_id: str = "entry-1", **options):
     return entry
 
 
-def _coordinator(system_time):
+def _coordinator(system_time, ems=False):
     coord = MagicMock()
     coord.data.inverter.system_time = system_time
+    coord.data.ems = MagicMock() if ems else None
     return coord
 
 
@@ -89,6 +90,17 @@ async def test_battery_data_only_entry_skipped(hass):
     entry = _entry(**{CONF_BATTERY_DATA_ONLY: True})
     _check_system_time_drift(hass, entry, _coordinator(_drifted(15)))
     assert _issue(hass, entry.entry_id) is None
+
+
+async def test_ems_controller_raises_non_fixable_notice(hass):
+    """EMS controllers can't have their clock set locally (the modbus library refuses
+    HR(35) writes), so the drift surfaces as a non-fixable notice, not a Fix button."""
+    entry = _entry()
+    _check_system_time_drift(hass, entry, _coordinator(_drifted(15), ems=True))
+    issue = _issue(hass, entry.entry_id)
+    assert issue is not None
+    assert issue.is_fixable is False
+    assert issue.translation_key == "system_time_drift_ems"
 
 
 async def test_toggle_off_does_not_raise(hass):


### PR DESCRIPTION
## Summary

The clock-drift repair (#219 follow-up) offered a one-click fix that writes HR(35). On an EMS plant the modbus library refuses that write — it models the controller as a non-inverter peer, so HR(35) isn't in the EMS write allow-list and `one_shot_command` raises `InvalidPduState` before anything reaches the wire. The result was a 500 ("Config flow could not be loaded") when opening the repair.

Reading the clock still works on EMS, and that read — surfaced via the **System Time** datetime entity — is what Predbat consumes. So this keeps detection and drops only the local write-fix, which can't function on EMS:

- **Repair:** on EMS the drift is raised as a **non-fixable** notice (`system_time_drift_ems`) that points to the GivEnergy app/portal, rather than a Fix button. Non-EMS behaviour is unchanged (still one-click fixable).
- **System Time entity:** its `async_set_value` now raises a clean `HomeAssistantError` on EMS instead of letting the library's `InvalidPduState` surface as a traceback. The entity stays for read/visibility.

The controller normally re-syncs its clock from the cloud, so on real hardware this often clears on its own.

## Test plan

- [x] `test_ems_controller_raises_non_fixable_notice` — EMS drift raises a non-fixable `system_time_drift_ems` issue
- [x] `test_set_system_time_rejected_on_ems` — setting System Time on EMS raises `HomeAssistantError`, never reaches the client
- [x] Existing fixable-path and datetime tests unchanged
- [x] Full suite: 544 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)