### PR TITLE
feat!: remove passive mode (#253)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ givenergy-modbus as its core library.
 - `coordinator.py` — DataUpdateCoordinator; centralises all Modbus polling via
   `client.refresh()` + `client.load_config()` (full refresh every N ticks)
 - `sensor.py`, `number.py`, `select.py`, `switch.py`, `time.py` — entity platforms
-- `config_flow.py` — UI setup (IP, port, scan interval, battery count, passive mode)
+- `config_flow.py` — UI setup (IP, port, scan interval)
 - `dashboard.py` — `generate_dashboard` service (deprecated; scheduled for removal); produces a Lovelace YAML file
 - `www/` — bundled frontend assets (e.g. `ge-cell-heatmap.js`) served at `/local/`
 
@@ -25,7 +25,9 @@ givenergy-modbus as its core library.
 - Be conservative with polling frequency — querying too often disrupts cloud metrics
   (device address 0x11 is the EMS; its interaction with the GivEnergy cloud is a known
   sensitivity)
-- Passive mode exists: listen-only when another Modbus client is already polling
+- Passive mode was removed in v1.3.37 (#253) — all entries poll actively; a legacy
+  `passive` key in entry data is deliberately inert. Concurrent active clients at
+  30-second intervals are well within what the hardware handles.
 
 ## Entity gating patterns
 Two conditional-creation patterns exist in `async_setup_entry`; follow them when adding

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Add the integration via **Settings → Devices & Services → Add Integration �
 | Inverter IP Address | — | Local IP of the inverter's data adapter |
 | Modbus Port | `8899` | Modbus TCP port |
 | Scan Interval | `30` s | How often HA polls for updated values |
-| [Passive mode](#passive-mode) | off | Listen only — use when another local polling client is already driving the inverter and this integration should just observe |
 
 To change any of these later, open the integration's **⋮** menu in **Settings → Devices & Services → GivEnergy Local** and choose **Reconfigure**. The integration reloads automatically when you save.
 
@@ -107,9 +106,7 @@ Both this integration and other local polling solutions (GivTCP, the GivEnergy a
 
 Running both integrations in parallel makes it easy to evaluate a switch without committing: you get a live side-by-side comparison and can cut over at your own pace. A migration script (`scripts/migrate_from_givtcp.py`) carries your long-term recorder statistics across — see [`docs/migration-from-givtcp.md`](docs/migration-from-givtcp.md) for usage.
 
-#### Passive mode
-
-When enabled, the integration connects to the inverter but sends no Modbus read requests after the initial connection. Instead, it reads the library's register cache on each scan interval tick. This is a secondary option for setups where you'd prefer this integration to observe rather than poll — the main case being a client you can't reconfigure (e.g. the GivEnergy app) where you want to avoid any overlap.
+> **Note:** earlier versions offered a "passive mode" (listen only, relying on another client's polling to keep values fresh). It was removed in v1.3.37: concurrent active polling is well within what the hardware handles, while passive mode's freshness expectations could never be met by the cloud's ~5-minute polling cadence, producing continuous spurious refresh failures (#253). An entry that still has the old setting stored simply polls actively.
 
 ## Entities
 
@@ -404,8 +401,7 @@ The daily counters reset at midnight; Home Assistant's recorder detects the rese
 ## Troubleshooting
 
 - **Transient connection drops are normal.** TCP-level timeouts and the occasional connection reset get logged at WARNING level and the next scan tick re-establishes the connection. The `Last Successful Refresh` and `Consecutive Refresh Failures` diagnostic sensors will tell you if something more persistent is going on.
-- **"Register cache unchanged" failures in passive mode** mean no peer client is refreshing the inverter. Switch back to active mode, or start the other client that's supposed to be driving the bus.
-- **Conflicts with another Modbus client** — concurrent active polling is generally reliable on current firmware; if you do see persistent connection errors with two clients running, [passive mode](#passive-mode) may help.
+- **Conflicts with another Modbus client** — concurrent active polling is reliable on current firmware, including multiple clients at 30-second intervals; if you do see persistent connection errors with two clients running, please open an issue.
 - **Wrong number of battery devices appearing** — battery count is auto-discovered at startup by probing the Modbus bus; there is no manual override. If detection misfires (e.g. a battery was slow to respond), reloading the integration usually fixes it. If the count is consistently wrong, [open an issue](https://github.com/dewet22/givenergy-hass/issues/48) and attach a frame capture (see [Supported inverters](#supported-inverters)).
 
 For anything else, please [open an issue](https://github.com/dewet22/givenergy-hass/issues) with the relevant HA log lines and your inverter model.

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -36,13 +36,11 @@ from homeassistant.util import dt as dt_util
 from .const import (
     CONF_BATTERY_DATA_ONLY,
     CONF_EXPOSE_PER_CELL,
-    CONF_PASSIVE,
     CONF_RETRIES,
     CONF_SCAN_INTERVAL,
     CONF_TIMEOUT_TOLERANCE,
     CONF_WARN_CLOCK_DRIFT,
     DEFAULT_BATTERY_DATA_ONLY,
-    DEFAULT_PASSIVE,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_WARN_CLOCK_DRIFT,
     DOMAIN,
@@ -775,7 +773,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         host=entry.data[CONF_HOST],
         port=entry.data[CONF_PORT],
         scan_interval=entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
-        passive=entry.data.get(CONF_PASSIVE, DEFAULT_PASSIVE),
+        # NB: a legacy `passive` key may remain in entry.data — deliberately
+        # ignored since passive mode's removal (#253); all entries poll actively.
         experimental_client_kwargs=experimental_client_kwargs,
         prior_capabilities=prior_capabilities,
         on_topology_changed=_on_topology_changed,

--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -20,11 +20,9 @@ from .const import (
     CONF_BATTERY_DATA_ONLY,
     CONF_EXPERIMENTAL,
     CONF_EXPOSE_PER_CELL,
-    CONF_PASSIVE,
     CONF_SCAN_INTERVAL,
     CONF_WARN_CLOCK_DRIFT,
     DEFAULT_BATTERY_DATA_ONLY,
-    DEFAULT_PASSIVE,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_WARN_CLOCK_DRIFT,
@@ -39,7 +37,6 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
         vol.Required(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): int,
-        vol.Required(CONF_PASSIVE, default=DEFAULT_PASSIVE): bool,
     }
 )
 
@@ -99,7 +96,7 @@ class GivEnergyLocalConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Update an existing entry's settings (scan interval, passive mode, …)."""
+        """Update an existing entry's settings (host, port, scan interval)."""
         entry = self._get_reconfigure_entry()
         errors: dict[str, str] = {}
 

--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -11,7 +11,6 @@ DEFAULT_PORT = 8899
 DEFAULT_SCAN_INTERVAL = 30
 
 CONF_SCAN_INTERVAL = "scan_interval"
-CONF_PASSIVE = "passive"
 # When enabled (per-entry option), suppress control entities and inverter-level
 # system sensors, leaving only battery pack / HV stack / AIO module / diagnostic
 # data. For a unit controlled by a Gateway in a parallel group, where its own
@@ -37,8 +36,6 @@ CONF_EXPOSE_PER_CELL = "expose_per_cell"
 # The current defaults live as constructor defaults on GivEnergyUpdateCoordinator.
 CONF_TIMEOUT_TOLERANCE = "timeout_tolerance"
 CONF_RETRIES = "retries"
-
-DEFAULT_PASSIVE = False
 
 PLATFORMS = ["binary_sensor", "sensor", "switch", "number", "select", "time", "datetime", "button"]
 

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -153,7 +153,6 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         host: str,
         port: int,
         scan_interval: int,
-        passive: bool = False,
         experimental_client_kwargs: dict[str, Any] | None = None,
         timeout_tolerance: int = 3,
         retries: int = 1,
@@ -170,7 +169,6 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         )
         self.host = host
         self.port = port
-        self.passive = passive
         # Resolved opt-in givenergy-modbus client kwargs (empty by default, so
         # Client(host, port) is unchanged). Splatted at every (re)connect.
         self._experimental_client_kwargs = experimental_client_kwargs or {}
@@ -225,8 +223,6 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         # Length of the current unbroken run of partial polls, used only to
         # throttle the partial log (see _record_partial). Reset by a clean poll.
         self._consecutive_partials: int = 0
-        self._last_inverter_time: datetime | None = None
-        self._unchanged_ticks: int = 0
         self._active_tick: int = 0
         self._full_refresh_every: int = max(1, round(_FULL_REFRESH_INTERVAL / scan_interval))
 
@@ -253,11 +249,7 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                 # down, and a routine unload should not log an ERROR.
                 return self.data
 
-            plant = (
-                await self._passive_update(reconnecting)
-                if self.passive
-                else await self._active_update()
-            )
+            plant = await self._active_update()
 
             # A fully clean poll ends the partial run so the next one warns afresh.
             # The last_partial_failures detail and last_partial_at are deliberately
@@ -331,7 +323,6 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
 
     def _mark_success(self, plant: Plant) -> None:
         """Record a tick that yielded usable data (full or partial success)."""
-        self._last_inverter_time = plant.inverter.system_time
         self.last_successful_refresh = dt_util.utcnow()
         self.consecutive_failures = 0
         self._accumulate_comms_counters(plant)
@@ -465,42 +456,6 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
             await self._client.load_config(retries=self.retries)
         return await self._client.refresh(retries=self.retries)
 
-    async def _passive_update(self, reconnecting: bool) -> Plant:
-        """Seed the cache on (re)connect; on subsequent ticks read the cached plant.
-
-        The library's register cache is kept fresh by a peer client on the
-        shared Modbus bus.  Raises UpdateFailed if the cache appears frozen.
-        """
-        assert self._client is not None  # _async_update_data ensures this
-        if reconnecting:
-            await self._client.load_config(retries=self.retries)
-            return await self._client.refresh(retries=self.retries)
-
-        plant = self._client.plant
-        self._check_cache_freshness(plant)
-        return plant
-
-    def _check_cache_freshness(self, plant: Plant) -> None:
-        """Raise UpdateFailed if system_time hasn't advanced for two consecutive ticks.
-
-        One unchanged tick is tolerated to absorb timing skew between our poll
-        interval and the peer's refresh cadence.
-        """
-        inverter_time = plant.inverter.system_time
-        if (
-            inverter_time is not None
-            and self._last_inverter_time is not None
-            and inverter_time == self._last_inverter_time
-        ):
-            self._unchanged_ticks += 1
-            if self._unchanged_ticks >= 2:
-                raise UpdateFailed(
-                    "Register cache unchanged for 2 consecutive ticks — "
-                    "no peer client appears to be refreshing the inverter"
-                )
-        else:
-            self._unchanged_ticks = 0
-
     # ------------------------------------------------------------------
     # Connection helpers
     # ------------------------------------------------------------------
@@ -572,8 +527,6 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                         "topology-healed callback failed; connection is up, continuing",
                         exc_info=True,
                     )
-            self._last_inverter_time = None
-            self._unchanged_ticks = 0
             self._active_tick = 0
             _LOGGER.info("Connected to inverter at %s:%s", self.host, self.port)
         except BaseException:

--- a/custom_components/givenergy_local/strings.json
+++ b/custom_components/givenergy_local/strings.json
@@ -8,7 +8,6 @@
           "host": "Inverter IP Address",
           "port": "Modbus Port",
           "scan_interval": "Scan Interval (seconds)",
-          "passive": "Passive mode (listen only — another client drives refreshes)",
           "battery_data_only": "Battery data only (suppress controls and system sensors)",
           "timeout_tolerance": "Timeout Tolerance (consecutive failures before unavailable)"
         }
@@ -20,7 +19,6 @@
           "host": "Inverter IP Address",
           "port": "Modbus Port",
           "scan_interval": "Scan Interval (seconds)",
-          "passive": "Passive mode (listen only — another client drives refreshes)",
           "timeout_tolerance": "Timeout Tolerance (consecutive failures before unavailable)"
         }
       }

--- a/custom_components/givenergy_local/translations/en.json
+++ b/custom_components/givenergy_local/translations/en.json
@@ -8,7 +8,6 @@
           "host": "Inverter IP Address",
           "port": "Modbus Port",
           "scan_interval": "Scan Interval (seconds)",
-          "passive": "Passive mode (listen only — another client drives refreshes)",
           "battery_data_only": "Battery data only (suppress controls and system sensors)"
         }
       },
@@ -18,8 +17,7 @@
         "data": {
           "host": "Inverter IP Address",
           "port": "Modbus Port",
-          "scan_interval": "Scan Interval (seconds)",
-          "passive": "Passive mode (listen only — another client drives refreshes)"
+          "scan_interval": "Scan Interval (seconds)"
         }
       }
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,7 +254,6 @@ def mock_config_entry() -> MockConfigEntry:
             "host": "192.168.1.100",
             "port": 8899,
             "scan_interval": 30,
