### PR TITLE
feat: native Predbat helper sensors — Battery SOC kWh + EMS load-energy integrals

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ When enabled, the integration connects to the inverter but sends no Modbus read 
 | PV Energy Today | kWh | |
 | PV Energy Total | kWh | |
 | Battery SOC | % | |
+| Battery SOC kWh | kWh | SOC × nominal capacity ([#248](https://github.com/dewet22/givenergy-hass/issues/248)) — nameplate-derived estimate, reads optimistic on aged packs |
 | Battery Power | W | Positive = discharging, negative = charging |
 | Battery Voltage / Current | V / A | |
 | Battery Temperature | °C | |
@@ -213,6 +214,16 @@ Cell-level entities are tagged as diagnostic, so they're hidden from the default
 #### AIO battery modules
 
 All-in-One systems expose each removable battery module separately, so on AIO hardware you'll see one extra device per module (parented to the AIO inverter) alongside the pack-level battery device. Each module device carries its `HX…` serial plus 24 per-cell voltages and 12 per-cell temperatures, all diagnostic. These mirror the LV per-cell entities, so the cell-heatmap card and the same pack-health views work at module granularity. Module data needs `givenergy-modbus` 2.2 or newer.
+
+### EMS controller device
+
+On an EMS plant the controller device carries plant-level aggregates the inverter registers don't: managed-inverter count, calculated/measured load power, grid meter power, total battery power and remaining battery energy. Two derived energy sensors build on the load aggregate:
+
+| Entity | Unit | Notes |
+|---|---|---|
+| EMS Calculated Load Energy Today / Total | kWh | Integrated client-side from *EMS Calculated Load Power* — the EMS rollup carries no energy counters, so no register-backed figure exists. An estimate, not a meter reading: it undercounts across restarts and outages (a sampling gap contributes at most one capped slice), though the accumulated value does survive Home Assistant restarts. |
+
+These replace the Integral + Utility Meter helpers a Predbat EMS setup previously had to hand-create ([#248](https://github.com/dewet22/givenergy-hass/issues/248)).
 
 ### Services
 

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -269,6 +269,18 @@ def _grid_import_power(inv: InverterModel) -> float | None:
     return max(-p, 0) if p is not None else None
 
 
+# SOC-scaled nominal capacity: the "soc_kw" figure Predbat wants per inverter (#248),
+# natively replacing the template-sensor helper users had to hand-create. Nameplate-
+# derived — battery_capacity_kwh is Ah × nominal voltage, not measured usable
+# capacity — so it reads optimistic on aged packs: an estimate, not a meter.
+def _soc_kwh(inv: InverterModel) -> float | None:
+    soc = getattr(inv, "battery_soc", None)
+    capacity = getattr(inv, "battery_capacity_kwh", None)
+    if soc is None or capacity is None:
+        return None
+    return soc / 100 * capacity
+
+
 INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
     # --- Status ---
     GivEnergyInverterSensorDescription(
@@ -1159,6 +1171,21 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         single_phase_only=True,
     ),
+    GivEnergyInverterSensorDescription(
+        key="soc_kwh",
+        name="Battery SOC kWh",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY_STORAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        value_fn=_soc_kwh,
+        # Derived, not register-backed: gate off EMS controllers (there the
+        # per-inverter figure belongs to per-inverter entries) and drop wherever
+        # either input is absent.
+        skip_if_none=True,
+        skip_if_ems=True,
+        single_phase_only=True,
+    ),
 )
 
 BATTERY_SENSORS: tuple[GivEnergyBatterySensorDescription, ...] = (
@@ -1746,6 +1773,27 @@ EMS_SENSORS: tuple[GivEnergyEmsSensorDescription, ...] = (
     ),
 )
 
+# Load-energy integrals (#248). Deliberately NOT in EMS_SENSORS: the generic setup
+# loop would build plain GivEnergyEmsSensor instances, and these need the
+# integrating subclass. value_fn is unused — GivEnergyEmsLoadEnergySensor
+# overrides native_value with its accumulator.
+EMS_LOAD_ENERGY_TOTAL = GivEnergyEmsSensorDescription(
+    key="ems_calc_load_energy_total",
+    name="EMS Calculated Load Energy Total",
+    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    device_class=SensorDeviceClass.ENERGY,
+    state_class=SensorStateClass.TOTAL_INCREASING,
+    suggested_display_precision=2,
+)
+EMS_LOAD_ENERGY_TODAY = GivEnergyEmsSensorDescription(
+    key="ems_calc_load_energy_today",
+    name="EMS Calculated Load Energy Today",
+    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    device_class=SensorDeviceClass.ENERGY,
+    state_class=SensorStateClass.TOTAL_INCREASING,
+    suggested_display_precision=2,
+)
+
 
 def _partial_failure_attributes(
     coordinator: GivEnergyUpdateCoordinator,
@@ -1974,6 +2022,13 @@ async def async_setup_entry(
         # (#201): managed-inverter count, calculated/measured load, grid-meter
         # power, total battery power and remaining battery energy.
         entities.extend(GivEnergyEmsSensor(coordinator, description) for description in EMS_SENSORS)
+        # Load energy exists only as an integral of calc_load_power on EMS (#248).
+        entities.append(
+            GivEnergyEmsLoadEnergySensor(coordinator, EMS_LOAD_ENERGY_TOTAL, daily_reset=False)
+        )
+        entities.append(
+            GivEnergyEmsLoadEnergySensor(coordinator, EMS_LOAD_ENERGY_TODAY, daily_reset=True)
+        )
 
     for battery_index, battery in enumerate(coordinator.data.batteries):
         entities.extend(
@@ -2790,6 +2845,105 @@ class GivEnergyEmsSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEn
         if ems is None:
             return None
         return self.entity_description.value_fn(ems)
+
+
+# Poll gaps beyond this many scan intervals contribute a single capped slice to the
+# load-energy integral, so an outage can't be billed as a rectangle of stale power.
+_LOAD_ENERGY_GAP_SCANS = 3
+# Fallback cap when the coordinator carries no update interval (never in practice).
+_LOAD_ENERGY_GAP_FLOOR = 300.0
+
+
+class GivEnergyEmsLoadEnergySensor(GivEnergyEmsSensor, RestoreEntity):
+    """Client-side integral of EMS calculated load power (#248).
+
+    The EMS rollup carries no energy counters and the site PV is only visible as
+    meter power samples, so on an EMS plant house-load energy exists solely as a
+    live power signal — there is nothing register-backed to read or balance
+    against (settled empirically against real EMS captures). This integrates
+    calc_load_power (IR2086) at poll cadence; measured_load_power reads a
+    constant zero on real sites and is deliberately not a fallback.
+
+    An estimate, not a meter: every failure mode undercounts, never overcounts.
+    The accumulator restores across HA restarts, and any sampling gap (restart,
+    outage, stalled polls) contributes at most one gap-capped slice.
+    """
+
+    def __init__(
+        self,
+        coordinator: GivEnergyUpdateCoordinator,
+        description: GivEnergyEmsSensorDescription,
+        *,
+        daily_reset: bool,
+    ) -> None:
+        super().__init__(coordinator, description)
+        self._daily_reset = daily_reset
+        self._total_kwh = 0.0
+        self._day: date | None = None
+        self._last_sample_at: datetime | None = None
+        self._last_mark: datetime | None = None
+        interval = coordinator.update_interval
+        self._gap_cap = (
+            _LOAD_ENERGY_GAP_SCANS * interval.total_seconds()
+            if interval
+            else _LOAD_ENERGY_GAP_FLOOR
+        )
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is None:
+            return
+        try:
+            restored = float(last_state.state)
+        except ValueError, TypeError:
+            return
+        last_date = dt_util.as_local(last_state.last_updated).date()
+        if self._daily_reset and last_date != dt_util.now().date():
+            # A prior-day value is spent; today restarts from zero.
+            self._day = dt_util.now().date()
+        else:
+            self._total_kwh = max(restored, 0.0)
+            self._day = last_date
+        # Seed the sample clock from the persisted timestamp either way, so the
+        # first post-restart refresh adds a (gap-capped) slice for the downtime
+        # rather than silently free-running from zero elapsed.
+        self._last_sample_at = last_state.last_updated
+
+    def _integrate(self) -> None:
+        """Accumulate once per successful refresh (idempotent across repeat reads)."""
+        mark = self.coordinator.last_successful_refresh
+        if mark is None or mark == self._last_mark:
+            return
+        ems = self.coordinator.data.ems
+        power = getattr(ems, "calc_load_power", None) if ems is not None else None
+        now = dt_util.utcnow()
+        if power is None:
+            # A successful refresh without a load sample (rollup bank missing or
+            # partial) consumes the sample boundary: advance the clock and mark
+            # without adding energy, so a later valid sample can't bridge the
+            # unknown interval at its own power — undercount, never overcount.
+            self._last_sample_at = now
+            self._last_mark = mark
+            return
+        if self._daily_reset:
+            today = dt_util.now().date()
+            if self._day != today:
+                # The midnight-spanning slice lands wholly in the new day — at
+                # most one scan interval of misattribution.
+                self._total_kwh = 0.0
+                self._day = today
+        if self._last_sample_at is not None:
+            elapsed = (now - self._last_sample_at).total_seconds()
+            if elapsed > 0:
+                self._total_kwh += power * min(elapsed, self._gap_cap) / 3_600_000
+        self._last_sample_at = now
+        self._last_mark = mark
+
+    @property
+    def native_value(self) -> float | None:
+        self._integrate()
+        return self._total_kwh
 
 
 class GivEnergyCoordinatorSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity):

--- a/prek.toml
+++ b/prek.toml
@@ -4,6 +4,11 @@
 
 ci = { autofix_prs = false }
 
+# Hook envs must parse the py3.14-only syntax ruff enforces (target-version
+# py314, e.g. PEP 758 unparenthesised except) — prek's managed default
+# interpreter is older and chokes on it in check-ast.
+default_language_version = { python = "python3.14" }
+
 [[repos]]
 repo = "https://github.com/pre-commit/pre-commit-hooks"
 rev = "v6.0.0"

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -5,14 +5,17 @@ None); the shared fixtures default ems to None, so here we override it with a
 mock Ems before setting up the integration.
 """
 
-from unittest.mock import MagicMock
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from givenergy_modbus.model.devices import InverterSummary
 from givenergy_modbus.model.inverter import Model
+from homeassistant.core import State
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.util import dt as dt_util
 
 from custom_components.givenergy_local.const import DOMAIN
 
@@ -394,6 +397,7 @@ async def test_inverter_sensors_kept_on_ems_except_gated(hass, ems_setup):
     assert _entity_id(hass, "sensor", "SA1234G123_e_self_consumption_today") is None
     assert _entity_id(hass, "sensor", "SA1234G123_e_self_consumption_total") is None
     assert _entity_id(hass, "sensor", "SA1234G123_e_pv_direct_today") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_soc_kwh") is None
 
 
 async def test_inverter_controls_suppressed_on_ems_plant(hass, ems_setup):
@@ -470,6 +474,8 @@ async def test_no_ems_sensors_for_non_ems_plant(hass, setup_integration):
     """A non-EMS plant must not get the EMS aggregate sensors."""
     assert _entity_id(hass, "sensor", "SA1234G123_ems_grid_meter_power") is None
     assert _entity_id(hass, "sensor", "SA1234G123_ems_inverter_count") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_ems_calc_load_energy_total") is None
+    assert _entity_id(hass, "sensor", "SA1234G123_ems_calc_load_energy_today") is None
 
 
 def test_ems_measured_load_power_hidden_by_default():
@@ -503,8 +509,166 @@ def test_inverter_sensors_gated_off_ems():
         "e_self_consumption_total",
         # DC-coupled GEN1 only; not validated on EMS controllers.
         "e_pv_direct_today",
+        # Derived figure; on EMS plants the per-inverter soc_kwh belongs to the
+        # per-inverter config entries, not the controller (#248).
+        "soc_kwh",
     }
     desc = next(d for d in INVERTER_SENSORS if d.key == "p_load_demand")
     inv = MagicMock()
     assert _include_inverter_sensor(desc, inv, False, False, True) is False
     assert _include_inverter_sensor(desc, inv, False, False, False) is True
+
+
+# ---------------------------------------------------------------------------
+# EMS load-energy integrals (#248)
+# ---------------------------------------------------------------------------
+
+
+def _load_energy_entity(mock_plant, mock_ems, *, daily=False):
+    """A bare integrator entity against a mocked coordinator (no hass setup)."""
+    from custom_components.givenergy_local.sensor import (
+        EMS_LOAD_ENERGY_TODAY,
+        EMS_LOAD_ENERGY_TOTAL,
+        GivEnergyEmsLoadEnergySensor,
+    )
+
+    mock_plant.ems = mock_ems
+    mock_plant.inverter.model = Model.EMS
+    mock_ems.calc_load_power = 1200  # 0.01 kWh per 30 s poll
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.last_successful_refresh = None
+    coordinator.update_interval = timedelta(seconds=30)
+    coordinator.data = mock_plant
+    desc = EMS_LOAD_ENERGY_TODAY if daily else EMS_LOAD_ENERGY_TOTAL
+    return GivEnergyEmsLoadEnergySensor(coordinator, desc, daily_reset=daily), coordinator
+
+
+def _refresh(entity, coordinator):
+    """Mark a successful coordinator refresh and read the accumulated value."""
+    coordinator.last_successful_refresh = dt_util.utcnow()
+    return entity.native_value
+
+
+def test_load_energy_integrates_per_poll(mock_plant, mock_ems, freezer):
+    """1200 W over a 30 s poll interval accumulates 0.01 kWh per slice."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity, coordinator = _load_energy_entity(mock_plant, mock_ems)
+
+    assert _refresh(entity, coordinator) == 0.0  # first sample only seeds the clock
+    freezer.tick(30)
+    assert _refresh(entity, coordinator) == pytest.approx(0.01)
+    freezer.tick(30)
+    assert _refresh(entity, coordinator) == pytest.approx(0.02)
+
+
+def test_load_energy_repeat_reads_are_idempotent(mock_plant, mock_ems, freezer):
+    """Repeat state reads within one refresh cycle must not double-integrate, and
+    time passing without a new successful-refresh mark accumulates nothing."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity, coordinator = _load_energy_entity(mock_plant, mock_ems)
+    _refresh(entity, coordinator)
+    freezer.tick(30)
+    assert _refresh(entity, coordinator) == pytest.approx(0.01)
+    assert entity.native_value == pytest.approx(0.01)  # same mark: no change
+    freezer.tick(30)
+    assert entity.native_value == pytest.approx(0.01)  # stale mark: outage pending
+
+
+def test_load_energy_missing_sample_consumes_boundary(mock_plant, mock_ems, freezer):
+    """A successful refresh without a load sample must not be bridged by the
+    next valid one: the unknown interval contributes nothing (Codex, #249).
+    1200 W / None / 1200 W over 30 s steps is 0.01 kWh, not 0.02."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity, coordinator = _load_energy_entity(mock_plant, mock_ems)
+    _refresh(entity, coordinator)
+    freezer.tick(30)
+    mock_ems.calc_load_power = None
+    assert _refresh(entity, coordinator) == 0.0
+    freezer.tick(30)
+    mock_ems.calc_load_power = 1200
+    assert _refresh(entity, coordinator) == pytest.approx(0.01)
+
+
+def test_load_energy_gap_capped(mock_plant, mock_ems, freezer):
+    """An hour-long sampling gap contributes one capped slice (3 polls = 90 s),
+    not a rectangle of stale power — outages undercount, never overcount."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity, coordinator = _load_energy_entity(mock_plant, mock_ems)
+    _refresh(entity, coordinator)
+    freezer.tick(30)
+    assert _refresh(entity, coordinator) == pytest.approx(0.01)
+    freezer.tick(3600)
+    assert _refresh(entity, coordinator) == pytest.approx(0.01 + 0.03)
+
+
+def test_load_energy_today_resets_at_midnight(mock_plant, mock_ems, freezer):
+    """The today integral re-baselines at the local date flip; the (capped)
+    midnight-spanning slice lands wholly in the new day."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity, coordinator = _load_energy_entity(mock_plant, mock_ems, daily=True)
+    _refresh(entity, coordinator)
+    freezer.tick(30)
+    assert _refresh(entity, coordinator) == pytest.approx(0.01)
+    freezer.tick(24 * 3600)
+    assert _refresh(entity, coordinator) == pytest.approx(0.03)
+    freezer.tick(30)
+    assert _refresh(entity, coordinator) == pytest.approx(0.04)
+
+
+def test_load_energy_total_survives_midnight(mock_plant, mock_ems, freezer):
+    """The lifetime integral carries straight through the date flip."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity, coordinator = _load_energy_entity(mock_plant, mock_ems)
+    _refresh(entity, coordinator)
+    freezer.tick(30)
+    assert _refresh(entity, coordinator) == pytest.approx(0.01)
+    freezer.tick(24 * 3600)
+    assert _refresh(entity, coordinator) == pytest.approx(0.04)  # 0.01 + capped 0.03
+
+
+async def test_load_energy_restores_across_restart(hass, mock_plant, mock_ems, freezer):
+    """The accumulator seeds from the recorder and the persisted timestamp seeds
+    the sample clock, so restart downtime costs at most one capped slice."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity, coordinator = _load_energy_entity(mock_plant, mock_ems)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_load_energy_total"
+    entity.async_get_last_state = AsyncMock(
+        return_value=State(
+            entity.entity_id,
+            "1.5",
+            last_updated=dt_util.utcnow() - timedelta(seconds=45),
+        )
+    )
+    await entity.async_added_to_hass()
+    # 45 s of downtime, under the 90 s cap, is credited in full on first refresh.
+    assert _refresh(entity, coordinator) == pytest.approx(1.5 + 0.015)
+
+
+async def test_load_energy_today_restore_prior_day(hass, mock_plant, mock_ems, freezer):
+    """A today-value persisted yesterday is spent: restore starts the day from
+    zero, and only the capped catch-up slice lands in it."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    entity, coordinator = _load_energy_entity(mock_plant, mock_ems, daily=True)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_load_energy_today"
+    entity.async_get_last_state = AsyncMock(
+        return_value=State(
+            entity.entity_id,
+            "5.5",
+            last_updated=dt_util.utcnow() - timedelta(hours=24),
+        )
+    )
+    await entity.async_added_to_hass()
+    assert _refresh(entity, coordinator) == pytest.approx(0.03)
+
+
+async def test_load_energy_entities_created_on_ems(hass, ems_setup):
+    """Both integrals surface on the controller device, starting from zero."""
+    total = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_ems_calc_load_energy_total"))
+    today = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_ems_calc_load_energy_today"))
+    assert total.state == "0.0"
+    assert today.state == "0.0"
+    assert total.attributes["unit_of_measurement"] == "kWh"
+    assert total.attributes["state_class"] == "total_increasing"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -183,7 +183,7 @@ def test_single_phase_only_sensors_gated_on_three_phase():
     permanently-unavailable orphan entities on three-phase inverters (#94), and
     t_battery would read a frozen, unpopulated single-phase register there (#174)."""
     inv = MagicMock()
-    gated_keys = {"p_pv", "e_pv_day", "battery_capacity_kwh", "t_battery"}
+    gated_keys = {"p_pv", "e_pv_day", "battery_capacity_kwh", "t_battery", "soc_kwh"}
 
     # Every gated key must actually carry the flag (guards against silent drift if
     # one is renamed/removed) ...
@@ -353,6 +353,29 @@ async def test_battery_soc_sensor(hass, setup_integration):
     state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_battery_soc"))
     assert state.state == "85"
     assert state.attributes["unit_of_measurement"] == "%"
+
+
+def test_soc_kwh_value_fn():
+    """#248: SOC-scaled nominal capacity — the Predbat soc_kw figure — is
+    None-safe on either missing input (skip_if_none then drops the sensor)."""
+    desc = _inverter_desc("soc_kwh")
+    inv = MagicMock()
+    inv.battery_soc = 85
+    inv.battery_capacity_kwh = 8.19
+    assert desc.value_fn(inv) == pytest.approx(6.9615)
+    inv.battery_soc = None
+    assert desc.value_fn(inv) is None
+    inv.battery_soc = 85
+    inv.battery_capacity_kwh = None
+    assert desc.value_fn(inv) is None
+
+
+async def test_soc_kwh_sensor_reads(hass, setup_integration):
+    """#248: Battery SOC kWh surfaces natively (85% of 8.19 kWh nominal)."""
+    state = hass.states.get(_entity_id(hass, "sensor", "SA1234G123_soc_kwh"))
+    assert float(state.state) == pytest.approx(6.9615)
+    assert state.attributes["unit_of_measurement"] == "kWh"
+    assert state.attributes["device_class"] == "energy_storage"
 
 
 async def test_grid_power_sensor_negative_is_import(hass, setup_integration):


### PR DESCRIPTION
Closes #248 — the two helper sets a Predbat install previously had to hand-create now ship natively.

## Battery SOC kWh (per inverter)
`SOC% × nominal capacity` — the Predbat `soc_kw` figure. Nameplate-derived (`battery_capacity_kwh` is Ah × nominal voltage, not measured usable capacity), so it reads optimistic on aged packs; documented as an estimate. `single_phase_only` (capacity field absent on 3ph), `skip_if_none`, and `skip_if_ems` — on an EMS plant the per-inverter figure belongs to the per-inverter entries, not the controller (pinned-set tests updated accordingly).

## EMS Calculated Load Energy Today / Total
Client-side integrals of `calc_load_power` on the EMS controller device. The register-derived alternative was investigated first and ruled out empirically against real EMS captures: the EMS rollup carries **no** energy counters, the site PV is only visible as meter *power* samples, per-inverter grid dailies are CT-position-dependent, and `e_pv_generation_today` on managed AC units mislabels the unit's own output. Load energy on an EMS exists only as a live power signal — so the integral is engineered for its failure modes rather than pretending it doesn't have them:

- accumulator **restores across HA restarts** (the persisted timestamp seeds the sample clock, so downtime costs at most one capped slice)
- sampling gaps are **capped at 3 polls** — an outage can't be billed as a rectangle of stale power
- accumulation is **idempotent per successful refresh** (keyed on the coordinator's refresh mark, so repeat state reads can't double-integrate)
- every failure mode **undercounts, never overcounts**; caveats published in the README
- `measured_load_power` is deliberately **not** a fallback (constant zero on real sites)
- the *Today* variant re-baselines at the local date flip; *Total* carries through

## Test plan
- [x] +10 tests: integration math, gap capping, idempotency, midnight reset (today) vs carry-through (total), restart restore incl. prior-day, EMS gating both ways, soc_kwh arithmetic + None-safety
- [x] 576 Python + 42 JS green, coverage 94.9% (floor 90)
- [x] ruff / ruff format / mypy clean
- [ ] Nick (reporter) validates on his EMS + per-inverter Predbat setup once released

## Tooling (in the diff)
`prek.toml` gains `default_language_version = { python = "python3.14" }`: prek's managed default interpreter is 3.11, which can't parse the PEP 758 except syntax ruff enforces at `target-version py314` — the mismatch blocked any commit touching `sensor.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new battery state-of-charge estimate in kWh for supported inverters.
  * Added EMS load energy readings for today and total, shown as energy sensors.
  * Improved the README with updated sensor and EMS device documentation.

* **Bug Fixes**
  * Smoothed EMS load energy tracking across refreshes, gaps, and restarts.
  * Ensured unsupported setups do not show the new EMS-only sensors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->