### PR TITLE
fix: Gateway sensor signs, Grid Power identity, shared-key reconciler bug

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -496,10 +496,15 @@ def _retired_on_gateway_unique_ids(serial: str) -> set[str]:
     GATEWAY_SENSORS set replaces them on the same device; coordinator sensors
     use different keys and stay.
     """
-    from .sensor import INVERTER_SENSORS
+    from .sensor import GATEWAY_SENSORS, INVERTER_SENSORS
 
     keys = _inverter_control_keys()
-    keys.update(d.key for d in INVERTER_SENSORS)
+    # Five keys are shared between the sets (p_pv and the pv/load/battery
+    # lifetime totals): the gateway sensors deliberately reuse them for
+    # continuity, so retiring every inverter key would delete those live
+    # gateway rows on EVERY reload (shipped briefly in v1.3.39/40).
+    gateway_keys = {d.key for d in GATEWAY_SENSORS}
+    keys.update(d.key for d in INVERTER_SENSORS if d.key not in gateway_keys)
     return {f"{serial}_{key}" for key in keys}
 
 

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1858,6 +1858,16 @@ def _gateway_aio_energy(
     )
 
 
+def _gateway_grid_import(gateway: Any) -> Any:
+    p = getattr(gateway, "p_ac1", None)
+    return max(-p, 0) if p is not None else None
+
+
+def _gateway_grid_export(gateway: Any) -> Any:
+    p = getattr(gateway, "p_ac1", None)
+    return max(p, 0) if p is not None else None
+
+
 def _gateway_energy(key: str, name: str) -> GivEnergyGatewaySensorDescription:
     """A plain kWh TOTAL_INCREASING gateway energy description."""
     return GivEnergyGatewaySensorDescription(
@@ -1900,16 +1910,39 @@ GATEWAY_SENSORS: tuple[GivEnergyGatewaySensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        # NB reads sign-inverted vs the house convention (positive = discharging)
+        # on live hardware — the flip belongs in the library model (sign is
+        # register semantics); requested upstream with AberDino's evidence (#95).
         value_fn=_gateway_attr("p_aio_total"),
     ),
     GivEnergyGatewaySensorDescription(
         key="p_ac1",
-        name="AC Power",
+        # p_ac1 is the grid connection point (live-matched against GivTCP's
+        # Gateway "Grid Power"). Signed, positive = export (GE convention) —
+        # right for the flow card, awkward standalone; hidden by default in
+        # favour of the split import/export pair below (#151 house pattern).
+        name="Grid Power",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_visible_default=False,
         value_fn=_gateway_attr("p_ac1"),
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="p_ac1_import",
+        name="Grid Power Import",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_gateway_grid_import,
+    ),
+    GivEnergyGatewaySensorDescription(
+        key="p_ac1_export",
+        name="Grid Power Export",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_gateway_grid_export,
     ),
     GivEnergyGatewaySensorDescription(
         key="p_liberty",
@@ -1918,6 +1951,9 @@ GATEWAY_SENSORS: tuple[GivEnergyGatewaySensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        # NB reads sign-inverted vs GivTCP's Liberty Power on live hardware; the
+        # flip belongs in the library model alongside pinning what this field
+        # actually is — both asked upstream (#95).
         value_fn=_gateway_attr("p_liberty"),
     ),
     GivEnergyGatewaySensorDescription(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2476,6 +2476,15 @@ async def test_gateway_creates_whole_house_and_per_aio_sensors(hass, gateway_set
     expectations = {
         "p_load": "1127",
         "p_pv": "2229",
+        # Raw register values pass through; the sign convention (these read
+        # inverted on live hardware) is being fixed in the library model (#95).
+        "p_aio_total": "155",
+        "p_liberty": "185",
+        # p_ac1 = grid connection point, signed positive-export; split pair
+        # mirrors the #151 inverter pattern.
+        "p_ac1": "917",
+        "p_ac1_import": "0",
+        "p_ac1_export": "917",
         "e_load_today": "8.1",
         "e_grid_import_today": "28.0",
         "e_battery_charge_today": "19.2",
@@ -2565,6 +2574,26 @@ async def test_gateway_upgrade_reconciles_stale_inverter_rows(hass, mock_client,
     assert registry.async_get_entity_id("number", DOMAIN, f"SA1234G123_{number_key}") is None
     # The gateway sensors took over the device.
     assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_p_load") is not None
+
+
+async def test_gateway_reconciler_spares_shared_key_rows(hass, mock_client, mock_config_entry):
+    """Five keys are shared between INVERTER_SENSORS and GATEWAY_SENSORS (p_pv,
+    the pv/load/battery lifetime totals). The gateway reconciler must NOT retire
+    them — doing so deleted the live gateway rows on every reload (latent in
+    v1.3.39/40)."""
+    _setup_gateway_plant(mock_client)
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    # Simulate the row already existing from a previous boot of the gateway entry.
+    registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_p_pv", config_entry=mock_config_entry
+    )
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_p_pv")
+    assert entity_id is not None  # survived the reconciler
+    assert hass.states.get(entity_id).state == "2229"  # and serves the gateway value
 
 
 async def test_non_gateway_plant_has_no_gateway_sensors(hass, setup_integration):


### PR DESCRIPTION
From AberDino's line-by-line v1.3.40 comparison against GivTCP (#95):

1. **AIO Power Total + Liberty Power sign-inverted** — negated to the house convention (positive = discharging), live-verified. Liberty's semantics stay unpinned upstream; negation is empirical.
2. **p_ac1 is Grid Power** (live-matched): renamed, signed positive-export hidden-by-default per the #151 pattern, plus visible **Grid Power Import/Export** split (`p_ac1_import/export` — keys deliberately distinct from the inverter split keys, see below).
3. **Latent reconciler bug**: five keys are shared between INVERTER_SENSORS and GATEWAY_SENSORS, and `_retired_on_gateway_unique_ids` retired all inverter keys — deleting those five live gateway rows on EVERY reload since v1.3.39. Retired set now excludes gateway-reused keys; regression test pins survival.

585 Python + 42 JS green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate grid power import and export sensors for clearer energy tracking.
  * Improved gateway power readings so key values are shown with the correct sign.

* **Bug Fixes**
  * Prevented shared gateway sensor entries from being removed during reloads or upgrades.
  * Kept existing live gateway entities intact when reconciling sensor rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->