### PR TITLE
feat: adopt givenergy-modbus 2.9.7 — Gateway lifetime totals + AC-side energy set

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ Confirmed working on real hardware:
 - AC-coupled (Gen 1)
 - All-in-One (AIO) — including per-module battery devices with per-cell data; needs v1.2.0 or later
 - EMS controller — validated on a live two-inverter EMS plant; some polling rough edges on busy shared buses are still being smoothed out in the library
-- Gateway (V1 / V2) — validated on a Gen 1 Gateway with two AIOs; exposes whole-house load/PV power and energy, grid import/export, and per-AIO SOC and charge/discharge. Lifetime totals are held back pending a decode fix, and no controls are offered through a Gateway yet
+- Hybrid three-phase — per-phase electricals, HV stacks with per-cell BMU data
+- HV battery stacks (BCU/BMU) — decoded per module, at their own device addresses
+- Gateway (Gen 1) — validated on a Gen 1 Gateway fronting two AIOs; exposes whole-house load/PV power and energy, grid import/export, lifetime totals, and per-AIO SOC and charge/discharge (needs v1.3.39 or later). No controls are offered through a Gateway yet
 
 The following have modelled register maps and are expected to work, but haven't yet been validated end-to-end by an owner — if yours is one of these and you run into sensor values that look wrong, please [open an issue](https://github.com/dewet22/givenergy-hass/issues):
 
-- Hybrid three-phase
-- HV battery stacks (BCU/BMU)
+- Hybrid single-phase Gen 2 — modelled, but no Gen 2 unit has ever been observed; a field report from an EA-prefix serial would settle its detection code
+- Polar, AIO Commercial, EMS Commercial, and 3-phase AC — model codes known, decode unverified against real hardware
 
 If you'd like to help validate, a wire-frame capture is the most useful thing you can include. If you already have the integration running, use the built-in action from **Developer Tools → Actions** (named **Services** in older Home Assistant versions):
 
@@ -224,7 +226,7 @@ These replace the Integral + Utility Meter helpers a Predbat EMS setup previousl
 
 ### Gateway device
 
-An entry pointed at a Gen 1 Gateway surfaces whole-house telemetry from the Gateway's own registers ([#194](https://github.com/dewet22/givenergy-hass/issues/194)): load and PV power, today's load / PV / grid import / grid export / battery charge / battery discharge energy, grid and load voltage, and — per attached AIO — battery SOC, power, and today's charge/discharge energy (unpopulated AIO slots are omitted). The standard inverter sensor set is suppressed on a Gateway entry: the Gateway's inverter-shaped registers read as zeros, and the real data lives in the Gateway banks. Lifetime totals are deliberately held back pending an upstream decode fix, and no control entities are offered through a Gateway yet. Your per-AIO entries (typically in battery-data-only mode) continue to work alongside.
+An entry pointed at a Gen 1 Gateway surfaces whole-house telemetry from the Gateway's own registers ([#194](https://github.com/dewet22/givenergy-hass/issues/194)): load and PV power, today's and lifetime load / PV / grid import / grid export / battery charge / battery discharge energy, grid and load voltage, and — per attached AIO — battery SOC, power, and today's/lifetime charge/discharge energy (unpopulated AIO slots are omitted). Two energy sets coexist by design: *Battery Charge/Discharge* figures are battery-DC energy, while the *AIO AC Charge/Discharge* figures are the AC-side site set — conversion losses sit between them, and on sites with a GivEnergy EV charger the AC-side charge figure includes EV charging energy. The standard inverter sensor set is suppressed on a Gateway entry: the Gateway's inverter-shaped registers read as zeros, and the real data lives in the Gateway banks. No control entities are offered through a Gateway yet. Your per-AIO entries (typically in battery-data-only mode) continue to work alongside.
 
 ### Services
 

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus==2.9.6"
+    "givenergy-modbus==2.9.7"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1842,25 +1842,41 @@ EMS_LOAD_ENERGY_TODAY = GivEnergyEmsSensorDescription(
 )
 
 
-def _gateway_aio_energy(slot: int, direction: str) -> GivEnergyGatewaySensorDescription:
-    """Per-AIO daily charge/discharge energy description for AIO slot `slot`."""
+def _gateway_aio_energy(
+    slot: int, direction: str, period: str
+) -> GivEnergyGatewaySensorDescription:
+    """Per-AIO charge/discharge energy description for AIO slot `slot`."""
     return GivEnergyGatewaySensorDescription(
-        key=f"e_aio{slot}_{direction}_today",
-        name=f"AIO {slot} {direction.capitalize()} Energy Today",
+        key=f"e_aio{slot}_{direction}_{period}",
+        name=f"AIO {slot} {direction.capitalize()} Energy {period.capitalize()}",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=1,
-        value_fn=_gateway_aio_attr(slot, f"e_aio{slot}_{direction}_today"),
+        value_fn=_gateway_aio_attr(slot, f"e_aio{slot}_{direction}_{period}"),
         skip_if_none=True,
     )
 
 
