### PR TITLE
fix: options flow can't save with the experimental section (#251)

### DIFF
--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -187,20 +187,24 @@ class GivEnergyLocalOptionsFlow(OptionsFlow):
         # Surface the collapsed "Experimental features" group only once at least one
         # flag exists, so the header never appears empty (the registry ships empty).
         if EXPERIMENTAL_FEATURES:
-            # Seed schema defaults from the currently-saved values so that a
-            # collapsed or omitted section round-trips correctly.  This works
-            # because HA's frontend either (a) submits the rendered (pre-filled)
-            # values for a collapsed section, in which case the submitted value
-            # wins, or (b) omits the section key entirely, in which case the
-            # vol.Optional / inner vol.Required defaults fill in the existing
-            # values.  The two cases are indistinguishable if the frontend sends
-            # base defaults (all False) for untouched collapsed sections — but
-            # HA keeps section inputs in the DOM, so (a) is what happens.
+            # Seed the section default from the currently-saved values so an
+            # omitted (untouched, collapsed) section round-trips its existing
+            # values: when the frontend omits the section key, the vol.Optional
+            # section default plus the inner defaults restore what was saved.
             existing_exp: dict[str, Any] = self.config_entry.options.get(CONF_EXPERIMENTAL, {})
             schema_dict[vol.Optional(CONF_EXPERIMENTAL, default=existing_exp)] = section(
                 vol.Schema(
                     {
-                        vol.Required(
+                        # vol.Optional, NOT vol.Required: a required field inside a
+                        # collapsed section is never initialised in the frontend's
+                        # data model (the inner form isn't rendered until the user
+                        # expands it), so HA's submit-time required-fields check
+                        # fails with "Not all required fields are filled in" and
+                        # blocks saving for any entry that has never opened the
+                        # section (#251). The default still applies server-side, and
+                        # resolve_experimental_client_kwargs reads via
+                        # .get(..., feature.default), so an omitted key is unchanged.
+                        vol.Optional(
                             feature.conf_key,
                             default=existing_exp.get(feature.conf_key, feature.default),
                         ): bool

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -421,3 +421,50 @@ async def test_options_flow_omits_section_when_no_features(hass, mock_client, se
     top_keys = {marker.schema for marker in result["data_schema"].schema}
     assert CONF_EXPERIMENTAL not in top_keys
     assert CONF_BATTERY_DATA_ONLY in top_keys
+
+
+async def test_options_flow_experimental_fields_are_optional(hass, mock_client, setup_integration):
+    """Inner section fields must serialise as optional, not required (#251).
+
+    A vol.Required field inside a collapsed section is never initialised in the
+    frontend's data model, so HA's submit-time required-fields check fails with
+    "Not all required fields are filled in" and blocks saving for any entry that
+    has never opened the section. Serialising the schema the way the frontend
+    receives it, the inner field must be optional so that check never fires."""
+    import voluptuous_serialize
+    from homeassistant.helpers import config_validation as cv
+
+    with patch(
+        "custom_components.givenergy_local.config_flow.EXPERIMENTAL_FEATURES",
+        (_DEMO_FEATURE,),
+    ):
+        result = await hass.config_entries.options.async_init(setup_integration.entry_id)
+    serialised = voluptuous_serialize.convert(
+        result["data_schema"], custom_serializer=cv.custom_serializer
+    )
+    section = next(f for f in serialised if f.get("name") == CONF_EXPERIMENTAL)
+    inner = section["schema"]
+    assert inner, "experimental section rendered no inner fields"
+    for field in inner:
+        assert not field.get("required"), f"{field['name']} is required inside a collapsed section"
+        assert field.get("optional"), f"{field['name']} must be optional (#251)"
+
+
+async def test_options_flow_saves_without_touching_experimental_section(
+    hass, mock_client, setup_integration
+):
+    """End-to-end #251 guard: a legacy entry (no 'experimental' key in options) can
+    submit the form omitting the collapsed section entirely and the save succeeds."""
+    with patch(
+        "custom_components.givenergy_local.config_flow.EXPERIMENTAL_FEATURES",
+        (_DEMO_FEATURE,),
+    ):
+        result = await hass.config_entries.options.async_init(setup_integration.entry_id)
+        # Submit as the frontend does for an untouched collapsed section: the
+        # section key is omitted from the payload entirely.
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {CONF_BATTERY_DATA_ONLY: True}
+        )
+        await hass.async_block_till_done()
+    assert result["type"] == "create_entry"
+    assert setup_integration.options[CONF_BATTERY_DATA_ONLY] is True


### PR DESCRIPTION
Fixes #251.

**Symptom:** opening **GivEnergy Local → Configure** and pressing Submit fails with *"Not all required fields are filled in"*, even though every visible field is set (see the reporter's screenshot). The options dialog is unsaveable.

**Cause:** the collapsed *Experimental features* section holds a `vol.Required` boolean. HA doesn't render a collapsed section's inner form, so that required field is never initialised in the frontend's data model; the dialog's submit-time required-fields check then walks the section, finds it undefined, and blocks. This affects **every** entry that has never opened+saved the section (none carry an `experimental` options key until then) — latent since the section shipped in v1.3.22, surfacing only now because opening options is rare.

**Fix:** inner section fields become `vol.Optional` (the documented HA pattern). The default still applies server-side and `resolve_experimental_client_kwargs` already reads via `.get(conf_key, feature.default)`, so an omitted toggle round-trips unchanged — behaviour identical, the frontend just stops treating a collapsed toggle as unfilled. The now-inaccurate comment (which asserted collapsed sections keep their inputs in the DOM — the very thing this disproves) is corrected.

**Tests:** serialises the schema as the frontend receives it and asserts the inner field is optional (verified to fail under `vol.Required`); plus an end-to-end save that omits the collapsed section. 581 Python + 42 JS green.