### PR TITLE
feat: Gateway sensor surface — whole-house + per-AIO telemetry (#194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Confirmed working on real hardware:
 - AC-coupled (Gen 1)
 - All-in-One (AIO) — including per-module battery devices with per-cell data; needs v1.2.0 or later
 - EMS controller — validated on a live two-inverter EMS plant; some polling rough edges on busy shared buses are still being smoothed out in the library
+- Gateway (V1 / V2) — validated on a Gen 1 Gateway with two AIOs; exposes whole-house load/PV power and energy, grid import/export, and per-AIO SOC and charge/discharge. Lifetime totals are held back pending a decode fix, and no controls are offered through a Gateway yet
 
 The following have modelled register maps and are expected to work, but haven't yet been validated end-to-end by an owner — if yours is one of these and you run into sensor values that look wrong, please [open an issue](https://github.com/dewet22/givenergy-hass/issues):
 
 - Hybrid three-phase
-- Gateway (V1 / V2) — register layout decoded from owner probes, but the integration hasn't been run against one directly
 - HV battery stacks (BCU/BMU)
 
 If you'd like to help validate, a wire-frame capture is the most useful thing you can include. If you already have the integration running, use the built-in action from **Developer Tools → Actions** (named **Services** in older Home Assistant versions):
@@ -221,6 +221,10 @@ On an EMS plant the controller device carries plant-level aggregates the inverte
 | EMS Calculated Load Energy Today / Total | kWh | Integrated client-side from *EMS Calculated Load Power* — the EMS rollup carries no energy counters, so no register-backed figure exists. An estimate, not a meter reading: it undercounts across restarts and outages (a sampling gap contributes at most one capped slice), though the accumulated value does survive Home Assistant restarts. |
 
 These replace the Integral + Utility Meter helpers a Predbat EMS setup previously had to hand-create ([#248](https://github.com/dewet22/givenergy-hass/issues/248)).
+
+### Gateway device
+
+An entry pointed at a Gen 1 Gateway surfaces whole-house telemetry from the Gateway's own registers ([#194](https://github.com/dewet22/givenergy-hass/issues/194)): load and PV power, today's load / PV / grid import / grid export / battery charge / battery discharge energy, grid and load voltage, and — per attached AIO — battery SOC, power, and today's charge/discharge energy (unpopulated AIO slots are omitted). The standard inverter sensor set is suppressed on a Gateway entry: the Gateway's inverter-shaped registers read as zeros, and the real data lives in the Gateway banks. Lifetime totals are deliberately held back pending an upstream decode fix, and no control entities are offered through a Gateway yet. Your per-AIO entries (typically in battery-data-only mode) continue to work alongside.
 
 ### Services
 

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -452,15 +452,27 @@ def _retired_inverter_unique_ids(serial: str) -> set[str]:
     Keyed by the controller serial; coordinator, battery, AIO and managed-inverter
     entities use different keys or their own serials, so they're excluded.
     """
-    # Local imports: these platform modules are imported by the platform setup
-    # anyway, and importing them at module scope here risks a load-order cycle.
+    from .sensor import INVERTER_SENSORS
+
+    keys = _inverter_control_keys()
+    # Inverter sensors gated on EMS (controller-local load + Battery Charge/Discharge Today).
+    keys.update(d.key for d in INVERTER_SENSORS if d.skip_if_ems)
+    # Duplicate EMS aggregate dropped in favour of the retained inverter Status sensor.
+    keys.add("ems_status")
+    return {f"{serial}_{key}" for key in keys}
+
+
+def _inverter_control_keys() -> set[str]:
+    """Keys of every inverter-level control description across the platforms.
+
+    Local imports: these platform modules are imported by the platform setup
+    anyway, and importing them at module scope here risks a load-order cycle.
+    """
     from .number import AC_COUPLED_NUMBER_DESCRIPTIONS, NUMBER_DESCRIPTIONS
     from .select import AC_COUPLED_SELECT_DESCRIPTIONS, SELECT_DESCRIPTIONS
-    from .sensor import INVERTER_SENSORS
     from .switch import AC_COUPLED_SWITCH_DESCRIPTIONS, SWITCH_DESCRIPTIONS
     from .time import SMART_LOAD_TIME_DESCRIPTIONS, TIME_DESCRIPTIONS
 
-    # All inverter-level controls are suppressed on EMS.
     controls = (
         *SWITCH_DESCRIPTIONS,
         *AC_COUPLED_SWITCH_DESCRIPTIONS,
@@ -471,12 +483,41 @@ def _retired_inverter_unique_ids(serial: str) -> set[str]:
         *TIME_DESCRIPTIONS,
         *SMART_LOAD_TIME_DESCRIPTIONS,
     )
-    keys = {d.key for d in controls}
-    # Inverter sensors gated on EMS (controller-local load + Battery Charge/Discharge Today).
-    keys.update(d.key for d in INVERTER_SENSORS if d.skip_if_ems)
-    # Duplicate EMS aggregate dropped in favour of the retained inverter Status sensor.
-    keys.add("ems_status")
+    return {d.key for d in controls}
+
+
+def _retired_on_gateway_unique_ids(serial: str) -> set[str]:
+    """Unique IDs of the entities retired on a Gateway plant (#194).
+
+    On a Gateway the 0x11 device's inverter registers decode as a spurious
+    all-zeros SinglePhaseInverter, so the ENTIRE standard inverter sensor set is
+    suppressed (unlike EMS, where the 0x11 block carries real data) along with
+    every inverter-level control (no validated write surface yet). The
+    GATEWAY_SENSORS set replaces them on the same device; coordinator sensors
+    use different keys and stay.
+    """
+    from .sensor import INVERTER_SENSORS
+
+    keys = _inverter_control_keys()
+    keys.update(d.key for d in INVERTER_SENSORS)
     return {f"{serial}_{key}" for key in keys}
+
+
+def _reconcile_gateway_entities(hass: HomeAssistant, entry: ConfigEntry, serial: str) -> None:
+    """Remove standard inverter entities from a Gateway entry (#194).
+
+    A Gateway entry created on v1.3.38 (before GATEWAY_SENSORS existed) carries
+    the full inverter sensor/control set as 0/Unknown registry rows; suppressing
+    creation alone would leave them orphaned on upgrade.
+    """
+    registry = er.async_get(hass)
+    retired = _retired_on_gateway_unique_ids(serial)
+    for ent in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if ent.unique_id in retired:
+            _LOGGER.info(
+                "Removing inverter entity %s retired on Gateway plant (#194)", ent.entity_id
+            )
+            registry.async_remove(ent.entity_id)
 
 
 def _reconcile_ems_entities(hass: HomeAssistant, entry: ConfigEntry, serial: str) -> None:
@@ -859,6 +900,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     capabilities = coordinator.data.capabilities
     if capabilities is not None and capabilities.device_type is Model.ALL_IN_ONE:
         _reconcile_aio_house_consumption(hass, coordinator.data.inverter_serial_number)
+
+    # On a Gateway the whole standard inverter sensor/control set is suppressed in
+    # favour of GATEWAY_SENSORS (#194): remove the 0/Unknown rows a pre-gateway-
+    # support entry (v1.3.38) created.
+    if capabilities is not None and capabilities.device_type is Model.GATEWAY:
+        _reconcile_gateway_entities(hass, entry, coordinator.data.inverter_serial_number)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/givenergy_local/button.py
+++ b/custom_components/givenergy_local/button.py
@@ -36,8 +36,13 @@ async def async_setup_entry(
     # Restart writes the inverter reboot register (HR163), which an EMS controller
     # rejects (not in its modbus write-safe set — same family as the clock-write
     # ban), so gate it off EMS like the other controls. Battery-data-only units are
-    # driven by their Gateway, so skip there too (#95).
-    if coordinator.data.ems is None and not entry.options.get(CONF_BATTERY_DATA_ONLY, False):
+    # driven by their Gateway, so skip there too (#95). Gateway entries have no
+    # validated write surface yet, so Restart is gated there as well (#194).
+    if (
+        coordinator.data.ems is None
+        and coordinator.data.gateway is None
+        and not entry.options.get(CONF_BATTERY_DATA_ONLY, False)
+    ):
         entities.append(GivEnergyRestartButton(coordinator))
     async_add_entities(entities)
 

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -255,6 +255,10 @@ async def async_setup_entry(
     if entry.options.get(CONF_BATTERY_DATA_ONLY, False):
         # Battery-data-only (#95): this unit's controls are owned by its Gateway.
         return
+    if coordinator.data.gateway is not None:
+        # Gateway plant (#194): no validated write surface yet — the HR config
+        # block reads plausibly but writing through a Gateway is untested.
+        return
     entities: list[NumberEntity] = []
     if coordinator.data.ems is not None:
         # EMS plant: the controller's slot/target controls are authoritative; all

--- a/custom_components/givenergy_local/select.py
+++ b/custom_components/givenergy_local/select.py
@@ -156,6 +156,10 @@ async def async_setup_entry(
     if entry.options.get(CONF_BATTERY_DATA_ONLY, False):
         # Battery-data-only (#95): this unit's controls are owned by its Gateway.
         return
+    if coordinator.data.gateway is not None:
+        # Gateway plant (#194): no validated write surface yet — the HR config
+        # block reads plausibly but writing through a Gateway is untested.
+        return
     entities: list[SelectEntity] = []
     if coordinator.data.ems is None:
         # Inverter-level selects (battery power/pause mode) are redundant on an EMS

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -196,6 +196,49 @@ class GivEnergyEmsSensorDescription(SensorEntityDescription):
     value_fn: Callable[[Ems], Any] = field(default=lambda _: None)
 
 
+@dataclass(frozen=True, kw_only=True)
+class GivEnergyGatewaySensorDescription(SensorEntityDescription):
+    """Sensor over `plant.gateway` (GatewayV1/V2 — identical field names).
+
+    On a Gateway plant `plant.inverter` is a spurious SinglePhaseInverter decoded
+    from the gateway's own 0x11 cache (all zeros), so the standard inverter sensor
+    set is suppressed and this set reads the real whole-house data from the
+    gateway register banks instead (#194).
+    """
+
+    value_fn: Callable[[Any], Any] = field(default=lambda _: None)
+    # Skip creation when the value reads None at setup — used to gate the per-AIO
+    # slots (the register map always carries three; unpopulated slots have an
+    # empty serial and their fields read as absent).
+    skip_if_none: bool = False
+
+
+def _gateway_attr(name: str) -> Callable[[Any], Any]:
+    """Return a value_fn reading `name` off the gateway model."""
+    return lambda gateway: getattr(gateway, name, None)
+
+
+def _gateway_aio_attr(slot: int, name: str) -> Callable[[Any], Any]:
+    """Read a per-AIO field, gated on AIO slot `slot` being populated.
+
+    The Gateway register map carries three AIO slots regardless of how many
+    units are installed; unpopulated slots report zeros, which must surface as
+    absent rather than as a phantom third AIO. The gate is the parallel AIO
+    count register, NOT the per-slot serial: on the live GAAA0014 shape the
+    GatewayV2 serial layout decodes aio2_serial_number as None under the
+    pinned modbus release, which would wrongly drop a real second AIO
+    (Codex catch on #258).
+    """
+
+    def value(gateway: Any) -> Any:
+        count = getattr(gateway, "parallel_aio_num", None)
+        if count is None or slot > count:
+            return None
+        return getattr(gateway, name, None)
+
+    return value
+
+
 def _summary_attr(name: str) -> Callable[[InverterSummary], Any]:
     """Return a value_fn that reads `name` off an EMS managed-inverter summary.
 
@@ -1799,6 +1842,288 @@ EMS_LOAD_ENERGY_TODAY = GivEnergyEmsSensorDescription(
 )
 
 
+def _gateway_aio_energy(slot: int, direction: str) -> GivEnergyGatewaySensorDescription:
+    """Per-AIO daily charge/discharge energy description for AIO slot `slot`."""
+    return GivEnergyGatewaySensorDescription(
+        key=f"e_aio{slot}_{direction}_today",
+        name=f"AIO {slot} {direction.capitalize()} Energy Today",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=1,
+        value_fn=_gateway_aio_attr(slot, f"e_aio{slot}_{direction}_today"),
+        skip_if_none=True,
+    )
+
+
+# Whole-house + per-AIO telemetry from the Gateway register banks (#194).
+# Deliberately EXCLUDED pending upstream decode verdicts (first live data,
+# AberDino's Gen 1 Gateway, 2026-07-03): every `*_total` lifetime counter
+# (mis-scaled ~10^4), the combined `e_aio_charge/discharge_today` pair
+# (disagrees with the per-AIO sum), and `battery_type` (mis-decodes).
+GATEWAY_SENSORS: tuple[GivEnergyGatewaySensorDescription, ...] = (
+    GivEnergyGatewaySensorDescription(
+        key="p_load",
+        name="Load Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_gateway_attr("p_load"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="p_pv",
+        name="PV Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_gateway_attr("p_pv"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="p_aio_total",
+        name="AIO Power Total",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_gateway_attr("p_aio_total"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="p_ac1",
+        name="AC Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_gateway_attr("p_ac1"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="p_liberty",
+        name="Liberty Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_gateway_attr("p_liberty"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="e_load_today",
+        name="Load Energy Today",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("e_load_today"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="e_pv_today",
+        name="PV Energy Today",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("e_pv_today"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="e_grid_import_today",
+        name="Grid Import Today",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("e_grid_import_today"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="e_grid_export_today",
+        name="Grid Export Today",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("e_grid_export_today"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="e_battery_charge_today",
+        name="Battery Charge Today",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("e_battery_charge_today"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="e_battery_discharge_today",
+        name="Battery Discharge Today",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("e_battery_discharge_today"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="v_grid",
+        name="Grid Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("v_grid"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="v_load",
+        name="Load Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("v_load"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="v_grid_relay",
+        name="Grid Relay Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("v_grid_relay"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="v_inverter_relay",
+        name="Inverter Relay Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("v_inverter_relay"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="i_grid",
+        name="Grid Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("i_grid"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="i_load",
+        name="Load Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("i_load"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="i_pv",
+        name="PV Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr("i_pv"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="parallel_aio_num",
+        name="AIO Count",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_gateway_attr("parallel_aio_num"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="parallel_aio_online_num",
+        name="AIO Online Count",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_gateway_attr("parallel_aio_online_num"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="aio_state",
+        name="AIO State",
+        value_fn=lambda gateway: _managed_status(getattr(gateway, "aio_state", None)),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="gateway_work_mode",
+        name="Work Mode",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda gateway: _managed_status(getattr(gateway, "work_mode", None)),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="gateway_fault_codes",
+        name="Gateway Fault Codes",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda gateway: (
+            ", ".join(codes)
+            if (codes := getattr(gateway, "gateway_fault_codes", None))
+            else ("None" if codes is not None else None)
+        ),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="aio1_soc",
+        name="AIO 1 Battery SOC",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_gateway_aio_attr(1, "aio1_soc"),
+        skip_if_none=True,
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="aio2_soc",
+        name="AIO 2 Battery SOC",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_gateway_aio_attr(2, "aio2_soc"),
+        skip_if_none=True,
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="aio3_soc",
+        name="AIO 3 Battery SOC",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_gateway_aio_attr(3, "aio3_soc"),
+        skip_if_none=True,
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="p_aio1_inverter",
+        name="AIO 1 Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_gateway_aio_attr(1, "p_aio1_inverter"),
+        skip_if_none=True,
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="p_aio2_inverter",
+        name="AIO 2 Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_gateway_aio_attr(2, "p_aio2_inverter"),
+        skip_if_none=True,
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="p_aio3_inverter",
+        name="AIO 3 Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_gateway_aio_attr(3, "p_aio3_inverter"),
+        skip_if_none=True,
+    ),
+    _gateway_aio_energy(1, "charge"),
+    _gateway_aio_energy(1, "discharge"),
+    _gateway_aio_energy(2, "charge"),
+    _gateway_aio_energy(2, "discharge"),
+    _gateway_aio_energy(3, "charge"),
+    _gateway_aio_energy(3, "discharge"),
+)
+
+
 def _partial_failure_attributes(
     coordinator: GivEnergyUpdateCoordinator,
 ) -> dict[str, Any] | None:
@@ -2000,6 +2325,7 @@ async def async_setup_entry(
     # CONF_EXPOSE_PER_CELL and _reconcile_per_cell_entities (__init__).
     expose_per_cell = entry.options.get(CONF_EXPOSE_PER_CELL, True)
     ems = coordinator.data.ems
+    gateway = coordinator.data.gateway
 
     entities: list[SensorEntity] = []
 
@@ -2008,17 +2334,30 @@ async def async_setup_entry(
     # sensors stay — only the derived House Consumption is gated out per-description
     # via skip_if_ems (#201). The EMS plant-level aggregates are added alongside.
     #
+    # On a Gateway plant the 0x11 device is the gateway: `plant.inverter` decodes
+    # its cache as a spurious all-zeros SinglePhaseInverter, so the whole inverter
+    # set is suppressed in favour of GATEWAY_SENSORS below (#194).
+    #
     # Battery-data-only (#95): a parallel-mode AIO is controlled by its Gateway,
     # so its own inverter-level sensors (PV/grid/load/derived consumption) are
     # misleading. Drop them; keep the battery pack / HV stack / module / coordinator
     # data below. Control platforms suppress themselves the same way.
-    if not battery_data_only:
+    if not battery_data_only and gateway is None:
         entities.extend(
             GivEnergyInverterSensor(coordinator, description)
             for description in INVERTER_SENSORS
             if _include_inverter_sensor(
                 description, inverter, is_three_phase, is_aio, ems is not None
             )
+        )
+
+    if gateway is not None:
+        # Whole-house + per-AIO telemetry from the gateway register banks (#194).
+        # skip_if_none gates the unpopulated AIO slots (empty serial ⇒ None).
+        entities.extend(
+            GivEnergyGatewaySensor(coordinator, description)
+            for description in GATEWAY_SENSORS
+            if not description.skip_if_none or description.value_fn(gateway) is not None
         )
 
     if ems is not None:
@@ -2852,6 +3191,50 @@ class GivEnergyEmsSensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEn
         if ems is None:
             return None
         return self.entity_description.value_fn(ems)
+
+
+class GivEnergyGatewaySensor(CoordinatorEntity[GivEnergyUpdateCoordinator], SensorEntity):
+    """Whole-house telemetry sensor for a Gateway (device 0x11, #194).
+
+    On a Gateway plant the 0x11 device is the gateway itself: `plant.inverter`
+    decodes its cache as a spurious all-zeros SinglePhaseInverter, so the
+    standard inverter sensor set is suppressed and this set reads the real data
+    (whole-house load/PV, grid import/export, per-AIO SOC and energy) from
+    `plant.gateway` (GatewayV1/V2) on the same device, which it also names.
+    """
+
+    _attr_has_entity_name = True
+    entity_description: GivEnergyGatewaySensorDescription
+
+    def __init__(
+        self,
+        coordinator: GivEnergyUpdateCoordinator,
+        description: GivEnergyGatewaySensorDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        serial = coordinator.data.inverter_serial_number
+        self._attr_unique_id = f"{serial}_{description.key}"
+        gateway = coordinator.data.gateway
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            name=f"GivEnergy Gateway {serial}",
+            manufacturer="GivEnergy",
+            model=_MODEL_NAMES[Model.GATEWAY],
+            sw_version=getattr(gateway, "software_version", None),
+            serial_number=serial,
+        )
+
+    @property
+    def available(self) -> bool:
+        return super().available and self.coordinator.data.gateway is not None
+
+    @property
+    def native_value(self) -> Any:
+        gateway = self.coordinator.data.gateway
+        if gateway is None:
+            return None
+        return self.entity_description.value_fn(gateway)
 
 
 # Poll gaps beyond this many scan intervals contribute a single capped slice to the

--- a/custom_components/givenergy_local/switch.py
+++ b/custom_components/givenergy_local/switch.py
@@ -99,6 +99,10 @@ async def async_setup_entry(
     if entry.options.get(CONF_BATTERY_DATA_ONLY, False):
         # Battery-data-only (#95): this unit's controls are owned by its Gateway.
         return
+    if coordinator.data.gateway is not None:
+        # Gateway plant (#194): no validated write surface yet — the HR config
+        # block reads plausibly but writing through a Gateway is untested.
+        return
     entities: list[SwitchEntity] = []
     if coordinator.data.ems is not None:
         # EMS plant: inverter-level switches are redundant — only Flexi EMS Control

--- a/custom_components/givenergy_local/time.py
+++ b/custom_components/givenergy_local/time.py
@@ -262,6 +262,10 @@ async def async_setup_entry(
     if entry.options.get(CONF_BATTERY_DATA_ONLY, False):
         # Battery-data-only (#95): this unit's controls are owned by its Gateway.
         return
+    if coordinator.data.gateway is not None:
+        # Gateway plant (#194): no validated write surface yet — the HR config
+        # block reads plausibly but writing through a Gateway is untested.
+        return
     entities: list[TimeEntity] = []
     if coordinator.data.ems is not None:
         # EMS plant: the controller owns scheduling. Expose its slots and skip the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,6 +201,9 @@ def mock_plant(mock_inverter, mock_battery) -> MagicMock:
     # No EMS by default; the EMS-specific tests override this with a mock Ems so
     # the EMS scheduling entities are only created for EMS plants.
     plant.ems = None
+    # No Gateway by default (#194) — a bare MagicMock attribute would be truthy
+    # and route every test through the gateway branch. Gateway tests override.
+    plant.gateway = None
     # A real PlantCapabilities — the integration's save-on-success path calls
     # .to_dict() through CapabilitiesCache, which would choke on a MagicMock.
     plant.capabilities = PlantCapabilities(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2361,3 +2361,183 @@ async def test_lv_per_cell_present_when_option_absent(hass, mock_client):
     entry = await _setup_lv_with_option(hass, expose_per_cell=None)
     uids = _sensor_uids(hass, entry)
     assert any("_v_cell_" in u for u in uids)
+
+
+# ---------------------------------------------------------------------------
+# Gateway plant sensors (#194)
+# ---------------------------------------------------------------------------
+
+
+def _mock_gateway() -> MagicMock:
+    """A GatewayV1 stand-in populated with AberDino's real daylight values (#95)."""
+    gateway = MagicMock()
+    values = {
+        "software_version": "GAAA0014",
+        "p_load": 1127,
+        "p_pv": 2229,
+        "p_ac1": 917,
+        "p_liberty": 185,
+        "p_aio_total": 155,
+        "e_load_today": 8.1,
+        "e_pv_today": 3.8,
+        "e_grid_import_today": 28.0,
+        "e_grid_export_today": 1.2,
+        "e_battery_charge_today": 19.2,
+        "e_battery_discharge_today": 2.0,
+        "v_grid": 244.1,
+        "v_load": 244.9,
+        "v_grid_relay": 243.5,
+        "v_inverter_relay": 243.9,
+        "i_grid": 4.3,
+        "i_load": 5.5,
+        "i_pv": 9.0,
+        "parallel_aio_num": 2,
+        "parallel_aio_online_num": 2,
+        "aio_state": "Static",
+        "work_mode": 2,
+        "gateway_fault_codes": [],
+        "aio1_serial_number": "CH1111G111",
+        # None mirrors the live 2.9.6 decode: the GatewayV2 serial layout reads
+        # aio2_serial_number as None on real GAAA0014 hardware — the per-AIO gate
+        # must NOT depend on serials (Codex catch on #258; parallel_aio_num rules).
+        "aio2_serial_number": None,
+        "aio3_serial_number": "",  # unpopulated third slot
+        "aio1_soc": 94,
+        "aio2_soc": 96,
+        "aio3_soc": 0,
+        "p_aio1_inverter": 76,
+        "p_aio2_inverter": 79,
+        "p_aio3_inverter": 0,
+        "e_aio1_charge_today": 9.9,
+        "e_aio1_discharge_today": 1.4,
+        "e_aio2_charge_today": 9.3,
+        "e_aio2_discharge_today": 0.6,
+        "e_aio3_charge_today": 0.0,
+        "e_aio3_discharge_today": 0.0,
+    }
+    for name, value in values.items():
+        setattr(gateway, name, value)
+    return gateway
+
+
+def _setup_gateway_plant(mock_client) -> None:
+    """Reshape the mock plant into a Gen 1 Gateway (no LV packs, two meters)."""
+    from givenergy_modbus.model.inverter import Model
+    from givenergy_modbus.model.plant import PlantCapabilities
+
+    mock_client.plant.gateway = _mock_gateway()
+    mock_client.plant.batteries = []
+    # The spurious inverter decode still reads a real HR(0), so its model is
+    # GATEWAY on real hardware — the coordinator/datetime entities name the
+    # device from it and must agree with the gateway sensors' naming.
+    mock_client.plant.inverter.model = Model.GATEWAY
+    mock_client.plant.capabilities = PlantCapabilities(
+        device_type=Model.GATEWAY,
+        inverter_address=0x11,
+        meter_addresses=[0x01, 0x02],
+        lv_battery_addresses=[],
+        bcu_stacks=[],
+    )
+
+
+@pytest.fixture
+async def gateway_setup(hass, mock_client, mock_config_entry):
+    """Set up the integration against a Gateway plant."""
+    _setup_gateway_plant(mock_client)
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry
+
+
+async def test_gateway_creates_whole_house_and_per_aio_sensors(hass, gateway_setup):
+    """A Gateway entry surfaces whole-house + per-AIO telemetry from plant.gateway,
+    on a device named as a Gateway with the gateway's own firmware version."""
+    registry = er.async_get(hass)
+    expectations = {
+        "p_load": "1127",
+        "p_pv": "2229",
+        "e_load_today": "8.1",
+        "e_grid_import_today": "28.0",
+        "e_battery_charge_today": "19.2",
+        "v_grid": "244.1",
+        "aio1_soc": "94",
+        "aio2_soc": "96",
+        "e_aio1_charge_today": "9.9",
+        "p_aio2_inverter": "79",
+        "parallel_aio_online_num": "2",
+        "aio_state": "Static",
+        "gateway_fault_codes": "None",
+    }
+    for key, expected in expectations.items():
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}")
+        assert entity_id is not None, key
+        assert hass.states.get(entity_id).state == expected, key
+
+    dev_registry = dr.async_get(hass)
+    device = dev_registry.async_get_device(identifiers={(DOMAIN, "SA1234G123")})
+    assert device is not None
+    assert device.name == "GivEnergy Gateway SA1234G123"
+    assert device.sw_version == "GAAA0014"
+
+
+async def test_gateway_suppresses_inverter_sensors_and_controls(hass, gateway_setup):
+    """The spurious all-zeros inverter decode must surface NOTHING on a Gateway:
+    no standard inverter sensors, no controls, no Restart button (#194)."""
+    registry = er.async_get(hass)
+    for key in ("battery_soc", "e_pv_day", "p_load_demand"):
+        assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is None, key
+    control_rows = [
+        e
+        for e in er.async_entries_for_config_entry(registry, gateway_setup.entry_id)
+        if e.domain in ("number", "select", "switch", "time")
+    ]
+    assert control_rows == []
+    buttons = [
+        e
+        for e in er.async_entries_for_config_entry(registry, gateway_setup.entry_id)
+        if e.domain == "button"
+    ]
+    # Re-detect stays (safe read-side reload); Restart is gated off Gateway.
+    assert len(buttons) == 1
+    assert "redetect" in buttons[0].unique_id
+
+
+async def test_gateway_unpopulated_aio_slot_gated(hass, gateway_setup):
+    """The register map always carries three AIO slots; with parallel_aio_num=2
+    the third slot must not surface phantom sensors (gate = AIO count, not the
+    unreliable per-slot serial decode)."""
+    registry = er.async_get(hass)
+    for key in ("aio3_soc", "p_aio3_inverter", "e_aio3_charge_today", "e_aio3_discharge_today"):
+        assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is None, key
+
+
+async def test_gateway_upgrade_reconciles_stale_inverter_rows(hass, mock_client, mock_config_entry):
+    """A Gateway entry created on v1.3.38 (pre-GATEWAY_SENSORS) carries the full
+    inverter sensor/control set as 0/Unknown rows; setup removes them (#194)."""
+    from custom_components.givenergy_local.number import NUMBER_DESCRIPTIONS
+
+    _setup_gateway_plant(mock_client)
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_battery_soc", config_entry=mock_config_entry
+    )
+    number_key = NUMBER_DESCRIPTIONS[0].key
+    registry.async_get_or_create(
+        "number", DOMAIN, f"SA1234G123_{number_key}", config_entry=mock_config_entry
+    )
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_battery_soc") is None
+    assert registry.async_get_entity_id("number", DOMAIN, f"SA1234G123_{number_key}") is None
+    # The gateway sensors took over the device.
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_p_load") is not None
+
+
+async def test_non_gateway_plant_has_no_gateway_sensors(hass, setup_integration):
+    """The default (hybrid) fixture must not create any gateway sensors."""
+    registry = er.async_get(hass)
+    for key in ("aio1_soc", "p_load", "e_load_today", "gateway_fault_codes"):
+        assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is None, key


### PR DESCRIPTION
The follow-through on #95/#194 phase 2: a Gateway entry now surfaces real data instead of the 0/Unknown wall.

**Why everything read zero:** on a Gateway plant `plant.inverter` is a spurious all-zeros SinglePhaseInverter decoded from the gateway's own cache; the real data lives in `plant.gateway` (GatewayV1/V2). New `GATEWAY_SENSORS` + `GivEnergyGatewaySensor` (the EMS pattern) read it on the same 0x11 device: whole-house load/PV power, today's energies (load, PV, grid import/export, battery charge/discharge), voltages, per-AIO SOC/power/energies, parallel status, fault codes. Unpopulated AIO slots are gated on their empty serial.

**Held back pending upstream decode verdicts** (from the first live data): lifetime `*_total` counters (mis-scaled ~10⁴), the combined `e_aio_charge/discharge_today` pair (≠ per-AIO sum), `battery_type`.

**Suppression:** the standard inverter set is suppressed on Gateway, all control platforms + Restart gate off Gateway entries (no validated write surface), and a reconciler removes the stale rows a v1.3.38 Gateway entry created.

**Test fixture uses AberDino's real daylight values** (p_load 1127 W, per-AIO SOC 94/96, charge todays 9.9+9.3=19.2). 578 Python + 42 JS green; ruff/mypy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gateway devices with dedicated telemetry, including whole-house power, daily energy, and per-AIO battery readings where available.

* **Bug Fixes**
  * Prevented standard inverter sensors, switches, numbers, selects, time controls, and restart actions from appearing on Gateway setups.
  * Improved handling of existing setups so outdated entities are removed when a Gateway is detected.

* **Documentation**
  * Updated the supported devices and entity documentation to reflect Gateway support and its current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->