### PR TITLE
feat: fast reconnect on ConnectionLost

### DIFF
--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from givenergy_modbus.client.client import Client
 from givenergy_modbus.exceptions import (
+    ConnectionLost,
     PlantTopologyMismatch,
     ReadFailure,
     RefreshFailed,
@@ -291,8 +292,31 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         except UpdateFailed:
             self._record_failure()
             raise
+        except ConnectionLost as err:
+            # The library has declared the connection known-dead (2.9.5+). It
+            # subclasses TimeoutError for compatibility, but treating it as a
+            # transient timeout would keep the dead client and burn the whole
+            # timeout tolerance serving stale data (~2 extra ticks). Reset now
+            # so the very next tick reconnects; serve last-known for THIS tick
+            # so entities don't flap for a single interval. Must precede the
+            # RefreshFailed/TimeoutError arms.
+            self._record_failure()
+            await self._reset_client()
+            return await self._serve_last_known_or_fail(
+                "Connection lost — reconnecting on next update", err
+            )
         except RefreshFailed as err:
             self._record_failure()
+            if self._contains_connection_lost(err):
+                # The wrapped form of the known-dead case above: a total read
+                # failure whose cause group carries ConnectionLost. It would
+                # otherwise pass the timeout-only test below (ConnectionLost
+                # subclasses TimeoutError) and keep the dead client for the
+                # whole tolerance window (#261 review).
+                await self._reset_client()
+                return await self._serve_last_known_or_fail(
+                    "Connection lost — reconnecting on next update", err
+                )
             if self._is_timeout_failure(err):
                 # Every read timed out — treat like the bare-TimeoutError path
                 # below: transient, keep the client and serve last-known data
@@ -402,6 +426,14 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                 len(exc.failures),
                 _summarize_failures(exc.failures),
             )
+
+    def _contains_connection_lost(self, err: RefreshFailed) -> bool:
+        """True when any grouped cause of a RefreshFailed is a ConnectionLost."""
+        cause = err.cause
+        if isinstance(cause, BaseExceptionGroup):
+            match, _ = cause.split(ConnectionLost)
+            return match is not None
+        return isinstance(cause, ConnectionLost)
 
     def _is_timeout_failure(self, err: RefreshFailed) -> bool:
         """True if every underlying cause of a RefreshFailed is a timeout.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -188,6 +188,96 @@ async def test_timeout_reaching_tolerance_resets_client(hass, mock_plant):
         assert coordinator._client is None
 
 
+async def test_connection_lost_resets_client_immediately(hass, mock_plant):
+    """ConnectionLost is a known-dead connection (2.9.5): unlike a transient
+    TimeoutError (which preserves the client for the whole tolerance window),
+    it must reset the client on the FIRST failure so the next tick reconnects —
+    while still serving last-known data for this one tick."""
+    from givenergy_modbus.exceptions import ConnectionLost
+
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, timeout_tolerance=3)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.refresh = AsyncMock(side_effect=ConnectionLost("connection lost"))
+        mock_cls.return_value = client
+        coordinator._client = client
+        coordinator.data = mock_plant  # seed stale data
+
+        result = await coordinator._async_update_data()  # failure 1 — resets anyway
+
+        client.close.assert_awaited_once()
+        assert coordinator._client is None
+        assert result is mock_plant  # one tick of last-known, no entity flap
+        assert coordinator.consecutive_failures == 1
+
+
+async def test_connection_lost_then_next_tick_reconnects(hass, mock_plant):
+    """After a ConnectionLost reset, the very next tick runs the full reconnect
+    path (fresh Client, load_config + refresh) and recovers."""
+    from givenergy_modbus.exceptions import ConnectionLost
+
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, timeout_tolerance=3)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        dead = AsyncMock()
+        dead.connected = True
+        dead.plant = mock_plant
+        dead.refresh = AsyncMock(side_effect=ConnectionLost("connection lost"))
+        fresh = AsyncMock()
+        fresh.connected = True
+        fresh.plant = mock_plant
+        fresh.refresh = AsyncMock(return_value=mock_plant)
+        fresh.load_config = AsyncMock(return_value=mock_plant)
+        mock_cls.return_value = fresh
+        coordinator._client = dead
+        coordinator.data = mock_plant
+
+        await coordinator._async_update_data()  # ConnectionLost → reset
+        assert coordinator._client is None
+
+        result = await coordinator._async_update_data()  # reconnect tick
+
+    fresh.load_config.assert_awaited_once()
+    fresh.refresh.assert_awaited_once()
+    assert result is mock_plant
+    assert coordinator.consecutive_failures == 0
+
+
+async def test_refresh_failed_wrapping_connection_lost_resets_client(hass, mock_plant):
+    """A total refresh failure whose cause group carries ConnectionLost is the
+    wrapped form of the known-dead case: it must reset immediately and serve one
+    tick of last-known — NOT pass the timeout-only test (ConnectionLost
+    subclasses TimeoutError) and keep the dead client (#261 review)."""
+    from givenergy_modbus.exceptions import ConnectionLost
+
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, timeout_tolerance=3)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.refresh = AsyncMock(
+            side_effect=RefreshFailed(
+                "all reads failed",
+                failures=[],
+                cause=ExceptionGroup("reads", [ConnectionLost("link dead"), TimeoutError()]),
+            )
+        )
+        mock_cls.return_value = client
+        coordinator._client = client
+        coordinator.data = mock_plant  # seed stale data
+
+        result = await coordinator._async_update_data()
+
+        client.close.assert_awaited_once()
+        assert coordinator._client is None
+        assert result is mock_plant
+        assert coordinator.consecutive_failures == 1
+
+
 async def test_detect_timeout_on_reconnect_discards_client(hass, mock_plant):
     """A reconnect whose detect() times out must not retain a capability-less client.
 


### PR DESCRIPTION
Adopts the opt-in offered with modbus 2.9.5: `ConnectionLost` subclasses `TimeoutError` for compatibility, so a known-dead connection previously rode the transient-timeout path — burning the timeout tolerance (~2 extra ticks of stale data) before anything reconnected. New arm ahead of `RefreshFailed`/`TimeoutError`: record failure, reset the client immediately, serve last-known for this single tick; the next tick reconnects. Two pinning tests (first-failure reset vs TimeoutError's preserved client; next-tick recovery). 580 Python + 42 JS green.