-            "passive": False,
         },
         unique_id="SA1234G123",
     )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -10,7 +10,6 @@ from custom_components.givenergy_local.const import (
     CONF_BATTERY_DATA_ONLY,
     CONF_EXPERIMENTAL,
     CONF_EXPOSE_PER_CELL,
-    CONF_PASSIVE,
     CONF_SCAN_INTERVAL,
     CONF_WARN_CLOCK_DRIFT,
     DOMAIN,
@@ -21,7 +20,6 @@ VALID_USER_INPUT = {
     CONF_HOST: "192.168.1.100",
     CONF_PORT: 8899,
     CONF_SCAN_INTERVAL: 30,
-    CONF_PASSIVE: False,
 }
 
 
@@ -162,25 +160,23 @@ async def test_reconfigure_form_is_prefilled(hass, mock_client, setup_integratio
     }
     assert suggested[CONF_HOST] == "192.168.1.100"
     assert suggested[CONF_SCAN_INTERVAL] == 30
-    assert suggested[CONF_PASSIVE] is False
 
 
 async def test_reconfigure_updates_settings_without_retesting_connection(
     hass, mock_client, setup_integration
 ):
-    """Changing only scan_interval/passive should skip the explicit connection test."""
+    """Changing only scan_interval should skip the explicit connection test."""
     mock_client.refresh.reset_mock()  # ignore the initial setup refresh
     mock_client.load_config.reset_mock()
 
     result = await setup_integration.start_reconfigure_flow(hass)
-    new_input = {**VALID_USER_INPUT, CONF_SCAN_INTERVAL: 60, CONF_PASSIVE: True}
+    new_input = {**VALID_USER_INPUT, CONF_SCAN_INTERVAL: 60}
     result = await hass.config_entries.flow.async_configure(result["flow_id"], new_input)
     await hass.async_block_till_done()
 
     assert result["type"] == "abort"
     assert result["reason"] == "reconfigure_successful"
     assert setup_integration.data[CONF_SCAN_INTERVAL] == 60
-    assert setup_integration.data[CONF_PASSIVE] is True
 
     # _test_connection (host/port change only) issues a bare refresh() with no
     # preceding load_config(); the post-reload coordinator always pairs the two

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -802,76 +802,13 @@ async def test_refresh_failed_mixed_group_cause_resets_immediately(hass, mock_pl
 
 
 # ---------------------------------------------------------------------------
-# Active / passive refresh cadence
+# Refresh cadence
 # ---------------------------------------------------------------------------
 
 
-async def test_passive_mode_initial_connect_does_full_refresh(hass, mock_plant):
-    """Even in passive mode the first connect must seed the cache with a full refresh."""
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True)
-
-    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
-        client = AsyncMock()
-        client.connected = True
-        client.plant = mock_plant
-        client.refresh = AsyncMock(return_value=mock_plant)
-        client.load_config = AsyncMock(return_value=mock_plant)
-        mock_cls.return_value = client
-
-        await coordinator._async_update_data()
-
-    client.load_config.assert_called_once_with(retries=1)
-    client.refresh.assert_called_once_with(retries=1)
-
-
-async def test_passive_mode_skips_refresh_on_subsequent_ticks(hass, mock_plant):
-    """After the initial connect, passive mode must not send any Modbus requests."""
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True)
-
-    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
-        client = AsyncMock()
-        client.connected = True
-        client.plant = mock_plant
-        client.refresh = AsyncMock(return_value=mock_plant)
-        client.load_config = AsyncMock(return_value=mock_plant)
-        mock_cls.return_value = client
-        coordinator._client = client  # already connected
-
-        from datetime import timedelta
-
-        base = datetime(2026, 5, 10, 12, 0, 0)
-        for tick in range(3):
-            mock_plant.inverter.system_time = base + timedelta(seconds=tick * 30)
-            await coordinator._async_update_data()
-
-    # No wire traffic — the client was already connected.
-    client.refresh.assert_not_called()
-    client.load_config.assert_not_called()
-
-
-async def test_passive_mode_reconnect_does_full_refresh(hass, mock_plant):
-    """If the connection drops in passive mode, reconnecting must re-seed the cache."""
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True)
-
-    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
-        client = AsyncMock()
-        client.connected = False  # simulate a dropped connection
-        client.plant = mock_plant
-        client.refresh = AsyncMock(return_value=mock_plant)
-        client.load_config = AsyncMock(return_value=mock_plant)
-        mock_cls.return_value = client
-
-        await coordinator._async_update_data()
-
-    client.load_config.assert_called_once_with(retries=1)
-    client.refresh.assert_called_once_with(retries=1)
-
-
 async def test_retries_forwarded_to_refresh_active(hass, mock_plant):
