### PR TITLE
fix: adopt OptionsFlowWithReload (HA 2026.12 deprecation)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -716,11 +716,6 @@ def _reconcile_ac_coupled_dc_limits(
             registry.async_remove(entity_id)
 
 
-async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload the entry when its options change (registered as an update listener)."""
-    await hass.config_entries.async_reload(entry.entry_id)
-
-
 @callback
 def _check_system_time_drift(
     hass: HomeAssistant, entry: ConfigEntry, coordinator: GivEnergyUpdateCoordinator
@@ -903,11 +898,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             coordinator._prior_capabilities = live_capabilities
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
-
-    # Reload the entry when its options change (e.g. the battery-data-only toggle,
-    # #95), so the platforms re-enumerate with the new filter. No listener exists
-    # otherwise, so an options change would have no effect until a manual reload.
-    entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
 
     # Watch the inverter clock each poll and raise a repair when it drifts (#219).
     @callback

--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
-    OptionsFlow,
+    OptionsFlowWithReload,
 )
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
@@ -170,13 +170,13 @@ class GivEnergyLocalConfigFlow(ConfigFlow, domain=DOMAIN):
             await client.close()
 
 
-class GivEnergyLocalOptionsFlow(OptionsFlow):
+class GivEnergyLocalOptionsFlow(OptionsFlowWithReload):
     """Per-entry options.
 
     Currently just the battery-data-only toggle (#95): for a unit controlled by a
     Gateway in a parallel group, suppress its control entities and inverter-level
     system sensors, leaving only battery / HV-stack / module / diagnostic data.
-    Changing it reloads the entry (see the update listener in __init__).
+    Saving reloads the entry (OptionsFlowWithReload) so the platforms re-enumerate.
     """
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:


### PR DESCRIPTION
Field report from AberDino (#95): HA's `helpers.frame` WARNING about our reload-only update listener, which stops working in HA 2026.12. The options flow now inherits `OptionsFlowWithReload`; the manual `_async_reload_entry` listener is removed (reconfigure already handles its own reload via `async_update_reload_and_abort`). Behaviour identical; 584 Python + 42 JS green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changing integration options now automatically reloads the integration, so updated settings take effect without manual steps.
  * Improved the options flow experience to ensure platform updates are applied consistently after saving changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->