### PR TITLE
feat: Restart + Re-detect buttons, partial-log readability (#233/#234/#235)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -121,6 +121,17 @@ async def _save_capabilities(
     await _capabilities_store(hass, entry_id).async_save(capabilities.to_dict())
 
 
+async def _redetect_plant_entry(hass: HomeAssistant, entry_id: str) -> None:
+    """Discard an entry's cached topology and reload it — a cold re-detect.
+
+    Shared by the `redetect_plant` service and the Re-detect Plant button: with no
+    prior on disk the next setup_entry runs a full `detect()` sweep, which is the
+    "I changed the hardware (added/recovered a battery), please rediscover" path.
+    """
+    await _capabilities_store(hass, entry_id).async_remove()
+    hass.config_entries.async_schedule_reload(entry_id)
+
+
 # Callers may identify the target inverter by HA-assigned device_id (convenient
 # in the Settings → Services UI) OR by inverter serial (convenient in dashboards
 # and automations that only know the serial). Exactly one must be supplied.
@@ -951,8 +962,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             target_entry_id, err = _resolve_target(hass, call.data)
             if err or target_entry_id is None:
                 raise HomeAssistantError(err or "Could not resolve target entry")
-            await _capabilities_store(hass, target_entry_id).async_remove()
-            hass.config_entries.async_schedule_reload(target_entry_id)
+            await _redetect_plant_entry(hass, target_entry_id)
 
         async def handle_expose_recommended_entities(call: ServiceCall) -> None:
             # Mirrors the dashboard generator's UX: a one-shot service that
@@ -1057,3 +1067,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.services.async_remove(DOMAIN, SERVICE_EXPOSE_RECOMMENDED_ENTITIES)
 
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Discard the entry's cached plant-capabilities store when it is deleted.
+
+    HA does not auto-remove an integration's `Store` data on config-entry
+    deletion, so without this a delete-then-re-add (or a leftover after an
+    uninstall) would orphan the `.storage` capabilities file. The cache is keyed
+    by entry_id, so a re-added entry gets a fresh id and a cold detect() either
+    way — this is housekeeping, not a behaviour change.
+    """
+    await _capabilities_store(hass, entry.entry_id).async_remove()

--- a/custom_components/givenergy_local/button.py
+++ b/custom_components/givenergy_local/button.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+
+from givenergy_modbus.client import commands
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_BATTERY_DATA_ONLY, DOMAIN
+from .coordinator import GivEnergyUpdateCoordinator
+from .sensor import _device_kind
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: GivEnergyUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[ButtonEntity] = [
+        # Re-detect is a safe read-side reload (clears the cached topology and
+        # re-probes), so it's offered on every entry — including the EMS controller,
+        # which otherwise exposes no controls (#233/#234). It's the in-UI equivalent
+        # of the redetect_plant service, for recovering a battery/device that went
+        # offline and came back.
+        GivEnergyRedetectButton(coordinator, entry.entry_id),
+    ]
+    # Restart writes the inverter reboot register (HR163), which an EMS controller
+    # rejects (not in its modbus write-safe set — same family as the clock-write
+    # ban), so gate it off EMS like the other controls. Battery-data-only units are
+    # driven by their Gateway, so skip there too (#95).
+    if coordinator.data.ems is None and not entry.options.get(CONF_BATTERY_DATA_ONLY, False):
+        entities.append(GivEnergyRestartButton(coordinator))
+    async_add_entities(entities)
+
+
+class _GivEnergyButtonBase(CoordinatorEntity[GivEnergyUpdateCoordinator], ButtonEntity):
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: GivEnergyUpdateCoordinator, key: str) -> None:
+        super().__init__(coordinator)
+        serial = coordinator.data.inverter_serial_number
+        self._attr_unique_id = f"{serial}_{key}"
+        model = coordinator.data.inverter.model
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy {_device_kind(model)} {serial}",
+        )
+
+
+class GivEnergyRestartButton(_GivEnergyButtonBase):
+    """Reboot the inverter (HR163) — the button form of the reboot_inverter service."""
+
+    _attr_name = "Restart"
+    _attr_device_class = ButtonDeviceClass.RESTART
+
+    def __init__(self, coordinator: GivEnergyUpdateCoordinator) -> None:
+        super().__init__(coordinator, "restart")
+
+    async def async_press(self) -> None:
+        client = self.coordinator._client
+        if client is None or not client.connected:
+            raise HomeAssistantError("GivEnergy inverter is not currently connected")
+        # No refresh: the inverter drops off the bus as it reboots; the coordinator
+        # reconnects on its own. A request_refresh here would just race the reboot.
+        await client.one_shot_command(commands.set_inverter_reboot())
+
+
+class GivEnergyRedetectButton(_GivEnergyButtonBase):
+    """Clear the cached plant topology and reload — re-probe for added/recovered devices."""
+
+    _attr_name = "Re-detect Plant"
+
+    def __init__(self, coordinator: GivEnergyUpdateCoordinator, entry_id: str) -> None:
+        super().__init__(coordinator, "redetect_plant")
+        self._entry_id = entry_id
+
+    async def async_press(self) -> None:
+        # Lazy import to avoid a package import cycle (mirrors repairs.py).
+        from . import _redetect_plant_entry
+
+        await _redetect_plant_entry(self.hass, self._entry_id)

--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -33,7 +33,7 @@ CONF_RETRIES = "retries"
 
 DEFAULT_PASSIVE = False
 
-PLATFORMS = ["binary_sensor", "sensor", "switch", "number", "select", "time", "datetime"]
+PLATFORMS = ["binary_sensor", "sensor", "switch", "number", "select", "time", "datetime", "button"]
 
 SERVICE_REBOOT_INVERTER = "reboot_inverter"
 SERVICE_CALIBRATE_BATTERY_SOC = "calibrate_battery_soc"

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -56,6 +56,21 @@ _FULL_REFRESH_INTERVAL = 300  # seconds (~5 minutes)
 # warns; the in-between ones drop to DEBUG so a flaky/contended plant doesn't
 # flood the log. The cumulative partial_failures counter/sensor is unaffected.
 _PARTIAL_LOG_EVERY = 20
+
+
+def _summarize_failures(failures: Iterable[ReadFailure]) -> str:
+    """Render dropped reads as e.g. ``IR(60) on device 0x03, HR(2040) on device 0x11``.
+
+    The raw ``ReadFailure`` repr is noisy; this names the register bank and the
+    device address so the failing *leg* (e.g. an EMS controller at 0x11 vs a
+    battery at 0x33) is obvious at a glance in the log.
+    """
+    return ", ".join(
+        f"{'HR' if 'Holding' in f.request_type else 'IR'}({f.base_register})"
+        f" on device 0x{f.device_address:02x}"
+        for f in failures
+    )
+
 
 # Per-slot probe budget for detect()'s peripheral sweep (batteries, meters).
 # More generous than the library defaults (0.5s / 1 retry): the battery sweep
@@ -265,13 +280,8 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                 # tolerance window — unchanged) or a cold start too sparse to set up
                 # at all (no inverter identity → raise → ConfigEntryNotReady, retry).
                 self._record_failure()
-                failure_summary = ", ".join(
-                    f"{'HR' if 'Holding' in f.request_type else 'IR'}({f.base_register})"
-                    f" on device 0x{f.device_address:02x}"
-                    for f in exc.failures
-                )
                 return await self._serve_last_known_or_fail(
-                    f"Partial data on (re)connect seed: {failure_summary}",
+                    f"Partial data on (re)connect seed: {_summarize_failures(exc.failures)}",
                     exc,
                 )
             # Steady state: serve the partial. The dropped device's last-known
@@ -381,20 +391,20 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                 "values for those banks (further partials this run at debug). "
                 "Failures: %s",
                 len(exc.failures),
-                exc.failures,
+                _summarize_failures(exc.failures),
             )
         elif self._consecutive_partials % _PARTIAL_LOG_EVERY == 0:
             _LOGGER.warning(
                 "Partial refresh still occurring (%d consecutive polls); serving "
                 "last-known values. Failures: %s",
                 self._consecutive_partials,
-                exc.failures,
+                _summarize_failures(exc.failures),
             )
         else:
             _LOGGER.debug(
                 "Partial refresh: %d register read(s) failed; serving last-known. Failures: %s",
                 len(exc.failures),
-                exc.failures,
+                _summarize_failures(exc.failures),
             )
 
     def _is_timeout_failure(self, err: RefreshFailed) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from givenergy_modbus.model.inverter import (
     MeterType,
     Model,
     SinglePhaseInverter,
+    Status,
 )
 from givenergy_modbus.model.plant import PlantCapabilities
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -258,6 +259,55 @@ def mock_config_entry() -> MockConfigEntry:
 
 @pytest.fixture
 async def setup_integration(hass, mock_client, mock_config_entry):
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
+
+
+@pytest.fixture
+def mock_ems() -> MagicMock:
+    """An EMS plant controller, with the slot/target/aggregate surface the EMS
+    platforms read. The shared fixtures default `plant.ems` to None; override with
+    this and set `mock_inverter.model = Model.EMS` to present as an EMS plant."""
+    ems = MagicMock()
+    ems.charge_slot_1 = TimeSlot.from_components(2, 0, 5, 0)
+    ems.charge_slot_2 = None
+    ems.charge_slot_3 = None
+    ems.discharge_slot_1 = TimeSlot.from_components(17, 0, 19, 0)
+    ems.discharge_slot_2 = None
+    ems.discharge_slot_3 = None
+    ems.export_slot_1 = TimeSlot.from_components(10, 0, 16, 0)
+    ems.export_slot_2 = None
+    ems.export_slot_3 = None
+    ems.charge_target_1 = 80
+    ems.charge_target_2 = 100
+    ems.charge_target_3 = 100
+    ems.discharge_target_1 = 20
+    ems.discharge_target_2 = 4
+    ems.discharge_target_3 = 4
+    ems.export_target_1 = 100
+    ems.export_target_2 = 4
+    ems.export_target_3 = 4
+    ems.export_power_limit = 3600
+    ems.plant_enabled = True
+    ems.managed_inverters = []
+    # Plant-level aggregate telemetry (#201) surfaced as EMS_SENSORS.
+    ems.ems_status = Status.NORMAL
+    ems.inverter_count = 2
+    ems.calc_load_power = 1234
+    ems.measured_load_power = 1300
+    ems.grid_meter_power = -500
+    ems.total_battery_power = 800
+    ems.remaining_battery_wh = 5000
+    return ems
+
+
+@pytest.fixture
+async def ems_setup(hass, mock_client, mock_plant, mock_inverter, mock_ems, mock_config_entry):
+    """Set up the integration with the plant presenting as an EMS."""
+    mock_plant.ems = mock_ems
+    mock_inverter.model = Model.EMS  # an EMS plant's controller decodes as Model.EMS
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,75 @@
+"""Tests for the button platform: Restart (inverter reboot) and Re-detect Plant."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.givenergy_local.const import DOMAIN
+
+
+def _entity_id(hass, unique_id: str) -> str | None:
+    return er.async_get(hass).async_get_entity_id("button", DOMAIN, unique_id)
+
+
+async def _press(hass, entity_id: str) -> None:
+    await hass.services.async_call("button", "press", {"entity_id": entity_id}, blocking=True)
+
+
+# --- Restart button (inverter reboot) ---------------------------------------
+
+
+async def test_restart_button_created_on_inverter(hass, setup_integration):
+    """A directly-connected inverter gets a Restart button with the RESTART class."""
+    entity_id = _entity_id(hass, "SA1234G123_restart")
+    assert entity_id is not None
+    assert hass.states.get(entity_id).attributes["device_class"] == "restart"
+
+
+async def test_restart_button_press_sends_reboot(hass, mock_client, setup_integration):
+    """Pressing Restart issues the one-shot inverter reboot command."""
+    await _press(hass, _entity_id(hass, "SA1234G123_restart"))
+    mock_client.one_shot_command.assert_called_once()
+
+
+async def test_restart_button_raises_when_disconnected(hass, mock_client, setup_integration):
+    """A press while the client is disconnected surfaces a clean error and sends nothing."""
+    mock_client.connected = False
+    with pytest.raises(HomeAssistantError):
+        await _press(hass, _entity_id(hass, "SA1234G123_restart"))
+    mock_client.one_shot_command.assert_not_called()
+
+
+async def test_restart_button_absent_on_ems(hass, ems_setup):
+    """The reboot register (HR163) isn't in the EMS controller's write-safe set, so no
+    Restart button is created on an EMS plant (mirrors the other control platforms)."""
+    assert _entity_id(hass, "SA1234G123_restart") is None
+
+
+# --- Re-detect Plant button --------------------------------------------------
+
+
+async def test_redetect_button_created_on_inverter(hass, setup_integration):
+    """A directly-connected inverter gets the Re-detect Plant button."""
+    assert _entity_id(hass, "SA1234G123_redetect_plant") is not None
+
+
+async def test_redetect_button_present_on_ems(hass, ems_setup):
+    """Re-detect is a safe read-side reload, so it's offered even on the EMS controller
+    (which otherwise exposes no controls)."""
+    assert _entity_id(hass, "SA1234G123_redetect_plant") is not None
+
+
+async def test_redetect_button_press_reloads_entry(hass, setup_integration):
+    """Pressing Re-detect clears the cached topology and schedules a reload — the
+    in-UI equivalent of the redetect_plant service."""
+    entity_id = _entity_id(hass, "SA1234G123_redetect_plant")
+    fake_store = AsyncMock()
+    with (
+        patch.object(hass.config_entries, "async_schedule_reload") as reload,
+        patch("custom_components.givenergy_local._capabilities_store", return_value=fake_store),
+    ):
+        await _press(hass, entity_id)
+    fake_store.async_remove.assert_awaited_once()
+    reload.assert_called_once_with(setup_integration.entry_id)

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -8,60 +8,15 @@ mock Ems before setting up the integration.
 from unittest.mock import MagicMock
 
 import pytest
-from givenergy_modbus.model import TimeSlot
 from givenergy_modbus.model.devices import InverterSummary
-from givenergy_modbus.model.inverter import Model, Status
+from givenergy_modbus.model.inverter import Model
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 
 from custom_components.givenergy_local.const import DOMAIN
 
-
-@pytest.fixture
-def mock_ems() -> MagicMock:
-    ems = MagicMock()
-    ems.charge_slot_1 = TimeSlot.from_components(2, 0, 5, 0)
-    ems.charge_slot_2 = None
-    ems.charge_slot_3 = None
-    ems.discharge_slot_1 = TimeSlot.from_components(17, 0, 19, 0)
-    ems.discharge_slot_2 = None
-    ems.discharge_slot_3 = None
-    ems.export_slot_1 = TimeSlot.from_components(10, 0, 16, 0)
-    ems.export_slot_2 = None
-    ems.export_slot_3 = None
-    ems.charge_target_1 = 80
-    ems.charge_target_2 = 100
-    ems.charge_target_3 = 100
-    ems.discharge_target_1 = 20
-    ems.discharge_target_2 = 4
-    ems.discharge_target_3 = 4
-    ems.export_target_1 = 100
-    ems.export_target_2 = 4
-    ems.export_target_3 = 4
-    ems.export_power_limit = 3600
-    ems.plant_enabled = True
-    ems.managed_inverters = []
-    # Plant-level aggregate telemetry (#201) surfaced as EMS_SENSORS.
-    ems.ems_status = Status.NORMAL
-    ems.inverter_count = 2
-    ems.calc_load_power = 1234
-    ems.measured_load_power = 1300
-    ems.grid_meter_power = -500
-    ems.total_battery_power = 800
-    ems.remaining_battery_wh = 5000
-    return ems
-
-
-@pytest.fixture
-async def ems_setup(hass, mock_client, mock_plant, mock_inverter, mock_ems, mock_config_entry):
-    """Set up the integration with the plant presenting as an EMS."""
-    mock_plant.ems = mock_ems
-    mock_inverter.model = Model.EMS  # an EMS plant's controller decodes as Model.EMS
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-    return mock_config_entry
+# mock_ems / ems_setup now live in conftest.py (shared with the button tests).
 
 
 def _entity_id(hass, platform: str, unique_id: str) -> str | None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,6 +17,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.givenergy_local import (
     _STRATEGY_URL,
     _STRATEGY_VERSION,
+    async_remove_entry,
     async_setup,
 )
 from custom_components.givenergy_local.const import (
@@ -206,6 +207,18 @@ async def test_redetect_plant_service_clears_cache_and_reloads(
     store_factory.assert_called_with(hass, setup_integration.entry_id)
     fake_store.async_remove.assert_awaited_once()
     reload_mock.assert_called_with(setup_integration.entry_id)
+
+
+async def test_async_remove_entry_clears_capabilities_cache(hass, mock_config_entry):
+    """Deleting a config entry discards its cached capabilities Store file — HA does
+    not clean integration Store data on entry removal, so the integration must."""
+    fake_store = AsyncMock()
+    with patch(
+        "custom_components.givenergy_local._capabilities_store", return_value=fake_store
+    ) as store_factory:
+        await async_remove_entry(hass, mock_config_entry)
+    store_factory.assert_called_once_with(hass, mock_config_entry.entry_id)
+    fake_store.async_remove.assert_awaited_once()
 
 
 async def test_set_system_datetime_service_sends_command(hass, mock_client, setup_integration):


### PR DESCRIPTION
Addresses a cluster of three issues from @njhcarroll's EMS/battery maintenance.

## #234 — Restart inverter from the integration
New `button` platform with a **Restart** button (`ButtonDeviceClass.RESTART`) — the button form of the existing `reboot_inverter` service. Created on directly-connected inverters only: the reboot register **HR163 isn't in the EMS controller's modbus write-safe set**, so a Restart on the EMS controller would error (same family as the clock-write ban). It's gated off EMS like the other control platforms.

## #233 — recover a battery/device that won't re-list
- A **Re-detect Plant** button (the in-UI equivalent of the `redetect_plant` service) — clears the cached topology and reloads, so a battery that went offline and came back gets re-probed. Offered on **every** entry including the EMS controller, which otherwise exposes no controls.
- `async_remove_entry()` now discards the per-entry capabilities `Store` on config-entry deletion (HA doesn't auto-clean integration Store data) — closes an orphaned-`.storage` leak.

> Note: the *primary* re-list failure for a genuinely-faulty pack is modbus-side (the detect battery-sweep breaks at the first non-responding slot, and the splice guard can hold a real cell fault indefinitely). That's handed off separately; these changes give the user a discoverable recovery affordance and tidy the cache lifecycle.

## #235 — partial failures on EMS
Log-readability only: `_record_partial`'s warning now renders `IR(60) on device 0x03, HR(2040) on device 0x11` (reusing the reconnect path's formatter) instead of the raw `ReadFailure` repr, so the failing **leg** is obvious. The differential (EMS reads degrade while direct per-inverter reads stay clean) points to RS485 noise on the EMS↔inverter legs — a hardware issue the integration already tolerates by serving last-known values.

## Tests
- `tests/test_button.py` — Restart present on inverter / absent on EMS / press sends reboot / raises when disconnected; Re-detect present everywhere incl. EMS / press clears cache + reloads.
- `async_remove_entry` cache-cleanup test.
- `mock_ems`/`ems_setup` fixtures promoted to conftest.
- Full suite: 555 passing; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added button controls for supported systems, including a re-detect action and an inverter restart action where available.
  * Improved support for EMS setups with additional integration setup coverage.

* **Bug Fixes**
  * Cached plant data is now cleaned up when the integration is removed, helping avoid stale state after reinstalling or re-adding it.
  * Re-detecting a plant now refreshes the integration more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->