-    """Active-mode ticks must thread the configured retries count to the primitives."""
-    coordinator = GivEnergyUpdateCoordinator(
-        hass, "192.168.1.1", 8899, 30, passive=False, retries=2
-    )
+    """Refresh ticks must thread the configured retries count to the primitives."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, retries=2)
 
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
@@ -888,27 +825,9 @@ async def test_retries_forwarded_to_refresh_active(hass, mock_plant):
     client.refresh.assert_called_once_with(retries=2)
 
 
-async def test_retries_forwarded_to_refresh_passive_reconnect(hass, mock_plant):
-    """Passive-mode reconnect (the only path that hits the wire) must also forward retries."""
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True, retries=3)
-
-    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
-        client = AsyncMock()
-        client.connected = False  # forces reconnect
-        client.plant = mock_plant
-        client.refresh = AsyncMock(return_value=mock_plant)
-        client.load_config = AsyncMock(return_value=mock_plant)
-        mock_cls.return_value = client
-
-        await coordinator._async_update_data()
-
-    client.load_config.assert_called_once_with(retries=3)
-    client.refresh.assert_called_once_with(retries=3)
-
-
 async def test_active_mode_always_refreshes(hass, mock_plant):
-    """In active (default) mode every tick issues a refresh() request."""
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=False)
+    """Every tick issues a refresh() request."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
 
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
@@ -927,7 +846,7 @@ async def test_active_mode_always_refreshes(hass, mock_plant):
 
 async def test_active_mode_first_tick_is_full_refresh(hass, mock_plant):
     """Tick 0 must always be a full refresh (load_config + refresh) regardless of interval."""
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=False)
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
 
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
@@ -947,7 +866,7 @@ async def test_active_mode_first_tick_is_full_refresh(hass, mock_plant):
 async def test_active_mode_intermediate_ticks_are_partial(hass, mock_plant):
     """Ticks 1 … (n-1) must skip load_config (input registers only)."""
     # scan_interval=30 → _full_refresh_every = round(300/30) = 10
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=False)
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
 
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
@@ -969,7 +888,7 @@ async def test_active_mode_intermediate_ticks_are_partial(hass, mock_plant):
 async def test_active_mode_nth_tick_is_full_refresh(hass, mock_plant):
     """Every _full_refresh_every ticks a full refresh (load_config) must be issued again."""
     # scan_interval=30 → _full_refresh_every = 10; tick 10 is the next full refresh
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=False)
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
 
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
@@ -990,7 +909,7 @@ async def test_active_mode_nth_tick_is_full_refresh(hass, mock_plant):
 
 async def test_active_mode_reconnect_resets_refresh_cycle(hass, mock_plant):
     """After a reconnect the full-refresh cycle must restart from tick 0."""
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=False)
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
 
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
         client = AsyncMock()
