### PR TITLE
fix: use getattr for e_pv_direct_today value_fn (3-phase AttributeError)

### DIFF
--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -806,7 +806,9 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         monotonic=True,
-        value_fn=lambda inv: inv.e_pv_direct_today,
+        # getattr, not direct access: SinglePhaseInverter-only computed field, absent on
+        # the polymorphic ThreePhaseInverter — returns None there, dropped by skip_if_none.
+        value_fn=lambda inv: getattr(inv, "e_pv_direct_today", None),
         skip_if_none=True,
         skip_if_ems=True,
     ),

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -74,6 +74,30 @@ def test_inverter_value_fns_resolve_against_real_model():
         d.value_fn(inv)
 
 
+def test_inverter_value_fns_resolve_against_three_phase_model():
+    """Companion to test_inverter_value_fns_resolve_against_real_model for the
+    polymorphic three-phase model. Plant.inverter is polymorphic, so every
+    non-single_phase_only value_fn must resolve against a real ThreePhaseInverter
+    too — which lacks the SinglePhaseInverter-only computed fields (e_pv_direct_today,
+    e_self_consumption_*, battery_nominal_*). Regression for e_pv_direct_today using
+    direct attribute access, which raised AttributeError on three-phase startup and
+    tripped the setup filter's field-drift warning on every poll. single_phase_only
+    descriptors are gated out before value_fn on three-phase (see
+    _include_inverter_sensor), so mirror that gate here.
+    """
+    from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
+
+    inv = ThreePhaseInverter()  # all fields None, like a pre-first-poll model
+    candidates = [d for d in INVERTER_SENSORS if not d.single_phase_only]
+
+    # Mirror the eager setup filter (skip_if_none value_fns evaluated here).
+    [d for d in candidates if not d.skip_if_none or d.value_fn(inv) is not None]
+
+    # And the native_value path for every non-gated sensor must resolve too.
+    for d in candidates:
+        d.value_fn(inv)
+
+
 def test_setup_filter_skips_bad_descriptor_instead_of_crashing():
     """A skip_if_none descriptor whose value_fn raises must be skipped (logged),
     not propagate — so one bad descriptor can't take down the whole platform the


### PR DESCRIPTION
## Summary

`e_pv_direct_today` is a `@computed_field` defined only on `SinglePhaseInverter`, but `Plant.inverter` is polymorphic — it returns a `ThreePhaseInverter` on three-phase plants. The #229 review swapped the value_fn from `getattr(inv, "e_pv_direct_today", None)` to direct attribute access, which shipped in v1.3.26. On a three-phase non-EMS plant the setup filter evaluates `value_fn(inverter)` eagerly, and `inv.e_pv_direct_today` raises `AttributeError`.

The platform's try/except catches it, so the sensor is still correctly skipped — nothing actually breaks — but it logs a misleading `WARNING "Skipping sensor e_pv_direct_today: its value_fn raised at setup (library field drift?)"` on every three-phase startup. The field hasn't drifted; it's simply single-phase-only.

## Fix

Revert the value_fn to `getattr(inv, "e_pv_direct_today", None)`, matching the pattern already used by `e_self_consumption_*` and `battery_nominal_*`. getattr returns `None` on models that lack the field, and `skip_if_none` then drops the sensor cleanly without the warning. (`single_phase_only=True` would also work, but the closest sibling sensors use getattr, and getattr additionally covers the AC-coupled/AIO/non-GEN1 None cases the flag wouldn't.)

## Test

Adds `test_inverter_value_fns_resolve_against_three_phase_model`, a companion to the existing single-phase resolution test — whose blind spot (never exercising `ThreePhaseInverter()`) is what let this slip through. It runs every non-`single_phase_only` value_fn against a real `ThreePhaseInverter` and asserts none raise: fails before this change, passes after. The broad form also guards against any future direct-access regression of the same class (none surfaced beyond `e_pv_direct_today`).

Full suite green at 95% coverage; mypy and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensor handling so a missing inverter value no longer causes errors and is safely omitted when unavailable.
* **Tests**
  * Added coverage to verify inverter sensor values resolve correctly across supported inverter types, including three-phase models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->