+def _gateway_energy(key: str, name: str) -> GivEnergyGatewaySensorDescription:
+    """A plain kWh TOTAL_INCREASING gateway energy description."""
+    return GivEnergyGatewaySensorDescription(
+        key=key,
+        name=name,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=1,
+        value_fn=_gateway_attr(key),
+    )
+
+
 # Whole-house + per-AIO telemetry from the Gateway register banks (#194).
-# Deliberately EXCLUDED pending upstream decode verdicts (first live data,
-# AberDino's Gen 1 Gateway, 2026-07-03): every `*_total` lifetime counter
-# (mis-scaled ~10^4), the combined `e_aio_charge/discharge_today` pair
-# (disagrees with the per-AIO sum), and `battery_type` (mis-decodes).
+# Lifetime `*_total` counters require modbus >= 2.9.7 (the #360 V1 word-order
+# fix — earlier releases assembled them ~10^4 too large on live hardware).
+# Energy semantics (verdict from AberDino's captures, modbus#360): `e_aio_*` is
+# the AC-side site energy set — on his unit it includes EV-charger energy —
+# while `e_battery_*` is battery-DC energy. Both are real; named distinctly.
 GATEWAY_SENSORS: tuple[GivEnergyGatewaySensorDescription, ...] = (
     GivEnergyGatewaySensorDescription(
         key="p_load",
@@ -2115,12 +2131,32 @@ GATEWAY_SENSORS: tuple[GivEnergyGatewaySensorDescription, ...] = (
         value_fn=_gateway_aio_attr(3, "p_aio3_inverter"),
         skip_if_none=True,
     ),
-    _gateway_aio_energy(1, "charge"),
-    _gateway_aio_energy(1, "discharge"),
-    _gateway_aio_energy(2, "charge"),
-    _gateway_aio_energy(2, "discharge"),
-    _gateway_aio_energy(3, "charge"),
-    _gateway_aio_energy(3, "discharge"),
+    _gateway_aio_energy(1, "charge", "today"),
+    _gateway_aio_energy(1, "discharge", "today"),
+    _gateway_aio_energy(2, "charge", "today"),
+    _gateway_aio_energy(2, "discharge", "today"),
+    _gateway_aio_energy(3, "charge", "today"),
+    _gateway_aio_energy(3, "discharge", "today"),
+    _gateway_aio_energy(1, "charge", "total"),
+    _gateway_aio_energy(1, "discharge", "total"),
+    _gateway_aio_energy(2, "charge", "total"),
+    _gateway_aio_energy(2, "discharge", "total"),
+    _gateway_aio_energy(3, "charge", "total"),
+    _gateway_aio_energy(3, "discharge", "total"),
+    # Site lifetime totals (require the modbus 2.9.7 word-order fix, #360).
+    _gateway_energy("e_grid_import_total", "Grid Import Total"),
+    _gateway_energy("e_grid_export_total", "Grid Export Total"),
+    _gateway_energy("e_pv_total", "PV Energy Total"),
+    _gateway_energy("e_load_total", "Load Energy Total"),
+    _gateway_energy("e_battery_charge_total", "Battery Charge Total"),
+    _gateway_energy("e_battery_discharge_total", "Battery Discharge Total"),
+    # AC-side site charge/discharge (distinct from the battery-DC set above:
+    # conversion losses sit between them, and on sites with a GivEnergy EV
+    # charger the AC-side charge figure includes EV charging energy).
+    _gateway_energy("e_aio_charge_today", "AIO AC Charge Today"),
+    _gateway_energy("e_aio_discharge_today", "AIO AC Discharge Today"),
+    _gateway_energy("e_aio_charge_total", "AIO AC Charge Total"),
+    _gateway_energy("e_aio_discharge_total", "AIO AC Discharge Total"),
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
     # an upstream patch that wasn't validated against this integration. Bump both
     # this and manifest.json together.
-    "givenergy-modbus==2.9.6",
+    "givenergy-modbus==2.9.7",
 ]
 
 [dependency-groups]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2414,6 +2414,25 @@ def _mock_gateway() -> MagicMock:
         "e_aio2_discharge_today": 0.6,
         "e_aio3_charge_today": 0.0,
         "e_aio3_discharge_today": 0.0,
+        # Lifetime totals: V1-word-order sane values (modbus 2.9.7, #360).
+        "e_grid_import_total": 12710.8,
+        "e_grid_export_total": 2192.7,
+        "e_pv_total": 5087.0,
+        "e_load_total": 12006.4,
+        "e_battery_charge_total": 8855.9,
+        "e_battery_discharge_total": 8998.8,
+        "e_aio1_charge_total": 4501.2,
+        "e_aio1_discharge_total": 4602.3,
+        "e_aio2_charge_total": 4354.7,
+        "e_aio2_discharge_total": 4396.5,
+        "e_aio3_charge_total": 0.0,
+        "e_aio3_discharge_total": 0.0,
+        # AC-side site set — distinct semantics from e_battery_* (DC side);
+        # includes EV-charger energy on AberDino's unit.
+        "e_aio_charge_today": 23.9,
+        "e_aio_discharge_today": 1.5,
+        "e_aio_charge_total": 9107.4,
+        "e_aio_discharge_total": 7801.2,
     }
     for name, value in values.items():
         setattr(gateway, name, value)