@@ -1013,105 +932,6 @@ async def test_active_mode_reconnect_resets_refresh_cycle(hass, mock_plant):
 
     # The post-reconnect call is tick 0 of a new cycle → load_config fires again.
     assert client.load_config.call_count == 2
-
-
-async def test_passive_stale_cache_raises_after_two_unchanged_ticks(hass, mock_plant):
-    """Cache is only considered stale after two consecutive unchanged ticks."""
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True)
-    fixed_time = datetime(2026, 5, 10, 12, 0, 0)
-    mock_plant.inverter.system_time = fixed_time
-
-    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
-        client = AsyncMock()
-        client.connected = True
-        client.plant = mock_plant
-        mock_cls.return_value = client
-        coordinator._client = client
-
-        await coordinator._async_update_data()  # tick 1: seeds _last_inverter_time
-        await coordinator._async_update_data()  # tick 2: first unchanged — tolerated
-        with pytest.raises(UpdateFailed, match="2 consecutive ticks"):
-            await coordinator._async_update_data()  # tick 3: second unchanged — stale
-
-    assert coordinator.consecutive_failures == 1
-
-
-async def test_passive_one_unchanged_tick_is_tolerated(hass, mock_plant):
-    """A single unchanged tick is allowed before the stale error is raised."""
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True)
-    fixed_time = datetime(2026, 5, 10, 12, 0, 0)
-    mock_plant.inverter.system_time = fixed_time
-
-    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
-        client = AsyncMock()
-        client.connected = True
-        client.plant = mock_plant
-        mock_cls.return_value = client
-        coordinator._client = client
-
-        await coordinator._async_update_data()  # seed
-        await coordinator._async_update_data()  # first unchanged — must not raise
-
-    assert coordinator.consecutive_failures == 0
-
-
-async def test_passive_advancing_system_time_succeeds(hass, mock_plant):
-    """If system_time advances the cache is live and no error is raised."""
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True)
-
-    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
-        client = AsyncMock()
-        client.connected = True
-        client.plant = mock_plant
-        mock_cls.return_value = client
-        coordinator._client = client
-
-        mock_plant.inverter.system_time = datetime(2026, 5, 10, 12, 0, 0)
-        await coordinator._async_update_data()
-
-        mock_plant.inverter.system_time = datetime(2026, 5, 10, 12, 0, 30)
-        await coordinator._async_update_data()
-
-    assert coordinator.consecutive_failures == 0
-
-
-async def test_passive_reconnect_resets_stale_detection(hass, mock_plant):
-    """Reconnecting clears _last_inverter_time so the first passive tick never fires stale."""
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True)
-    fixed_time = datetime(2026, 5, 10, 12, 0, 0)
-    mock_plant.inverter.system_time = fixed_time
-    coordinator._last_inverter_time = fixed_time  # same as what the plant will return
-
-    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
-        client = AsyncMock()
-        client.connected = True
-        client.plant = mock_plant
-        client.refresh = AsyncMock(return_value=mock_plant)
-        client.load_config = AsyncMock(return_value=mock_plant)
-        mock_cls.return_value = client
-        # _client is None → reconnecting=True → _last_inverter_time is reset before the check
-
-        await coordinator._async_update_data()
-
-    assert coordinator.consecutive_failures == 0
-
-
-async def test_passive_none_system_time_skips_stale_check(hass, mock_plant):
-    """If system_time is None (register not yet populated) the stale check is skipped."""
-    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True)
-    mock_plant.inverter.system_time = None
-
-    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
-        client = AsyncMock()
-        client.connected = True
-        client.plant = mock_plant
-        mock_cls.return_value = client
-        coordinator._client = client
-
-        await coordinator._async_update_data()
-        await coordinator._async_update_data()  # would raise if check wasn't skipped
-
-    assert coordinator.consecutive_failures == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -117,7 +117,7 @@ async def test_migrate_v1_entry_strips_retries_and_tolerance(hass, mock_client):
             "host": "192.168.1.100",
             "port": 8899,
             "scan_interval": 30,
