### PR TITLE
chore(deps): adopt givenergy-modbus 2.9.4 (#352 primary-battery routing fix)

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus==2.9.3"
+    "givenergy-modbus==2.9.4"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
     # an upstream patch that wasn't validated against this integration. Bump both
     # this and manifest.json together.
-    "givenergy-modbus==2.9.3",
+    "givenergy-modbus==2.9.4",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = "==2.9.3" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.9.4" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.9.3"
+version = "2.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/39/f17f59afce49dd2186b665d5f67886f5851aafe5ce824f11a5db5f426cf1/givenergy_modbus-2.9.3.tar.gz", hash = "sha256:c452b57be9782721dd75b27b58135622fb1210bc6eb5b72505e910336ea81dc4", size = 502868, upload-time = "2026-06-30T11:41:28.63Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/52/92bfaa929e67eabd5f0e09f350677aef1ec782bcd422f1da5d23c9a17b79/givenergy_modbus-2.9.4.tar.gz", hash = "sha256:448808cec3e097fe9de8921dfa71e7f59bb169dd4797090f3899a81c7375a799", size = 504754, upload-time = "2026-06-30T23:29:16.436Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/41/9188f981fc371376abc9296a6f2e6604cc715942d507ecbcf03b52020bd7/givenergy_modbus-2.9.3-py3-none-any.whl", hash = "sha256:710ba26ea84af8448a4229abc6e5064cfcfde63fea7adee8ce2c2c3b0250404f", size = 198353, upload-time = "2026-06-30T11:41:27.046Z" },
+    { url = "https://files.pythonhosted.org/packages/99/67/e49e8172ff27c7ae3b85eb31e65d957a63f1b188b7b4ceeca0932748c130/givenergy_modbus-2.9.4-py3-none-any.whl", hash = "sha256:e45803b973f6f0308ebc56e5650c32772df564209925f67b50bcceac1131187b", size = 198654, upload-time = "2026-06-30T23:29:14.834Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts givenergy-modbus **2.9.4**, which closes givenergy-modbus#352 — the routing quirk behind #350's primary-battery dropout.

## What 2.9.4 does
Makes the `0x32` (primary LV pack) battery/inverter routing unconditional, so a capabilities-absent detect/reconnect read goes through the battery splice guard, and gives `0x32` the same cold-start hold→corroborate→commit that `0x33`+ have had since 2.7.1. This extends the full battery guard to the primary on *every* corruption shape, not just the all-zero impossible one 2.9.3 already refused.

Patch release, no public API change — pure pin-bump (`==2.9.3` → `==2.9.4`).

## Why an rc
The reconnect/detect path only exercises once a day (~02:00 cloud-sync), it's the exact path #350 lived in, and its failure mode is silent. Per the modbus soak note, one live overnight reconnect is enough — it's a proven mechanism (`0x33`'s hold-corroborate since 2.7.1) extended to one more address, but a detect regression slipped past green CI during 2.9.4 review, so one live pass is worth confirming. To be cut as `v1.3.33rc1` and soaked one night.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] `detect()`/`refresh()`/`load_config()` signatures introspection-verified identical (no API change)
- [x] 566 Python + 42 JS tests green
- [ ] one overnight ~02:00 reconnect: `0x32` should now log the cold-start hold→corroborate→commit sequence (same as `0x33`), both packs stay listed, primary recovers within seconds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned `givenergy-modbus` dependency to version `2.9.4`.
  * Kept project configuration otherwise unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->