@@ -2464,6 +2483,11 @@ async def test_gateway_creates_whole_house_and_per_aio_sensors(hass, gateway_set
         "aio1_soc": "94",
         "aio2_soc": "96",
         "e_aio1_charge_today": "9.9",
+        "e_grid_import_total": "12710.8",
+        "e_battery_charge_total": "8855.9",
+        "e_aio1_charge_total": "4501.2",
+        "e_aio_charge_today": "23.9",
+        "e_aio_charge_total": "9107.4",
         "p_aio2_inverter": "79",
         "parallel_aio_online_num": "2",
         "aio_state": "Static",
@@ -2508,7 +2532,14 @@ async def test_gateway_unpopulated_aio_slot_gated(hass, gateway_setup):
     the third slot must not surface phantom sensors (gate = AIO count, not the
     unreliable per-slot serial decode)."""
     registry = er.async_get(hass)
-    for key in ("aio3_soc", "p_aio3_inverter", "e_aio3_charge_today", "e_aio3_discharge_today"):
+    for key in (
+        "aio3_soc",
+        "p_aio3_inverter",
+        "e_aio3_charge_today",
+        "e_aio3_discharge_today",
+        "e_aio3_charge_total",
+        "e_aio3_discharge_total",
+    ):
         assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is None, key
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = "==2.9.6" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.9.7" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.9.6"
+version = "2.9.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/7e/79a7732a1a20711cf3376ed1e79cfe2cb3e7afcbd1c22aba0837838eb875/givenergy_modbus-2.9.6.tar.gz", hash = "sha256:6b4d344f687def5b158b2e37755e722db394694ff94584678760a581afa49151", size = 510011, upload-time = "2026-07-02T23:04:54.872Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/17/921947fa8bc069ee8cdb625eb8a43ae507481d7232d85ba689588d7021b8/givenergy_modbus-2.9.7.tar.gz", hash = "sha256:f7339c23784d088bcf47607412ea83e85e0a4b70401cea414a2c38e3473d3a05", size = 527236, upload-time = "2026-07-07T11:10:29.294Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/30/88dcdcef127861343e776b0f14b5e68d71e83c46d0399ccca7315e24a244/givenergy_modbus-2.9.6-py3-none-any.whl", hash = "sha256:9012f10f7a1ac90a79ba91f61df88d4d43c0005d7f48fc3798d64e684d91ae66", size = 200745, upload-time = "2026-07-02T23:04:53.358Z" },
+    { url = "https://files.pythonhosted.org/packages/82/62/89ca9600075c941cf1d4da10d7433f054df47dc4557a5ab7250daaa28c0c/givenergy_modbus-2.9.7-py3-none-any.whl", hash = "sha256:be74d75b9b4eefdc06dd56d6504e6a7fae109170d03bc0d5ea97b5f63767a1d6", size = 202205, upload-time = "2026-07-07T11:10:27.899Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-through on #258 once the modbus#360 fix shipped (2.9.7): `select_gateway()` defaults to V1 word order (the version-based selector was falsified by the first live unit) and the per-AIO serial layout is corrected.

**Lifts the #258 hold:** site lifetime totals (grid import/export, PV, load, battery charge/discharge), per-AIO lifetime totals (`parallel_aio_num`-gated), and the AC-side site set (`e_aio_charge/discharge` today+total) named **AIO AC …** — distinct real semantics from the battery-DC set (conversion losses between them; includes EV-charger energy on equipped sites, per AberDino's observation — this explains the 24.0 vs 19.2 discrepancy flagged in #258).

README: Gateway section updated; supported-hardware list aligned with the library's validated matrix.

Test fixture carries the V1-order sane totals from the decode verdict (grid import 12,710.8 kWh etc.). 578 Python + 42 JS green; ruff/mypy clean.