### PR TITLE
chore(deps): adopt givenergy-modbus 2.9.5 (reconnect hygiene)

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus==2.9.4"
+    "givenergy-modbus==2.9.5"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
     # an upstream patch that wasn't validated against this integration. Bump both
     # this and manifest.json together.
-    "givenergy-modbus==2.9.4",
+    "givenergy-modbus==2.9.5",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = "==2.9.4" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.9.5" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.9.4"
+version = "2.9.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/52/92bfaa929e67eabd5f0e09f350677aef1ec782bcd422f1da5d23c9a17b79/givenergy_modbus-2.9.4.tar.gz", hash = "sha256:448808cec3e097fe9de8921dfa71e7f59bb169dd4797090f3899a81c7375a799", size = 504754, upload-time = "2026-06-30T23:29:16.436Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/f5/11d4a21683029d26e5cdaed5f1b5f8c2305832eb6321e9eff659a642cb0c/givenergy_modbus-2.9.5.tar.gz", hash = "sha256:7bf455b4ad6f31f23bc02940a9c453b6f52a4202827b92ddc0efeaa669ba0c42", size = 508895, upload-time = "2026-07-02T20:13:49.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/67/e49e8172ff27c7ae3b85eb31e65d957a63f1b188b7b4ceeca0932748c130/givenergy_modbus-2.9.4-py3-none-any.whl", hash = "sha256:e45803b973f6f0308ebc56e5650c32772df564209925f67b50bcceac1131187b", size = 198654, upload-time = "2026-06-30T23:29:14.834Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/69/c0bddf02513da82c2ced1b33fd36387c55e9b4493c5546d480251a04e7af/givenergy_modbus-2.9.5-py3-none-any.whl", hash = "sha256:650e43f7258237fe0e9838b01a337f89d49946b15858312874f0758f66a66425", size = 200352, upload-time = "2026-07-02T20:13:48.162Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pin bump `==2.9.4` → `==2.9.5`. Reconnect hygiene: the nightly reconnect's CRITICAL log becomes a single WARNING with clean teardown, and the wedged-producer stall (the "Producer task is stuck" symptom from #233's comms-noisy EMS plant) is bounded ~10 s. New `ConnectionLost` exception subclasses both `CommunicationError` and `TimeoutError` — coordinator behaviour unchanged (introspection-verified); explicit fast-reconnect adoption is a deliberate non-goal here. 579 Python + 42 JS green. Dep-bump: merging on green CI.