### PR TITLE
chore(deps): adopt givenergy-modbus 2.9.2

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus==2.9.2"
+    "givenergy-modbus==2.9.3"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus==2.8.0"
+    "givenergy-modbus==2.9.2"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
     # an upstream patch that wasn't validated against this integration. Bump both
     # this and manifest.json together.
-    "givenergy-modbus==2.9.2",
+    "givenergy-modbus==2.9.3",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
     # an upstream patch that wasn't validated against this integration. Bump both
     # this and manifest.json together.
-    "givenergy-modbus==2.8.0",
+    "givenergy-modbus==2.9.2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = "==2.9.2" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.9.3" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.9.2"
+version = "2.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/48/c65b9f45efed2c84b67e4a32574c3cf622c37f0ee9524d70c22d5963ed21/givenergy_modbus-2.9.2.tar.gz", hash = "sha256:50ba5eb76eecc62a9c9ba7713adae9e88a5fce48603d19b47b6e05c31b459fdf", size = 500470, upload-time = "2026-06-29T21:24:55.106Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/39/f17f59afce49dd2186b665d5f67886f5851aafe5ce824f11a5db5f426cf1/givenergy_modbus-2.9.3.tar.gz", hash = "sha256:c452b57be9782721dd75b27b58135622fb1210bc6eb5b72505e910336ea81dc4", size = 502868, upload-time = "2026-06-30T11:41:28.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/fa/45b35a309bd8dc18f3d8a427a9ba2e7941e7d723634cdf9ddb98b8849486/givenergy_modbus-2.9.2-py3-none-any.whl", hash = "sha256:898e252a5b6f8a02e0371cac3f8a56be5b68e8717c99026e06cd11572b3fbabd", size = 196999, upload-time = "2026-06-29T21:24:53.664Z" },
+    { url = "https://files.pythonhosted.org/packages/54/41/9188f981fc371376abc9296a6f2e6604cc715942d507ecbcf03b52020bd7/givenergy_modbus-2.9.3-py3-none-any.whl", hash = "sha256:710ba26ea84af8448a4229abc6e5064cfcfde63fea7adee8ce2c2c3b0250404f", size = 198353, upload-time = "2026-06-30T11:41:27.046Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = "==2.8.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.9.2" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.8.0"
+version = "2.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/2f/7313d672838b4f1de53d7c4dfb23b90f6384a5ab0fd11de888802f9d6899/givenergy_modbus-2.8.0.tar.gz", hash = "sha256:e8630c71af516592b17889fbb5e81d454e86bee2a2ec6ab4ff6f14fc923ca4ae", size = 491435, upload-time = "2026-06-29T13:29:44.033Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/48/c65b9f45efed2c84b67e4a32574c3cf622c37f0ee9524d70c22d5963ed21/givenergy_modbus-2.9.2.tar.gz", hash = "sha256:50ba5eb76eecc62a9c9ba7713adae9e88a5fce48603d19b47b6e05c31b459fdf", size = 500470, upload-time = "2026-06-29T21:24:55.106Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/67/0322a797abc0c7ff13661df157b6be1baf72dc43f64103caf2e76b8ff40b/givenergy_modbus-2.8.0-py3-none-any.whl", hash = "sha256:475795cd057d3ea8871ce6c305df80c4522841164f0d63867c2e6804c6dafc75", size = 193651, upload-time = "2026-06-29T13:29:42.325Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/fa/45b35a309bd8dc18f3d8a427a9ba2e7941e7d723634cdf9ddb98b8849486/givenergy_modbus-2.9.2-py3-none-any.whl", hash = "sha256:898e252a5b6f8a02e0371cac3f8a56be5b68e8717c99026e06cd11572b3fbabd", size = 196999, upload-time = "2026-06-29T21:24:53.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts givenergy-modbus **2.9.2**, completing the modbus #268 epic. Exact pin bumped `==2.8.0` → `==2.9.2` in `pyproject.toml` + `manifest.json` (+ `uv.lock`), per the deliberate-sync policy.

## What 2.9.x brings
- **2.9.0** — `Plant.from_caches()` offline construction, a tri-state register-block presence marker, and an internal `detect()` refactor (`_strategise`/`_probe_ranges`/`_derive_capabilities`) with stale-cache eviction on every probe-failure path. No public API change.
- **2.9.1** — `refresh(max_age=)` generalises skip-if-fresh to every IR bank; the old `ir0_max_age=` is now a deprecated alias (removed in 3.0).
- **2.9.2** — `refresh()` skips banks `detect()` marked absent (~2s/tick saving in the capabilities-as-target case).

## Why no code change
The coordinator's entire modbus call surface is `detect(prior=, probe_timeout=, probe_retries=)`, `refresh(retries=)` and `load_config(retries=)` — all keep identical signatures in 2.9.2 (verified by introspection). We never passed `ir0_max_age`, so the deprecation doesn't apply and `deprecation watch` stays green. Adopting `max_age=` is deliberately deferred to a separate, independently-validated change.

## Why rc
The headline change is behavioural: the `detect()` refactor reworks the detection hot path that surfaces batteries / EMS / HV stacks — the same machinery behind the #233 enumeration deadlock. So this is being cut as a **v1.3.32rc** pre-release for real-hardware validation before a stable v1.3.32.

## Test plan
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy` clean
- [x] 566 Python tests green against 2.9.2
- [x] 42 JS tests green
- [ ] Real-hardware validation via HACS pre-release (detection, battery/EMS/HV enumeration, poll stability)
