### PR TITLE
feat: adopt givenergy-modbus 2.8.0 + fault/warning code sensors

### DIFF
--- a/.github/workflows/bump-givenergy-modbus.yml
+++ b/.github/workflows/bump-givenergy-modbus.yml
@@ -81,11 +81,13 @@ jobs:
           python3 - <<'PY'
           import os, re, pathlib, glob
           new = os.environ["NEW"]
-          # Match "givenergy-modbus>=<version>" capturing the version as a
-          # separate group that stops at the next comma or closing quote;
-          # this handles pre-release suffixes (e.g. "1.2.0a1") in the
-          # existing pin without leaving the suffix glued to the new version.
-          pattern = re.compile(r'("givenergy-modbus>=)[^",]+(.*?")')
+          # Rewrite the givenergy-modbus requirement to an exact ==<new> pin,
+          # whatever operator or bounds it currently carries. The integration
+          # pins modbus exactly (we own both sides of the ecosystem, so each
+          # bump is a deliberate sync); the whole quoted requirement is replaced
+          # wholesale, matching the legacy ">=x,<y" range and the current "==x"
+          # shape alike, including pre-release suffixes.
+          pattern = re.compile(r'"givenergy-modbus[^"]*"')
 
           targets = ["pyproject.toml", *glob.glob("custom_components/*/manifest.json")]
           for path in targets:
@@ -93,7 +95,7 @@ jobs:
               if not p.exists():
                   continue
               text = p.read_text()
-              updated, n = pattern.subn(rf'\g<1>{new}\g<2>', text)
+              updated, n = pattern.subn(f'"givenergy-modbus=={new}"', text)
               if n == 0:
                   print(f"warning: no givenergy-modbus pin found in {path}")
                   continue

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus>=2.7.1,<3.0.0"
+    "givenergy-modbus==2.8.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -286,7 +286,21 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
     GivEnergyInverterSensorDescription(
         key="fault_code",
         name="Fault Code",
-        value_fn=lambda inv: inv.fault_code,
+        # modbus 2.8.0 split the old combined fault_code into two 16-bit words and
+        # dropped the deprecated alias from ThreePhaseInverter (it raised on 3ph).
+        # Read IR39 directly; key stays "fault_code" to keep the entity ID, recorder
+        # history, and the dashboard row that's slugged on it.
+        value_fn=lambda inv: inv.inverter_fault_code,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyInverterSensorDescription(
+        # key is "warning_code" (not the library attr inverter_warning_code) to
+        # mirror its sibling "fault_code" — both are user-facing slugs, matching
+        # the existing convention where key="fault_code" reads inverter_fault_code.
+        key="warning_code",
+        name="Warning Code",
+        # IR40 — the warning half split out of the old fault_code in modbus 2.8.0.
+        value_fn=lambda inv: inv.inverter_warning_code,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     GivEnergyInverterSensorDescription(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ version = "0.0.0"
 description = "Home Assistant custom component for GivEnergy inverters via local Modbus TCP"
 requires-python = ">=3.14.2"
 dependencies = [
-    "givenergy-modbus>=2.7.1,<3.0.0",
+    # Exact-pinned, not a floating range: we own both sides of this ecosystem,
+    # so syncing deliberately on each modbus release (and keeping the dev venv
+    # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
+    # an upstream patch that wasn't validated against this integration. Bump both
+    # this and manifest.json together.
+    "givenergy-modbus==2.8.0",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,10 @@ def mock_inverter() -> MagicMock:
     inv.precision_of = SinglePhaseInverter.precision_of
     inv.status = MagicMock()
     inv.status.name = "NORMAL"
-    inv.fault_code = "00000000"
+    # modbus 2.8.0 split the old 8-hex fault_code into IR39 (fault) + IR40 (warning),
+    # each a 4-hex word. Mirror the real model's rendering.
+    inv.inverter_fault_code = "0000"
+    inv.inverter_warning_code = "0000"
     inv.model = MagicMock()
     inv.model.name = "HYBRID"
     inv.firmware_version = "D0.19-A0.21"

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = ">=2.7.1,<3.0.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.8.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.7.1"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/16/98c31052e3af6c0bdab6f3c6be3312b7659e0a85c36b2851ca7f0ee605fb/givenergy_modbus-2.7.1.tar.gz", hash = "sha256:8e0d56da78b4a39a70cab8f004011a0ca8773e2ff68e999425afc51bc560847f", size = 486329, upload-time = "2026-06-29T11:26:01.959Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/2f/7313d672838b4f1de53d7c4dfb23b90f6384a5ab0fd11de888802f9d6899/givenergy_modbus-2.8.0.tar.gz", hash = "sha256:e8630c71af516592b17889fbb5e81d454e86bee2a2ec6ab4ff6f14fc923ca4ae", size = 491435, upload-time = "2026-06-29T13:29:44.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/bf/2bfaf504d7cd7b05555617323a1ab4e7be55d49a71010fd44cbf26a5de21/givenergy_modbus-2.7.1-py3-none-any.whl", hash = "sha256:6ca9f68163d20175067a866d55aed361a28c81da7a680aaa9f9862d22d303bd3", size = 190721, upload-time = "2026-06-29T11:26:00.434Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/67/0322a797abc0c7ff13661df157b6be1baf72dc43f64103caf2e76b8ff40b/givenergy_modbus-2.8.0-py3-none-any.whl", hash = "sha256:475795cd057d3ea8871ce6c305df80c4522841164f0d63867c2e6804c6dafc75", size = 193651, upload-time = "2026-06-29T13:29:42.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Deliberate adoption of givenergy-modbus 2.8.0, pinned exactly (`==2.8.0`) in both `pyproject.toml` and `manifest.json` rather than left floating. Since both sides of this ecosystem are maintained together, syncing on each modbus release is easier to reason about than auto-floating onto an upstream patch that wasn't validated against this integration.

## Changes

- **Pin `givenergy-modbus==2.8.0`** (both pins + `uv.lock`).
- **Fault Code sensor migrated.** 2.8.0 splits the old combined `fault_code` into `inverter_fault_code` (IR39) + `inverter_warning_code` (IR40) and removes the deprecated `fault_code` alias from `ThreePhaseInverter` — direct access raised `AttributeError` on 3-phase. The sensor now reads `inverter_fault_code`; the entity key stays `fault_code`, so the entity ID, recorder history, and the dashboard row keyed on it are unchanged.
- **New Warning Code sensor** for `inverter_warning_code` (IR40), the warning half that the split newly exposes.

## Heads-up: Inverter Export Total discontinuity

2.8.0 rescales `e_inverter_export_total` to 0.1 kWh (the library's correction — the prior value read 10× high). The surfaced total drops to a tenth on the first poll after upgrading. As a `TOTAL_INCREASING` sensor this shows as a one-time downward step in the Energy Dashboard rather than a negative spike; no code change is needed, but it's worth calling out in the release note.

## Test plan

- [x] `ruff check` / `ruff format` clean
- [x] `mypy` clean
- [x] `pytest --cov` — 566 passed, 94.94% (floor 90)
- [x] `npm test` — 42 passed
- [x] `test_inverter_value_fns_resolve_against_three_phase_model` (the regression guard that failed on the `fault_code` break) now green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a separate diagnostic warning code sensor so inverter fault and warning information are shown independently.
* **Bug Fixes**
  * Updated the existing fault code sensor to report the correct inverter fault value.
* **Chores**
  * Pinned the modbus dependency to a specific supported release for consistency.
  * Aligned test data with the updated fault and warning code handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->