-            "passive": False,
+            "passive": False,  # stale key from before passive mode's removal (#253)
             CONF_TIMEOUT_TOLERANCE: 7,  # user had a custom override
             CONF_RETRIES: 3,  # user had a custom override
         },
@@ -145,7 +145,7 @@ async def test_migrate_v1_entry_without_legacy_fields_is_idempotent(hass, mock_c
             "host": "192.168.1.100",
             "port": 8899,
             "scan_interval": 30,
-            "passive": False,
+            "passive": False,  # stale key from before passive mode's removal (#253)
         },
         unique_id="SA1234G123",
     )
@@ -155,6 +155,30 @@ async def test_migrate_v1_entry_without_legacy_fields_is_idempotent(hass, mock_c
     await hass.async_block_till_done()
 
     assert entry.version == 2
+
+
+async def test_entry_with_passive_enabled_polls_actively(hass, mock_client):
+    """Passive mode was removed (#253): an entry that still stores passive=True
+    must set up normally and poll the inverter itself — the stale key is inert."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "192.168.1.100",
+            "port": 8899,
+            "scan_interval": 30,
+            "passive": True,
+        },
+        unique_id="SA1234G123",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Active polling happened: the coordinator issued its own full refresh
+    # (load_config + refresh) rather than waiting on a peer client's traffic.
+    assert mock_client.load_config.call_count >= 1
+    assert mock_client.refresh.call_count >= 1
 
 
 async def test_migrate_refuses_future_version(hass, mock_client):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1468,7 +1468,7 @@ async def _setup_battery_data_only(hass, mock_client, *, enabled: bool):
     _setup_hv_plant(mock_client, [_mock_hv_stack(0x70, _mock_bcu())])
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={"host": "192.168.1.100", "port": 8899, "scan_interval": 30, "passive": False},
+        data={"host": "192.168.1.100", "port": 8899, "scan_interval": 30},
         options={CONF_BATTERY_DATA_ONLY: enabled},
         unique_id="SA1234G123",
     )
@@ -2257,7 +2257,7 @@ async def _setup_hv_with_modules(
     options = {} if expose_per_cell is None else {CONF_EXPOSE_PER_CELL: expose_per_cell}
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={"host": "192.168.1.100", "port": 8899, "scan_interval": 30, "passive": False},
+        data={"host": "192.168.1.100", "port": 8899, "scan_interval": 30},
         options=options,
         unique_id="SA1234G123",
     )
@@ -2337,7 +2337,7 @@ async def _setup_lv_with_option(hass, expose_per_cell: bool | None):
     options = {} if expose_per_cell is None else {CONF_EXPOSE_PER_CELL: expose_per_cell}
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={"host": "192.168.1.100", "port": 8899, "scan_interval": 30, "passive": False},
+        data={"host": "192.168.1.100", "port": 8899, "scan_interval": 30},
         options=options,
         unique_id="SA1234G123",
     )


### PR DESCRIPTION
Closes #253.

**Why remove rather than fix:** passive mode's freshness check (fail after ~60 s without a cache update) could never coexist with the GivEnergy cloud's ~5-minute polling cadence — the setup users most plausibly ran it with. The result was a spurious refresh failure on ~87% of ticks and entities flapping unavailable while everything was actually working; the reporter's screenshot shows the counter climbing at exactly one per 30 s tick for 15 hours. The contention fear that motivated passive mode hasn't materialised on any hardware we've encountered — multiple active clients at 30-second intervals are well within what the dongle handles.

**What changes:** the coordinator always polls actively (`_passive_update`, `_check_cache_freshness` and their state removed); the setup/reconfigure field, constants and translation labels go; README loses the passive section, gains a removal note, and the troubleshooting entries are updated. A legacy `passive` key left in entry data is deliberately inert — entries that had it enabled simply start polling actively, which is the fix. No migration needed.

**Tests:** 9 passive tests removed; new test pins the legacy-inert-key behaviour (`passive: true` entry sets up and issues its own load_config+refresh). 573 Python + 42 JS green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The integration now always uses active polling, including for older setups that previously relied on passive mode.
  * Concurrent polling with other local clients is now supported more reliably.

* **Documentation**
  * Updated setup and troubleshooting guidance to remove references to passive mode.
  * Clarified that existing saved passive settings are ignored and normal polling continues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->