### PR TITLE
fix: disambiguate HV stack device names + gate House Consumption off AIO

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -11,6 +11,7 @@ from typing import TypedDict
 
 import voluptuous as vol
 from givenergy_modbus.client import commands
+from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
@@ -499,6 +500,21 @@ def _reconcile_ems_entities(hass: HomeAssistant, entry: ConfigEntry, serial: str
             registry.async_remove(ent.entity_id)
 
 
+def _reconcile_aio_house_consumption(hass: HomeAssistant, serial: str) -> None:
+    """Remove the derived House Consumption Today row on an AIO entry (#95).
+
+    The sensor is gated off AIO — its PV/grid inputs are the registers whose
+    identity is under investigation upstream (modbus#293), and AIO units report
+    no raw consumption figure — but an upgraded entry keeps the stale registry
+    row when the platform stops creating it.
+    """
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_e_consumption_today")
+    if entity_id is not None:
+        _LOGGER.info("Removing %s: derived consumption is gated off AIO (#95)", entity_id)
+        registry.async_remove(entity_id)
+
+
 def _remove_stale_control(registry: er.EntityRegistry, serial: str, domain: str, key: str) -> None:
     """Remove a readability-gated control's stale registry row, if present (#207)."""
     entity_id = registry.async_get_entity_id(domain, DOMAIN, f"{serial}_{key}")
@@ -837,6 +853,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # version (or a prior opt-in) created, so the toggle cleans up rather than
     # leaving orphaned/unavailable cell entities (#179).
     _reconcile_per_cell_entities(hass, entry)
+
+    # House Consumption Today is gated off AIO (#95): remove the stale row an
+    # upgraded AIO entry would otherwise keep as orphaned/unavailable. Strictly
+    # ALL_IN_ONE, matching the skip_if_aio creation gate (AIO_HYBRID has real PV).
+    capabilities = coordinator.data.capabilities
+    if capabilities is not None and capabilities.device_type is Model.ALL_IN_ONE:
+        _reconcile_aio_house_consumption(hass, coordinator.data.inverter_serial_number)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -808,6 +808,10 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         # computes a per-controller figure (e.g. -9.8) rather than whole-plant load;
         # the EMS load aggregates cover it there instead (#201).
         skip_if_ems=True,
+        # Also meaningless on AIO (#95): the derivation's PV/grid inputs are the
+        # registers whose identity is under investigation there (modbus#293), and
+        # AIO units report no raw consumption figure to fall back on.
+        skip_if_aio=True,
         # Resolves per-model: e_load_today isn't in the single-phase LUT (the
         # derived value stays untracked for staleness), but on three-phase it
         # names the native register the value_fn falls back to (#152/#158).
@@ -2625,11 +2629,14 @@ class GivEnergyHvStackSensor(
         self._init_stale_gate(coordinator, type(stack.bcu), description.key)
         inv_serial = coordinator.data.inverter_serial_number
         device_id = f"{inv_serial}_hvstack_{stack.device_address:#04x}"
-        # Only disambiguate the device name by address when there's more than one
-        # stack, so the common single-stack case stays clean.
-        name = "GivEnergy HV Battery Stack"
-        if len(stacks) > 1:
-            name = f"{name} {stack.device_address:#04x}"
+        # Name = parent serial (a BCU has no serial of its own) + the stack's bus
+        # address. The address is deliberately the SAME token used by the device
+        # id, the modbus logs, givenergy-cli and the Comms per_device attributes —
+        # one namespace, nothing to cross-map (a friendlier "Stack 1/2/3" would
+        # add an off-by-one trap against 0x70/0x71 in every log line). Carrying
+        # the serial keeps names unique across config entries: two AIOs each with
+        # one identically-named stack would otherwise slug the second to "_2" (#95).
+        name = f"GivEnergy HV Battery {inv_serial} Stack {stack.device_address:#04x}"
         self._attr_unique_id = f"{device_id}_{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device_id)},

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -150,9 +150,11 @@ def test_aio_inapplicable_inverter_sensors_skip_if_none():
 def test_aio_inapplicable_inverter_sensors_gated_on_aio():
     """MPPT Count, Solar Diverter and Battery Discharge This Year read a meaningless
     value (0, 0.0, a static figure) — not None — on an AIO, so skip_if_none never
-    dropped them. They're gated on AIO topology instead (#95)."""
+    dropped them. They're gated on AIO topology instead (#95). House Consumption
+    Today joins them: its PV/grid inputs are under identity investigation on AIO
+    (modbus#293) and the unit reports no raw consumption figure."""
     inv = MagicMock()  # every attr returns a truthy mock, i.e. "not None"
-    aio_gated = {"num_mppt", "e_solar_diverter", "e_discharge_year"}
+    aio_gated = {"num_mppt", "e_solar_diverter", "e_discharge_year", "e_consumption_today"}
     flagged = {d.key for d in INVERTER_SENSORS if d.skip_if_aio}
     assert flagged == aio_gated
     for key in aio_gated:
@@ -1260,7 +1262,7 @@ async def test_hv_stack_creates_one_device(hass, hv_setup):
     device = dev_registry.async_get(registry.async_get(entity_id).device_id)
     assert device is not None
     assert (DOMAIN, device_id) in device.identifiers
-    assert device.name == "GivEnergy HV Battery Stack"
+    assert device.name == "GivEnergy HV Battery SA1234G123 Stack 0x70"
     assert device.model == "HV Battery Stack (BCU)"
     assert device.sw_version == "GA000009"
     inverter_device = dev_registry.async_get_device(identifiers={(DOMAIN, "SA1234G123")})
@@ -1276,11 +1278,52 @@ async def test_aio_model_suppresses_pv_sensors_even_with_empty_modules(hass, hv_
     """The AIO gate keys off the detected model (Model.ALL_IN_ONE, restored from the
     capabilities cache), not decoded module telemetry. hv_setup is an AIO whose
     aio_battery_modules list is empty (the cold-start / transient-drop case), yet the
-    PV/solar-only inverter sensors must still be suppressed (#95, review)."""
+    PV/solar-only inverter sensors must still be suppressed (#95, review). The derived
+    House Consumption Today joins the gated set: its PV/grid inputs are under identity
+    investigation on AIO (modbus#293) and there is no raw backing figure."""
     registry = er.async_get(hass)
-    for key in ("num_mppt", "e_solar_diverter", "e_discharge_year"):
+    for key in ("num_mppt", "e_solar_diverter", "e_discharge_year", "e_consumption_today"):
         assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is None, key
     # Sanity: the inverter-sensor loop did run (only the PV/solar fields were gated).
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_system_mode") is not None
+
+
+async def test_hv_stack_names_unique_across_stacks(hass, mock_client, mock_config_entry):
+    """Stack device names carry serial + bus address — the same token as the device
+    id, logs, CLI and diagnostics (one namespace, no off-by-one mapping) — so
+    multi-stack and multi-entry installs never collide into HA's "_2" slug (#95)."""
+    _setup_hv_plant(
+        mock_client,
+        [_mock_hv_stack(0x70, _mock_bcu()), _mock_hv_stack(0x72, _mock_bcu())],
+    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    dev_registry = dr.async_get(hass)
+    names = {
+        d.name
+        for d in dr.async_entries_for_config_entry(dev_registry, mock_config_entry.entry_id)
+        if d.model == "HV Battery Stack (BCU)"
+    }
+    assert names == {
+        "GivEnergy HV Battery SA1234G123 Stack 0x70",
+        "GivEnergy HV Battery SA1234G123 Stack 0x72",
+    }
+
+
+async def test_upgrade_removes_house_consumption_on_aio(hass, mock_client, mock_config_entry):
+    """Upgrade path (#95): an existing AIO entry carries the House Consumption Today
+    row a pre-gate version created; reconciliation removes exactly that row and
+    leaves the retained inverter sensors alone."""
+    _setup_hv_plant(mock_client, [_mock_hv_stack(0x70, _mock_bcu())])
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_e_consumption_today", config_entry=mock_config_entry
+    )
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_e_consumption_today") is None
     assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_system_mode") is not None
 
 


### PR DESCRIPTION
Two fixes from AberDino's multi-AIO report on #95.

## HV stack device naming
The stack device name was the bare `GivEnergy HV Battery Stack`, so a second AIO's stack slugged to `…_2` with no way to attribute stacks to their AIOs. Names now carry the parent serial + the stack's bus address: **`GivEnergy HV Battery CH2414G163 Stack 0x70`**.

The bus address is deliberately the *same token* as the device id, modbus log lines, `givenergy-cli` and the Comms `per_device` attributes — one namespace end to end. A friendlier "Stack 1/2/3" was considered and rejected: it adds a second namespace with an off-by-one mapping (Stack 1 ↔ 0x70) that every diagnostic conversation would trip over.

Existing installs keep their entity ids (device renames don't touch the registry); the README "Recreate entity IDs" flow adopts the new slugs.

## House Consumption Today gated off AIO
The derived consumption figure is meaningless on AIO — its PV/grid inputs are the registers under identity investigation there (givenergy-modbus#293), and the unit reports no raw backing figure (confirmed by AberDino's JSON). Now `skip_if_aio` (strictly `ALL_IN_ONE`; AIO-hybrid keeps it, matching the existing gate semantics), with an upgrade reconciler removing the stale row from existing AIO entries. If the #293 verdict rehabilitates the inputs, re-enabling is a one-flag change.

## Test plan
- [x] +3 tests: multi-stack name uniqueness (0x70/0x72), AIO consumption suppression, upgrade reconciliation removes exactly the gated row
- [x] pinned skip_if_aio boundary set updated
- [x] 579 Python + 42 JS green; ruff/mypy clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a stale “House Consumption Today” sensor from all-in-one setups during upgrade, and prevented it from being created on those devices going forward.
  * Improved HV battery stack naming so each stack is shown with the inverter serial and bus address, avoiding duplicate-looking devices.

* **Tests**
  * Expanded coverage for all-in-one sensor suppression and upgrade cleanup.
  * Added checks for unique HV stack device names across multiple stacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->