### PR TITLE
chore(deps): adopt givenergy-modbus 2.9.8 (splice-reject log coalescing)

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus==2.9.7"
+    "givenergy-modbus==2.9.8"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
     # an upstream patch that wasn't validated against this integration. Bump both
     # this and manifest.json together.
-    "givenergy-modbus==2.9.7",
+    "givenergy-modbus==2.9.8",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = "==2.9.7" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.9.8" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.9.7"
+version = "2.9.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/17/921947fa8bc069ee8cdb625eb8a43ae507481d7232d85ba689588d7021b8/givenergy_modbus-2.9.7.tar.gz", hash = "sha256:f7339c23784d088bcf47607412ea83e85e0a4b70401cea414a2c38e3473d3a05", size = 527236, upload-time = "2026-07-07T11:10:29.294Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/88/bb3fede3f37263cc35b702f7bf6e73bde5c95e91339e528a3d90ace7be3a/givenergy_modbus-2.9.8.tar.gz", hash = "sha256:31abc18c2df33db811378ed7890f3be289b7dd9d0975031514755f168788838f", size = 529958, upload-time = "2026-07-07T17:11:34.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/62/89ca9600075c941cf1d4da10d7433f054df47dc4557a5ab7250daaa28c0c/givenergy_modbus-2.9.7-py3-none-any.whl", hash = "sha256:be74d75b9b4eefdc06dd56d6504e6a7fae109170d03bc0d5ea97b5f63767a1d6", size = 202205, upload-time = "2026-07-07T11:10:27.899Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b9/459c6170cbe1983dcfaf3000d1b46ea723ba946ce4e1fc7a2be5748fce83/givenergy_modbus-2.9.8-py3-none-any.whl", hash = "sha256:31c71db15a1a261b9469048fc3fdd8e6446fe80c96ffee994c6be141d0b52e63", size = 203632, upload-time = "2026-07-07T17:11:32.904Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pin bump `==2.9.7` → `==2.9.8` (final planned 2.9.x). Logging-only upstream change: splice-reject WARNING coalescing (modbus#355); "please report if seen" now marks genuinely novel corruption shapes only. Call surface introspection-verified; 584 Python + 42 JS green. Dep-bump: merging on green CI.