### PR TITLE
feat: battery nominal sensors + modbus 2.6.0

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.5.13,<3.0.0"
+    "givenergy-modbus>=2.6.0,<3.0.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -298,6 +298,38 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         value_fn=lambda inv: inv.system_mode,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # Battery topology nameplate (HR308-310, givenergy-modbus 2.6.0). Static ratings,
+    # not live telemetry, so DIAGNOSTIC + no state_class. skip_if_none drops them where
+    # the register doesn't decode (None in the modbus fixtures; populated on inverters
+    # that poll the HR300 block). NB power/current scale is the library's most-likely
+    # raw-uint16 reading, flagged "unconfirmed on live hardware" upstream — confirm
+    # against real values before relying on the units. max_charge_pct is self-validating.
+    GivEnergyInverterSensorDescription(
+        key="battery_nominal_power",
+        name="Battery Nominal Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        value_fn=lambda inv: getattr(inv, "battery_nominal_power", None),
+        skip_if_none=True,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyInverterSensorDescription(
+        key="battery_nominal_current",
+        name="Battery Nominal Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        value_fn=lambda inv: getattr(inv, "battery_nominal_current", None),
+        skip_if_none=True,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyInverterSensorDescription(
+        key="battery_max_charge_pct",
+        name="Battery Max Charge Percentage",
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda inv: getattr(inv, "battery_max_charge_pct", None),
+        skip_if_none=True,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     GivEnergyInverterSensorDescription(
         key="battery_maintenance_mode",
         name="Battery Maintenance Mode",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.5.13,<3.0.0",
+    "givenergy-modbus>=2.6.0,<3.0.0",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,10 @@ def mock_inverter() -> MagicMock:
     inv.e_self_consumption_total = 4207.8
     # PV direct to load (givenergy-modbus 2.5.13, DC-coupled GEN1 only).
     inv.e_pv_direct_today = 5.3
+    # Battery topology nameplate (HR308-310, givenergy-modbus 2.6.0).
+    inv.battery_nominal_power = 3600
+    inv.battery_nominal_current = 70
+    inv.battery_max_charge_pct = 100
     # Native load registers (IR 1396-1399) exist only on three-phase models —
     # mirror the real model so the mock can't fabricate fields the sensors
     # then break on. Three-phase tests set these (and delete the derived

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -741,6 +741,43 @@ async def test_pv_direct_today_absent_when_field_missing(hass, mock_client, mock
     assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_e_pv_direct_today") is None
 
 
+async def test_battery_nominal_sensors_created(hass, setup_integration):
+    """Battery topology nameplate (HR308-310, givenergy-modbus 2.6.0) surfaces as
+    diagnostic sensors with power (W), current (A), and percentage units."""
+    power = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_battery_nominal_power"))
+    assert power.state == "3600"
+    assert power.attributes["unit_of_measurement"] == "W"
+    assert power.attributes["device_class"] == "power"
+
+    current = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_battery_nominal_current"))
+    assert current.state == "70"
+    assert current.attributes["unit_of_measurement"] == "A"
+    assert current.attributes["device_class"] == "current"
+
+    pct = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_battery_max_charge_pct"))
+    assert pct.state == "100"
+    assert pct.attributes["unit_of_measurement"] == "%"
+
+
+async def test_battery_nominal_sensors_absent_when_field_missing(
+    hass, mock_client, mock_config_entry
+):
+    """Inverters that don't decode the HR300 block return None; skip_if_none must drop
+    the sensors rather than orphan them as unavailable."""
+    inv = mock_client.plant.inverter
+    inv.battery_nominal_power = None
+    inv.battery_nominal_current = None
+    inv.battery_max_charge_pct = None
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    for key in ("battery_nominal_power", "battery_nominal_current", "battery_max_charge_pct"):
+        assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is None
+
+
 async def test_ac_charge_today_sensor_replaces_load_energy(hass, setup_integration):
     """e_load_day was a mislabel (it's AC charge); the renamed sensor reads it, and
     nothing remains registered under the old unique_id."""

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.5.13,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.6.0,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.5.13"
+version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/31/d77032446cc8947fb99ba5989c119b0a4d7abdccfb3134df9787a80bdc15/givenergy_modbus-2.5.13.tar.gz", hash = "sha256:254438ba269ffaa9bc269de159d3e0a820b17d7b5c0d6ad9001245052ef4c1c0", size = 458474, upload-time = "2026-06-26T01:02:12.946Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d3/5569fe9e63a84b380e88667b5a7aa4c656217474df2a7cb633ed2b6f8818/givenergy_modbus-2.6.0.tar.gz", hash = "sha256:87a3274a1c4fd57edf58bc331cb11b629a480bd9766ee57a5b73b6bf3e572b43", size = 467901, upload-time = "2026-06-26T13:56:17.549Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/ee/afe5a065504f4299a5a4bc7bb1329d483b371c02239a4b279cdbcb0e9bac/givenergy_modbus-2.5.13-py3-none-any.whl", hash = "sha256:8ffc5efba2826ff34278d667b3115cdfc97d0387806ad32b6a154dcb2790c56d", size = 174936, upload-time = "2026-06-26T01:02:11.167Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/24/f0dbc8ee3fc77eb56e7bedf17229aa20ae243cb28f6c3791064cc9994246/givenergy_modbus-2.6.0-py3-none-any.whl", hash = "sha256:1bcc077867d9e71b1452e33dc72beb6e82d798c5cd0941fdc0613e7864ba42e9", size = 180995, upload-time = "2026-06-26T13:56:15.959Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adopts `givenergy-modbus` 2.6.0 (pin `>=2.6.0`, no breaking changes, no polling overhead) and exposes the confident subset of its newly-decoded registers.

- **Battery topology nameplate (HR308–310)** → three new **diagnostic** sensors: Battery Nominal Power (W), Battery Nominal Current (A), Battery Max Charge Percentage (%). Static ratings, so no state class; `skip_if_none` drops them on inverters that don't decode the HR300 block.

**Deferred deliberately** (learn-before-facade): the HR63–83 AC grid-protection block (library scaling inferred from the 3ph parallel block, *unverified on single-phase hardware*), the 3ph-only control flags, and the installer-tier write surface (`installer_command()` — safety-sensitive, warrants its own design).

**Caveat:** the power/current scale is the library's most-likely raw-uint16 reading, marked "unconfirmed on live hardware" upstream. Units are provisional — I'll confirm against live values on a real inverter before they're relied on. Max charge % is self-validating.

## Test plan
- [x] `test_battery_nominal_sensors_created` — all three surface with W/A/% units
- [x] `test_battery_nominal_sensors_absent_when_field_missing` — `skip_if_none` drops them when the block is None
- [x] Full suite: 546 passing; ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)