### PR TITLE
feat: adopt givenergy-modbus 2.10.1 — honest AC/AIO output fields + migrations module

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Running both integrations in parallel makes it easy to evaluate a switch without
 | Consecutive Refresh Failures | — | Diagnostic; resets to 0 on next success |
 | Total Refresh Failures | — | Diagnostic; ever-increasing counter (resets only when HA restarts — HA's long-term statistics handle that transparently) |
 
+Some energy sensors are model-dependent: on AC-coupled and All-in-One systems the registers historically labelled *PV Generation Today/Total* actually count the unit's battery-discharge AC output, so from v1.3.41 they appear there as **Inverter Output Today/Total** instead (existing entities are renamed in place, keeping their history), and the PV-derived sensors (Self Consumption, PV Direct) don't exist on those models.
+
 #### Controls
 
 | Entity | Type | Notes |

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -7,7 +7,6 @@ import sys
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import TypedDict
 
 import voluptuous as vol
 from givenergy_modbus.client import commands
@@ -35,7 +34,6 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_BATTERY_DATA_ONLY,
-    CONF_EXPOSE_PER_CELL,
     CONF_RETRIES,
     CONF_SCAN_INTERVAL,
     CONF_TIMEOUT_TOLERANCE,
@@ -64,6 +62,16 @@ from .http import (
     capture_dir,
     write_capture,
 )
+from .migrations import (
+    _migrate_ac_aio_pv_generation,
+    _migrate_unique_ids,
+    _reconcile_ac_coupled_dc_limits,
+    _reconcile_aio_house_consumption,
+    _reconcile_ems_entities,
+    _reconcile_gateway_entities,
+    _reconcile_per_cell_entities,
+    _reconcile_readability_gated_controls,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,7 +86,7 @@ _STRATEGY_URL = f"/{DOMAIN}/{_STRATEGY_FILENAME}"
 # served from the same package dir so they resolve offline without a CDN.
 _FONTS_DIRNAME = "fonts"
 _FONTS_URL = f"/{DOMAIN}/{_FONTS_DIRNAME}"
-_STRATEGY_VERSION = "11"
+_STRATEGY_VERSION = "12"
 
 # Per-config-entry topology cache. PlantCapabilities is persisted as
 # `to_dict()` directly (no envelope) following HA Core's Store convention —
@@ -359,206 +367,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-# unique_id suffixes renamed in givenergy-modbus #174 (2.1.1). The old data is
-# valid — IR35 was always AC charge, merely mislabelled "load" — so re-point the
-# existing registry entry to the new unique_id, carrying its history, statistics
-# and customisations across rather than orphaning it and starting fresh.
-
-# Values: (new_uid_suffix, old_entity_id_slug | None).
-# old_entity_id_slug is the name-slug the entity carried before renaming; None
-# means no entity_id rename is needed (unique_id suffix change only).
-_RENAMED_UNIQUE_ID_SUFFIXES: dict[str, tuple[str, str | None]] = {
-    # givenergy-modbus #174 (2.1.1): IR35 was AC charge, not house load.
-    "e_load_day": ("e_ac_charge_today", None),
-    # givenergy-modbus #174/#176 (2.1.2): IR44/IR45-46 are PV generation, not
-    # inverter AC output. Move both sensors together so today+total stay paired.
-    "e_inverter_out_day": ("e_pv_generation_today", None),
-    "e_inverter_out_total": ("e_pv_generation_total", None),
-    # #52: p_grid_out (IR30) is a signed net flow, not export-only — rename the
-    # surfaced entity to "Grid Power" to match. Existing history is valid (the
-    # underlying register hasn't changed), so re-point in place.
-    # entity_id was "…_grid_export_power"; must also be renamed so dashboard
-    # references to "…_grid_power" resolve correctly.
-    "p_grid_out": ("grid_power", "grid_export_power"),
-}
-
-
-class _EntityUpdates(TypedDict, total=False):
-    """The kwargs subset _migrate_unique_ids passes to async_update_entity."""
-
-    new_unique_id: str
-    new_entity_id: str
-
-
-def _migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Re-point entities registered under a renamed unique_id suffix in place.
-
-    Both halves are independent and idempotent: the unique_id rename fires only
-    while the old suffix is still present, and the entity_id rename fires whenever
-    the old name-slug is still present — including on installs where an earlier
-    release already migrated the unique_id but not the entity_id (the entity_id
-    rename was added later). Keying the entity_id rename on the unique_id would
-    miss exactly those installs.
-    """
-    registry = er.async_get(hass)
-    for ent in er.async_entries_for_config_entry(registry, entry.entry_id):
-        for old, (new, old_slug) in _RENAMED_UNIQUE_ID_SUFFIXES.items():
-            uid_stale = ent.unique_id.endswith(f"_{old}")
-            uid_already_new = ent.unique_id.endswith(f"_{new}")
-            entity_id_stale = bool(old_slug) and ent.entity_id.endswith(f"_{old_slug}")
-            if not uid_stale and not (uid_already_new and entity_id_stale):
-                continue
-
-            updates: _EntityUpdates = {}
-            if uid_stale:
-                new_uid = ent.unique_id[: -len(old)] + new
-                if registry.async_get_entity_id(ent.domain, DOMAIN, new_uid):
-                    # Target unique_id already exists (genuine collision) — don't
-                    # clobber it; leave the old entry for manual cleanup.
-                    _LOGGER.debug(
-                        "Skipping unique_id migration for %s: %s already exists",
-                        ent.entity_id,
-                        new_uid,
-                    )
-                else:
-                    updates["new_unique_id"] = new_uid
-            if entity_id_stale:
-                assert old_slug is not None  # entity_id_stale ⇒ old_slug truthy
-                new_entity_id = ent.entity_id[: -len(old_slug)] + new
-                if registry.async_get(new_entity_id) is not None:
-                    _LOGGER.debug(
-                        "Skipping entity_id rename for %s: %s already exists",
-                        ent.entity_id,
-                        new_entity_id,
-                    )
-                else:
-                    updates["new_entity_id"] = new_entity_id
-            if updates:
-                _LOGGER.info("Migrating %s in place: %s", ent.entity_id, updates)
-                registry.async_update_entity(ent.entity_id, **updates)
-            break
-
-
-def _retired_inverter_unique_ids(serial: str) -> set[str]:
-    """Unique IDs of the entities retired on an EMS plant (#201).
-
-    On an EMS controller the inverter-level *controls* are suppressed (the EMS
-    slots are authoritative) and a few inverter sensors are gated via
-    `skip_if_ems` (the controller-local load figures plus Battery Charge/Discharge
-    Today, which the 0x11 controller doesn't populate), plus the dropped duplicate
-    `ems_status` aggregate. The rest of the inverter sensors stay — the 0x11 block
-    carries real plant data (PV/grid/battery/AC) — so they are deliberately NOT in
-    this set.
-    Keyed by the controller serial; coordinator, battery, AIO and managed-inverter
-    entities use different keys or their own serials, so they're excluded.
-    """
-    from .sensor import INVERTER_SENSORS
-
-    keys = _inverter_control_keys()
-    # Inverter sensors gated on EMS (controller-local load + Battery Charge/Discharge Today).
-    keys.update(d.key for d in INVERTER_SENSORS if d.skip_if_ems)
-    # Duplicate EMS aggregate dropped in favour of the retained inverter Status sensor.
-    keys.add("ems_status")
-    return {f"{serial}_{key}" for key in keys}
-
-
-def _inverter_control_keys() -> set[str]:
-    """Keys of every inverter-level control description across the platforms.
-
-    Local imports: these platform modules are imported by the platform setup
-    anyway, and importing them at module scope here risks a load-order cycle.
-    """
-    from .number import AC_COUPLED_NUMBER_DESCRIPTIONS, NUMBER_DESCRIPTIONS
-    from .select import AC_COUPLED_SELECT_DESCRIPTIONS, SELECT_DESCRIPTIONS
-    from .switch import AC_COUPLED_SWITCH_DESCRIPTIONS, SWITCH_DESCRIPTIONS
-    from .time import SMART_LOAD_TIME_DESCRIPTIONS, TIME_DESCRIPTIONS
-
-    controls = (
-        *SWITCH_DESCRIPTIONS,
-        *AC_COUPLED_SWITCH_DESCRIPTIONS,
-        *NUMBER_DESCRIPTIONS,
-        *AC_COUPLED_NUMBER_DESCRIPTIONS,
-        *SELECT_DESCRIPTIONS,
-        *AC_COUPLED_SELECT_DESCRIPTIONS,
-        *TIME_DESCRIPTIONS,
-        *SMART_LOAD_TIME_DESCRIPTIONS,
-    )
-    return {d.key for d in controls}
-
-
-def _retired_on_gateway_unique_ids(serial: str) -> set[str]:
-    """Unique IDs of the entities retired on a Gateway plant (#194).
-
-    On a Gateway the 0x11 device's inverter registers decode as a spurious
-    all-zeros SinglePhaseInverter, so the ENTIRE standard inverter sensor set is
-    suppressed (unlike EMS, where the 0x11 block carries real data) along with
-    every inverter-level control (no validated write surface yet). The
-    GATEWAY_SENSORS set replaces them on the same device; coordinator sensors
-    use different keys and stay.
-    """
-    from .sensor import GATEWAY_SENSORS, INVERTER_SENSORS
-
-    keys = _inverter_control_keys()
-    # Five keys are shared between the sets (p_pv and the pv/load/battery
-    # lifetime totals): the gateway sensors deliberately reuse them for
-    # continuity, so retiring every inverter key would delete those live
-    # gateway rows on EVERY reload (shipped briefly in v1.3.39/40).
-    gateway_keys = {d.key for d in GATEWAY_SENSORS}
-    keys.update(d.key for d in INVERTER_SENSORS if d.key not in gateway_keys)
-    return {f"{serial}_{key}" for key in keys}
-
-
-def _reconcile_gateway_entities(hass: HomeAssistant, entry: ConfigEntry, serial: str) -> None:
-    """Remove standard inverter entities from a Gateway entry (#194).
-
-    A Gateway entry created on v1.3.38 (before GATEWAY_SENSORS existed) carries
-    the full inverter sensor/control set as 0/Unknown registry rows; suppressing
-    creation alone would leave them orphaned on upgrade.
-    """
-    registry = er.async_get(hass)
-    retired = _retired_on_gateway_unique_ids(serial)
-    for ent in er.async_entries_for_config_entry(registry, entry.entry_id):
-        if ent.unique_id in retired:
-            _LOGGER.info(
-                "Removing inverter entity %s retired on Gateway plant (#194)", ent.entity_id
-            )
-            registry.async_remove(ent.entity_id)
-
-
-def _reconcile_ems_entities(hass: HomeAssistant, entry: ConfigEntry, serial: str) -> None:
-    """Remove inverter-level entities retired on an EMS plant (#201).
-
-    Suppressing creation only affects fresh installs: on an upgraded EMS entry HA
-    keeps the existing registry rows when a platform stops adding those entities,
-    so the controller would otherwise keep orphaned rows for the entities no longer
-    created on EMS (inverter controls, the EMS-gated inverter sensors, the dropped
-    ems_status). Remove exactly those (matched by the controller serial + a retired
-    key), leaving the retained inverter sensors and all coordinator, battery, AIO,
-    managed-inverter and EMS-specific entities untouched.
-    """
-    registry = er.async_get(hass)
-    retired = _retired_inverter_unique_ids(serial)
-    for ent in er.async_entries_for_config_entry(registry, entry.entry_id):
-        if ent.unique_id in retired:
-            _LOGGER.info("Removing inverter entity %s retired on EMS plant (#201)", ent.entity_id)
-            registry.async_remove(ent.entity_id)
-
-
-def _reconcile_aio_house_consumption(hass: HomeAssistant, serial: str) -> None:
-    """Remove the derived House Consumption Today row on an AIO entry (#95).
-
-    The sensor is gated off AIO — its PV/grid inputs are the registers whose
-    identity is under investigation upstream (modbus#293), and AIO units report
-    no raw consumption figure — but an upgraded entry keeps the stale registry
-    row when the platform stops creating it.
-    """
-    registry = er.async_get(hass)
-    entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_e_consumption_today")
-    if entity_id is not None:
-        _LOGGER.info("Removing %s: derived consumption is gated off AIO (#95)", entity_id)
-        registry.async_remove(entity_id)
-
-
 def _live_device_identifiers(plant: Plant) -> set[tuple[str, str]]:
     """Identifiers of every device the CURRENT topology would create.
 
@@ -604,121 +412,6 @@ async def async_remove_config_entry_device(
         # the user clean up freely.
         return True
     return not (device.identifiers & _live_device_identifiers(coordinator.data))
-
-
-def _remove_stale_control(registry: er.EntityRegistry, serial: str, domain: str, key: str) -> None:
-    """Remove a readability-gated control's stale registry row, if present (#207)."""
-    entity_id = registry.async_get_entity_id(domain, DOMAIN, f"{serial}_{key}")
-    if entity_id is not None:
-        _LOGGER.info(
-            "Removing control %s: register absent on this device/firmware (#207)", entity_id
-        )
-        registry.async_remove(entity_id)
-
-
-def _reconcile_readability_gated_controls(
-    hass: HomeAssistant, coordinator: GivEnergyUpdateCoordinator
-) -> None:
-    """Remove control rows whose register is absent on this device/firmware (#207).
-
-    The control platforms skip creating a skip_if_none control when its register
-    reads None, but on an upgraded entry HA keeps the pre-existing row — an
-    orphaned, unavailable control the readability gate is meant to remove. Mirror
-    the EMS reconciliation: remove exactly those rows pre-platform, reusing each
-    platform's own gate so the readability logic isn't duplicated here.
-    """
-    # Local imports: the platforms import from this package, so importing them at
-    # module scope risks a load-order cycle. The gate helpers are the single source
-    # of truth for "is this control's register present".
-    from .datetime import SYSTEM_TIME_DESCRIPTION
-    from .number import AC_COUPLED_NUMBER_DESCRIPTIONS, _include_number
-    from .select import SELECT_DESCRIPTIONS, _include_select
-    from .time import TIME_DESCRIPTIONS, _include_time
-
-    # A partial seed poll serves last-good with last_partial_failures set, so a None
-    # read may be a transient bank failure rather than structural absence. Removing
-    # rows now would lose history/customisation and the controls until a reload —
-    # reconcile only on a clean seed (#208 review).
-    if coordinator.last_partial_failures:
-        return
-
-    inverter = coordinator.data.inverter
-    serial = coordinator.data.inverter_serial_number
-    registry = er.async_get(hass)
-    for number_desc in AC_COUPLED_NUMBER_DESCRIPTIONS:
-        if not _include_number(number_desc, inverter):
-            _remove_stale_control(registry, serial, "number", number_desc.key)
-    for select_desc in SELECT_DESCRIPTIONS:
-        if not _include_select(select_desc, inverter):
-            _remove_stale_control(registry, serial, "select", select_desc.key)
-    for time_desc in TIME_DESCRIPTIONS:
-        if not _include_time(time_desc, inverter):
-            _remove_stale_control(registry, serial, "time", time_desc.key)
-    # The System Time datetime (HR35-40) follows the same readability gate — remove
-    # its row when the clock register is absent on this device/firmware (#219).
-    if inverter.system_time is None:
-        _remove_stale_control(registry, serial, "datetime", SYSTEM_TIME_DESCRIPTION.key)
-
-
-# Substrings identifying a per-cell entity's unique_id (gated by
-# CONF_EXPOSE_PER_CELL). Roll-ups (`cell_voltage_min`, …) and the `v_cells_sum`
-# aggregate deliberately don't match — only the individual per-cell rows do.
-_PER_CELL_UNIQUE_ID_MARKERS = ("_v_cell_", "_t_cell_", "_t_cells_")
-
-
-def _reconcile_per_cell_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Remove per-cell entity rows when per-cell exposure is off (#179).
-
-    The sensor platform stops creating the individual per-cell voltage/temperature
-    entities when CONF_EXPOSE_PER_CELL is False, but HA keeps the pre-existing rows
-    on an entry that previously had them — so turning the option off would leave
-    orphaned, unavailable cell entities. Remove exactly those (matched by the
-    per-cell unique_id markers), leaving the roll-ups and every other entity intact.
-    Absent ⇒ legacy ⇒ on, so existing installs keep their cells untouched.
-    """
-    if entry.options.get(CONF_EXPOSE_PER_CELL, True):
-        return
-    registry = er.async_get(hass)
-    for ent in er.async_entries_for_config_entry(registry, entry.entry_id):
-        if ent.unique_id and any(m in ent.unique_id for m in _PER_CELL_UNIQUE_ID_MARKERS):
-            _LOGGER.info(
-                "Removing per-cell entity %s (per-cell exposure disabled, #179)",
-                ent.entity_id,
-            )
-            registry.async_remove(ent.entity_id)
-
-
-def _reconcile_ac_coupled_dc_limits(
-    hass: HomeAssistant, coordinator: GivEnergyUpdateCoordinator
-) -> None:
-    """Remove the DC battery-limit rows on AC-coupled / AIO plants (#52).
-
-    Battery power on these plants is controlled via the AC pair (HR313/314); the
-    number platform suppresses the DC pair (HR111/112) there. But on an upgraded
-    entry HA keeps the pre-existing DC rows when the platform stops adding them, so
-    the bundled dashboard would still resolve the now-orphaned DC controls from the
-    registry. Mirror the other reconcilers and remove exactly those rows pre-platform.
-    DC-coupled hybrids don't enter this branch and keep their DC controls.
-    """
-    # Local import: the platform imports from this package, so a module-scope import
-    # risks a load-order cycle. The key set is the same one the platform suppresses on.
-    from .number import _DC_BATTERY_LIMIT_KEYS
-
-    # The gate is structural (plant capability), not a register read, so — like the
-    # EMS reconciliation — it needs no partial-poll guard: a None/incomplete
-    # capabilities simply fails the positive check and removes nothing.
-    caps = coordinator.data.capabilities
-    if caps is None or not caps.has_ac_config_block or caps.is_three_phase:
-        return
-    serial = coordinator.data.inverter_serial_number
-    registry = er.async_get(hass)
-    for key in _DC_BATTERY_LIMIT_KEYS:
-        entity_id = registry.async_get_entity_id("number", DOMAIN, f"{serial}_{key}")
-        if entity_id is not None:
-            _LOGGER.info(
-                "Removing DC control %s: AC-coupled plant uses the AC pair (#52)", entity_id
-            )
-            registry.async_remove(entity_id)
 
 
 @callback
@@ -942,6 +635,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     capabilities = coordinator.data.capabilities
     if capabilities is not None and capabilities.device_type is Model.ALL_IN_ONE:
         _reconcile_aio_house_consumption(hass, coordinator.data.inverter_serial_number)
+
+    # PV Generation reads None on Model.AC / ALL_IN_ONE since 2.10.0 (Slice A):
+    # rename the pair in place to Inverter Output (same-register history rides)
+    # and clear the derived rows that lost their inputs. Strictly those two
+    # models, matching the library's manifest gate.
+    if capabilities is not None and capabilities.device_type in (Model.AC, Model.ALL_IN_ONE):
+        _migrate_ac_aio_pv_generation(
+            hass, coordinator.data.inverter_serial_number, capabilities.device_type
+        )
 
     # On a Gateway the whole standard inverter sensor/control set is suppressed in
     # favour of GATEWAY_SENSORS (#194): remove the 0/Unknown rows a pre-gateway-

--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -71,8 +71,11 @@ EXPOSE_RECOMMENDED_ENTITY_KEYS = (
     "p_load_demand",
     "e_consumption_today",
     "e_load_total",  # three-phase only — silently skipped elsewhere
-    # PV generation total (was e_inverter_out_total / "Inverter Output Total")
+    # PV generation total (was e_inverter_out_total / "Inverter Output Total").
+    # On Model.AC/ALL_IN_ONE this entity doesn't exist (2.10.0 Slice A) — the
+    # matcher skips absent entities, and the honest counterpart below matches.
     "e_pv_generation_total",
+    "inverter_output_total",
     # Health — entity description's `key` is "status"; `inverter_status` is
     # the translation_key, which is not what's in the unique_id suffix.
     "status",

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus==2.10.0"
+    "givenergy-modbus==2.10.1"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus==2.9.8"
+    "givenergy-modbus==2.10.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/migrations.py
+++ b/custom_components/givenergy_local/migrations.py
@@ -1,0 +1,435 @@
+"""Entity-registry migrations and reconciliations.
+
+House policy: every function here is a dated, gated correction to registry
+state — a unique_id rename carrying history across a semantic fix, or the
+removal of rows an older version created that the current version no longer
+does. Each carries an `Introduced:` header (version, date, issue) and a
+`Removal candidate:` criterion; they are all expected to be DELETED once their
+upgrade cohort is presumed extinct. Add new entries here, never in __init__.
+
+All run pre-platform from async_setup_entry (order: unique_id migrations
+first, then model/option-gated reconciliations), so renamed rows are adopted
+and removed rows are not recreated when the platforms enumerate.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TypedDict
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .const import CONF_EXPOSE_PER_CELL, DOMAIN
+from .coordinator import GivEnergyUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# unique_id suffixes renamed in givenergy-modbus #174 (2.1.1). The old data is
+# valid — IR35 was always AC charge, merely mislabelled "load" — so re-point the
+# existing registry entry to the new unique_id, carrying its history, statistics
+# and customisations across rather than orphaning it and starting fresh.
+
+# Values: (new_uid_suffix, old_entity_id_slug | None).
+# old_entity_id_slug is the name-slug the entity carried before renaming; None
+# means no entity_id rename is needed (unique_id suffix change only).
+_RENAMED_UNIQUE_ID_SUFFIXES: dict[str, tuple[str, str | None]] = {
+    # givenergy-modbus #174 (2.1.1): IR35 was AC charge, not house load.
+    "e_load_day": ("e_ac_charge_today", None),
+    # givenergy-modbus #174/#176 (2.1.2): IR44/IR45-46 are PV generation, not
+    # inverter AC output. Move both sensors together so today+total stay paired.
+    "e_inverter_out_day": ("e_pv_generation_today", None),
+    "e_inverter_out_total": ("e_pv_generation_total", None),
+    # #52: p_grid_out (IR30) is a signed net flow, not export-only — rename the
+    # surfaced entity to "Grid Power" to match. Existing history is valid (the
+    # underlying register hasn't changed), so re-point in place.
+    # entity_id was "…_grid_export_power"; must also be renamed so dashboard
+    # references to "…_grid_power" resolve correctly.
+    "p_grid_out": ("grid_power", "grid_export_power"),
+}
+
+
+class _EntityUpdates(TypedDict, total=False):
+    """The kwargs subset _migrate_unique_ids passes to async_update_entity."""
+
+    new_unique_id: str
+    new_entity_id: str
+
+
+def _migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Re-point entities registered under a renamed unique_id suffix in place.
+
+    Introduced: v1.1.x era (2026-06, modbus 2.1.1/2.1.2 renames #174/#176);
+    p_grid_out entry added v1.3.x (#52). Removal candidate: when installs
+    predating v1.3.31 are presumed extinct — retire map entries individually.
+
+    Both halves are independent and idempotent: the unique_id rename fires only
+    while the old suffix is still present, and the entity_id rename fires whenever
+    the old name-slug is still present — including on installs where an earlier
+    release already migrated the unique_id but not the entity_id (the entity_id
+    rename was added later). Keying the entity_id rename on the unique_id would
+    miss exactly those installs.
+    """
+    registry = er.async_get(hass)
+    for ent in er.async_entries_for_config_entry(registry, entry.entry_id):
+        for old, (new, old_slug) in _RENAMED_UNIQUE_ID_SUFFIXES.items():
+            uid_stale = ent.unique_id.endswith(f"_{old}")
+            uid_already_new = ent.unique_id.endswith(f"_{new}")
+            entity_id_stale = bool(old_slug) and ent.entity_id.endswith(f"_{old_slug}")
+            if not uid_stale and not (uid_already_new and entity_id_stale):
+                continue
+
+            updates: _EntityUpdates = {}
+            if uid_stale:
+                new_uid = ent.unique_id[: -len(old)] + new
+                if registry.async_get_entity_id(ent.domain, DOMAIN, new_uid):
+                    # Target unique_id already exists (genuine collision) — don't
+                    # clobber it; leave the old entry for manual cleanup.
+                    _LOGGER.debug(
+                        "Skipping unique_id migration for %s: %s already exists",
+                        ent.entity_id,
+                        new_uid,
+                    )
+                else:
+                    updates["new_unique_id"] = new_uid
+            if entity_id_stale:
+                assert old_slug is not None  # entity_id_stale ⇒ old_slug truthy
+                new_entity_id = ent.entity_id[: -len(old_slug)] + new
+                if registry.async_get(new_entity_id) is not None:
+                    _LOGGER.debug(
+                        "Skipping entity_id rename for %s: %s already exists",
+                        ent.entity_id,
+                        new_entity_id,
+                    )
+                else:
+                    updates["new_entity_id"] = new_entity_id
+            if updates:
+                _LOGGER.info("Migrating %s in place: %s", ent.entity_id, updates)
+                registry.async_update_entity(ent.entity_id, **updates)
+            break
+
+
+def _retired_inverter_unique_ids(serial: str) -> set[str]:
+    """Unique IDs of the entities retired on an EMS plant (#201).
+
+    Introduced: v1.3.11, narrowed v1.3.12 (#206, 2026-06). Removal candidate:
+    when upgrades from pre-v1.3.12 EMS installs are presumed extinct.
+
+    On an EMS controller the inverter-level *controls* are suppressed (the EMS
+    slots are authoritative) and a few inverter sensors are gated via
+    `skip_if_ems` (the controller-local load figures plus Battery Charge/Discharge
+    Today, which the 0x11 controller doesn't populate), plus the dropped duplicate
+    `ems_status` aggregate. The rest of the inverter sensors stay — the 0x11 block
+    carries real plant data (PV/grid/battery/AC) — so they are deliberately NOT in
+    this set.
+    Keyed by the controller serial; coordinator, battery, AIO and managed-inverter
+    entities use different keys or their own serials, so they're excluded.
+    """
+    from .sensor import INVERTER_SENSORS
+
+    keys = _inverter_control_keys()
+    # Inverter sensors gated on EMS (controller-local load + Battery Charge/Discharge Today).
+    keys.update(d.key for d in INVERTER_SENSORS if d.skip_if_ems)
+    # Duplicate EMS aggregate dropped in favour of the retained inverter Status sensor.
+    keys.add("ems_status")
+    return {f"{serial}_{key}" for key in keys}
+
+
+def _inverter_control_keys() -> set[str]:
+    """Keys of every inverter-level control description across the platforms.
+
+    Local imports: these platform modules are imported by the platform setup
+    anyway, and importing them at module scope here risks a load-order cycle.
+    """
+    from .number import AC_COUPLED_NUMBER_DESCRIPTIONS, NUMBER_DESCRIPTIONS
+    from .select import AC_COUPLED_SELECT_DESCRIPTIONS, SELECT_DESCRIPTIONS
+    from .switch import AC_COUPLED_SWITCH_DESCRIPTIONS, SWITCH_DESCRIPTIONS
+    from .time import SMART_LOAD_TIME_DESCRIPTIONS, TIME_DESCRIPTIONS
+
+    controls = (
+        *SWITCH_DESCRIPTIONS,
+        *AC_COUPLED_SWITCH_DESCRIPTIONS,
+        *NUMBER_DESCRIPTIONS,
+        *AC_COUPLED_NUMBER_DESCRIPTIONS,
+        *SELECT_DESCRIPTIONS,
+        *AC_COUPLED_SELECT_DESCRIPTIONS,
+        *TIME_DESCRIPTIONS,
+        *SMART_LOAD_TIME_DESCRIPTIONS,
+    )
+    return {d.key for d in controls}
+
+
+def _retired_on_gateway_unique_ids(serial: str) -> set[str]:
+    """Unique IDs of the entities retired on a Gateway plant (#194).
+
+    Introduced: v1.3.39 (2026-07-03); shared-key exclusion added 2026-07-08
+    (#266). Removal candidate: when upgrades from pre-v1.3.39 Gateway entries
+    are presumed extinct — but note the suppression itself is permanent.
+
+    On a Gateway the 0x11 device's inverter registers decode as a spurious
+    all-zeros SinglePhaseInverter, so the ENTIRE standard inverter sensor set is
+    suppressed (unlike EMS, where the 0x11 block carries real data) along with
+    every inverter-level control (no validated write surface yet). The
+    GATEWAY_SENSORS set replaces them on the same device; coordinator sensors
+    use different keys and stay.
+    """
+    from .sensor import GATEWAY_SENSORS, INVERTER_SENSORS
+
+    keys = _inverter_control_keys()
+    # Five keys are shared between the sets (p_pv and the pv/load/battery
+    # lifetime totals): the gateway sensors deliberately reuse them for
+    # continuity, so retiring every inverter key would delete those live
+    # gateway rows on EVERY reload (shipped briefly in v1.3.39/40).
+    gateway_keys = {d.key for d in GATEWAY_SENSORS}
+    keys.update(d.key for d in INVERTER_SENSORS if d.key not in gateway_keys)
+    return {f"{serial}_{key}" for key in keys}
+
+
+def _reconcile_gateway_entities(hass: HomeAssistant, entry: ConfigEntry, serial: str) -> None:
+    """Remove standard inverter entities from a Gateway entry (#194).
+
+    Introduced: v1.3.39 (2026-07-03). Ongoing while Gateway suppression exists
+    (cheap no-op once rows are gone).
+
+    A Gateway entry created on v1.3.38 (before GATEWAY_SENSORS existed) carries
+    the full inverter sensor/control set as 0/Unknown registry rows; suppressing
+    creation alone would leave them orphaned on upgrade.
+    """
+    registry = er.async_get(hass)
+    retired = _retired_on_gateway_unique_ids(serial)
+    for ent in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if ent.unique_id in retired:
+            _LOGGER.info(
+                "Removing inverter entity %s retired on Gateway plant (#194)", ent.entity_id
+            )
+            registry.async_remove(ent.entity_id)
+
+
+def _reconcile_ems_entities(hass: HomeAssistant, entry: ConfigEntry, serial: str) -> None:
+    """Remove inverter-level entities retired on an EMS plant (#201).
+
+    Introduced: v1.3.11/12 (2026-06). Ongoing while EMS suppression exists
+    (cheap no-op once rows are gone).
+
+    Suppressing creation only affects fresh installs: on an upgraded EMS entry HA
+    keeps the existing registry rows when a platform stops adding those entities,
+    so the controller would otherwise keep orphaned rows for the entities no longer
+    created on EMS (inverter controls, the EMS-gated inverter sensors, the dropped
+    ems_status). Remove exactly those (matched by the controller serial + a retired
+    key), leaving the retained inverter sensors and all coordinator, battery, AIO,
+    managed-inverter and EMS-specific entities untouched.
+    """
+    registry = er.async_get(hass)
+    retired = _retired_inverter_unique_ids(serial)
+    for ent in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if ent.unique_id in retired:
+            _LOGGER.info("Removing inverter entity %s retired on EMS plant (#201)", ent.entity_id)
+            registry.async_remove(ent.entity_id)
+
+
+def _reconcile_aio_house_consumption(hass: HomeAssistant, serial: str) -> None:
+    """Remove the derived House Consumption Today row on an AIO entry (#95).
+
+    Introduced: v1.3.35 (2026-07-02, #250; #293-evidence-confirmed). Removal
+    candidate: when upgrades from pre-v1.3.35 AIO installs are presumed extinct.
+
+    The sensor is gated off AIO — its PV/grid inputs are the registers whose
+    identity is under investigation upstream (modbus#293), and AIO units report
+    no raw consumption figure — but an upgraded entry keeps the stale registry
+    row when the platform stops creating it.
+    """
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_e_consumption_today")
+    if entity_id is not None:
+        _LOGGER.info("Removing %s: derived consumption is gated off AIO (#95)", entity_id)
+        registry.async_remove(entity_id)
+
+
+# The PV Generation → Inverter Output rename on Model.AC / ALL_IN_ONE, plus the
+# derived rows that lose their inputs there. Values: (old_key, new_key) pairs
+# share the entity_id slug shapes (pv_generation_x → inverter_output_x).
+_AC_AIO_PV_RENAMES = (
+    ("e_pv_generation_today", "inverter_output_today", "pv_generation_today"),
+    ("e_pv_generation_total", "inverter_output_total", "pv_generation_total"),
+)
+_AC_AIO_STALE_DERIVED_KEYS = (
+    "e_self_consumption_today",
+    "e_self_consumption_total",
+    "e_pv_direct_today",
+)
+
+
+def _migrate_ac_aio_pv_generation(hass: HomeAssistant, serial: str, model: object) -> None:
+    """Rename PV Generation → Inverter Output on Model.AC / ALL_IN_ONE (2.10.0).
+
+    Introduced: v1.3.41 (2026-07-08) — givenergy-modbus 2.10.0 (#293 manifest,
+    Slice A). Removal candidate: once AC/AIO installs predating v1.3.41 are
+    presumed extinct (AC/AIO support itself only shipped 2026-06, so the cohort
+    is small).
+
+    e_pv_generation_* honestly return None on those models — IR44/45-46 were
+    never PV there, they're the unit's battery-discharge AC output, now carried
+    by e_inverter_out_* and surfaced as the Inverter Output pair. The recorded
+    history under the PV name is genuine same-register data, so rename the rows
+    in place (unique_id + entity_id slug, collision-safe) and let the new
+    sensors adopt them. The derived rows (Self Consumption pair, PV Direct —
+    and House Consumption on Model.AC, where no other reconciler covers it)
+    lose their inputs by upstream None-propagation and have no successor:
+    remove them.
+    """
+    from givenergy_modbus.model.inverter import Model
+
+    registry = er.async_get(hass)
+    for old_key, new_key, old_slug in _AC_AIO_PV_RENAMES:
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_{old_key}")
+        if entity_id is None:
+            continue
+        if registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_{new_key}"):
+            _LOGGER.debug("Skipping %s rename: target %s exists", entity_id, new_key)
+            continue
+        updates: _EntityUpdates = {"new_unique_id": f"{serial}_{new_key}"}
+        if entity_id.endswith(f"_{old_slug}"):
+            new_entity_id = entity_id[: -len(old_slug)] + new_key
+            if registry.async_get(new_entity_id) is None:
+                updates["new_entity_id"] = new_entity_id
+        _LOGGER.info("Migrating %s in place (AC/AIO, 2.10.0): %s", entity_id, updates)
+        registry.async_update_entity(entity_id, **updates)
+
+    stale: tuple[str, ...] = _AC_AIO_STALE_DERIVED_KEYS
+    if model is Model.AC:
+        # ALL_IN_ONE's consumption row is handled by _reconcile_aio_house_consumption.
+        stale = (*stale, "e_consumption_today")
+    for key in stale:
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_{key}")
+        if entity_id is not None:
+            _LOGGER.info(
+                "Removing %s: derived field lost its PV input on AC/AIO (2.10.0)", entity_id
+            )
+            registry.async_remove(entity_id)
+
+
+def _remove_stale_control(registry: er.EntityRegistry, serial: str, domain: str, key: str) -> None:
+    """Remove a readability-gated control's stale registry row, if present (#207).
+
+    Introduced: v1.3.13 (2026-06). Ongoing — the readability gate is permanent.
+    """
+    entity_id = registry.async_get_entity_id(domain, DOMAIN, f"{serial}_{key}")
+    if entity_id is not None:
+        _LOGGER.info(
+            "Removing control %s: register absent on this device/firmware (#207)", entity_id
+        )
+        registry.async_remove(entity_id)
+
+
+def _reconcile_readability_gated_controls(
+    hass: HomeAssistant, coordinator: GivEnergyUpdateCoordinator
+) -> None:
+    """Remove control rows whose register is absent on this device/firmware (#207).
+
+    Introduced: v1.3.13 (2026-06). Ongoing — the readability gate is permanent.
+
+    The control platforms skip creating a skip_if_none control when its register
+    reads None, but on an upgraded entry HA keeps the pre-existing row — an
+    orphaned, unavailable control the readability gate is meant to remove. Mirror
+    the EMS reconciliation: remove exactly those rows pre-platform, reusing each
+    platform's own gate so the readability logic isn't duplicated here.
+    """
+    # Local imports: the platforms import from this package, so importing them at
+    # module scope risks a load-order cycle. The gate helpers are the single source
+    # of truth for "is this control's register present".
+    from .datetime import SYSTEM_TIME_DESCRIPTION
+    from .number import AC_COUPLED_NUMBER_DESCRIPTIONS, _include_number
+    from .select import SELECT_DESCRIPTIONS, _include_select
+    from .time import TIME_DESCRIPTIONS, _include_time
+
+    # A partial seed poll serves last-good with last_partial_failures set, so a None
+    # read may be a transient bank failure rather than structural absence. Removing
+    # rows now would lose history/customisation and the controls until a reload —
+    # reconcile only on a clean seed (#208 review).
+    if coordinator.last_partial_failures:
+        return
+
+    inverter = coordinator.data.inverter
+    serial = coordinator.data.inverter_serial_number
+    registry = er.async_get(hass)
+    for number_desc in AC_COUPLED_NUMBER_DESCRIPTIONS:
+        if not _include_number(number_desc, inverter):
+            _remove_stale_control(registry, serial, "number", number_desc.key)
+    for select_desc in SELECT_DESCRIPTIONS:
+        if not _include_select(select_desc, inverter):
+            _remove_stale_control(registry, serial, "select", select_desc.key)
+    for time_desc in TIME_DESCRIPTIONS:
+        if not _include_time(time_desc, inverter):
+            _remove_stale_control(registry, serial, "time", time_desc.key)
+    # The System Time datetime (HR35-40) follows the same readability gate — remove
+    # its row when the clock register is absent on this device/firmware (#219).
+    if inverter.system_time is None:
+        _remove_stale_control(registry, serial, "datetime", SYSTEM_TIME_DESCRIPTION.key)
+
+
+# Substrings identifying a per-cell entity's unique_id (gated by
+# CONF_EXPOSE_PER_CELL). Roll-ups (`cell_voltage_min`, …) and the `v_cells_sum`
+# aggregate deliberately don't match — only the individual per-cell rows do.
+_PER_CELL_UNIQUE_ID_MARKERS = ("_v_cell_", "_t_cell_", "_t_cells_")
+
+
+def _reconcile_per_cell_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Remove per-cell entity rows when per-cell exposure is off (#179).
+
+    Introduced: v1.3.30 (2026-06-29). Ongoing — option-driven cleanup, not a
+    dated migration; permanent while CONF_EXPOSE_PER_CELL exists.
+
+    The sensor platform stops creating the individual per-cell voltage/temperature
+    entities when CONF_EXPOSE_PER_CELL is False, but HA keeps the pre-existing rows
+    on an entry that previously had them — so turning the option off would leave
+    orphaned, unavailable cell entities. Remove exactly those (matched by the
+    per-cell unique_id markers), leaving the roll-ups and every other entity intact.
+    Absent ⇒ legacy ⇒ on, so existing installs keep their cells untouched.
+    """
+    if entry.options.get(CONF_EXPOSE_PER_CELL, True):
+        return
+    registry = er.async_get(hass)
+    for ent in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if ent.unique_id and any(m in ent.unique_id for m in _PER_CELL_UNIQUE_ID_MARKERS):
+            _LOGGER.info(
+                "Removing per-cell entity %s (per-cell exposure disabled, #179)",
+                ent.entity_id,
+            )
+            registry.async_remove(ent.entity_id)
+
+
+def _reconcile_ac_coupled_dc_limits(
+    hass: HomeAssistant, coordinator: GivEnergyUpdateCoordinator
+) -> None:
+    """Remove the DC battery-limit rows on AC-coupled / AIO plants (#52).
+
+    Introduced: v1.3.17 (2026-06). Ongoing while the AC-pair suppression exists
+    (cheap no-op once rows are gone).
+
+    Battery power on these plants is controlled via the AC pair (HR313/314); the
+    number platform suppresses the DC pair (HR111/112) there. But on an upgraded
+    entry HA keeps the pre-existing DC rows when the platform stops adding them, so
+    the bundled dashboard would still resolve the now-orphaned DC controls from the
+    registry. Mirror the other reconcilers and remove exactly those rows pre-platform.
+    DC-coupled hybrids don't enter this branch and keep their DC controls.
+    """
+    # Local import: the platform imports from this package, so a module-scope import
+    # risks a load-order cycle. The key set is the same one the platform suppresses on.
+    from .number import _DC_BATTERY_LIMIT_KEYS
+
+    # The gate is structural (plant capability), not a register read, so — like the
+    # EMS reconciliation — it needs no partial-poll guard: a None/incomplete
+    # capabilities simply fails the positive check and removes nothing.
+    caps = coordinator.data.capabilities
+    if caps is None or not caps.has_ac_config_block or caps.is_three_phase:
+        return
+    serial = coordinator.data.inverter_serial_number
+    registry = er.async_get(hass)
+    for key in _DC_BATTERY_LIMIT_KEYS:
+        entity_id = registry.async_get_entity_id("number", DOMAIN, f"{serial}_{key}")
+        if entity_id is not None:
+            _LOGGER.info(
+                "Removing DC control %s: AC-coupled plant uses the AC pair (#52)", entity_id
+            )
+            registry.async_remove(entity_id)

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -980,12 +980,17 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         # _RENAMED_UNIQUE_ID_SUFFIXES migration renames e_inverter_out_total to
         # e_pv_generation_total unconditionally (the pre-v1.3.31 hybrid rename)
         # and would hijack these rows on restart. getattr per the SP-only rule.
+        # source_field stays e_pv_generation_today: e_inverter_out_today is a
+        # model-validator-only attribute with no registers_of() entry, so
+        # pointing the stale-IR gate at it would silently disable staleness
+        # detection (registers_of() only knows the pre-2.10.0 field name that
+        # actually backs IR44).
         key="inverter_output_today",
         name="Inverter Output Today",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        source_field="e_inverter_out_today",
+        source_field="e_pv_generation_today",
         value_fn=lambda inv: getattr(inv, "e_inverter_out_today", None),
         skip_if_none=True,
     ),
@@ -995,7 +1000,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        source_field="e_inverter_out_total",
+        source_field="e_pv_generation_total",
         value_fn=lambda inv: getattr(inv, "e_inverter_out_total", None),
         skip_if_none=True,
     ),

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1940,9 +1940,6 @@ GATEWAY_SENSORS: tuple[GivEnergyGatewaySensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        # NB reads sign-inverted vs the house convention (positive = discharging)
-        # on live hardware — the flip belongs in the library model (sign is
-        # register semantics); requested upstream with AberDino's evidence (#95).
         value_fn=_gateway_attr("p_aio_total"),
     ),
     GivEnergyGatewaySensorDescription(
@@ -1981,9 +1978,8 @@ GATEWAY_SENSORS: tuple[GivEnergyGatewaySensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        # NB reads sign-inverted vs GivTCP's Liberty Power on live hardware; the
-        # flip belongs in the library model alongside pinning what this field
-        # actually is — both asked upstream (#95).
+        # Exact semantics still unconfirmed upstream (tracks p_aio_total closely;
+        # best guess is AC-side aggregate vs p_aio_total's DC side) — modbus#373.
         value_fn=_gateway_attr("p_liberty"),
     ),
     GivEnergyGatewaySensorDescription(

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -949,17 +949,20 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         value_fn=lambda inv: inv.e_ac_charge_today,
     ),
     GivEnergyInverterSensorDescription(
-        # IR44 is PV generation, not inverter AC output. givenergy-modbus #174
-        # renamed e_inverter_out_day -> e_pv_generation_today (single-phase). The
-        # total (IR45/46) was confirmed as PV-generation-total in #176 and renamed
-        # e_inverter_out_total -> e_pv_generation_total. Both entity keys and names
-        # move together; unique_id migrations in __init__.py carry existing history.
+        # IR44 is PV generation on DC hybrids only. givenergy-modbus #174 renamed
+        # e_inverter_out_day -> e_pv_generation_today; 2.10.0 (#293 manifest,
+        # Slice A) made the fields model-aware: on Model.AC / Model.ALL_IN_ONE
+        # they honestly return None (IR44/45-46 are battery-discharge AC output
+        # there, surfaced by the Inverter Output pair below). skip_if_none keeps
+        # these off new AC/AIO installs; _reconcile_ac_aio_pv_generation clears
+        # upgraded ones. unique_id migrations in __init__.py carry old history.
         key="e_pv_generation_today",
         name="PV Generation Today",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda inv: inv.e_pv_generation_today,
+        skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
         key="e_pv_generation_total",
@@ -968,6 +971,33 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda inv: inv.e_pv_generation_total,
+        skip_if_none=True,
+    ),
+    GivEnergyInverterSensorDescription(
+        # The honest home of IR44/45-46 on Model.AC / Model.ALL_IN_ONE (2.10.0
+        # Slice A): the unit's battery-discharge AC output. None everywhere else
+        # (skip_if_none). Keys are deliberately NOT e_inverter_out_* — the
+        # _RENAMED_UNIQUE_ID_SUFFIXES migration renames e_inverter_out_total to
+        # e_pv_generation_total unconditionally (the pre-v1.3.31 hybrid rename)
+        # and would hijack these rows on restart. getattr per the SP-only rule.
+        key="inverter_output_today",
+        name="Inverter Output Today",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        source_field="e_inverter_out_today",
+        value_fn=lambda inv: getattr(inv, "e_inverter_out_today", None),
+        skip_if_none=True,
+    ),
+    GivEnergyInverterSensorDescription(
+        key="inverter_output_total",
+        name="Inverter Output Total",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        source_field="e_inverter_out_total",
+        value_fn=lambda inv: getattr(inv, "e_inverter_out_total", None),
+        skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
         key="e_inverter_export_total",

--- a/custom_components/givenergy_local/www/ge-strategy.js
+++ b/custom_components/givenergy_local/www/ge-strategy.js
@@ -652,7 +652,10 @@
         row(a.inv("e_battery_discharge_total"), "Battery Discharged"),
         row(a.inv("e_grid_out_total"), "Grid Exported"),
         row(a.inv("e_grid_in_total"), "Grid Imported"),
+        // PV Generation Total exists on hybrids; on Model.AC/ALL_IN_ONE the same
+        // register is honestly Inverter Output Total (modbus 2.10.0, #293).
         row(a.inv("e_pv_generation_total"), "PV Generation Total"),
+        row(a.inv("inverter_output_total"), "Inverter Output Total"),
         row(a.inv("e_inverter_in_total"), "Charged from Grid"),
         row(a.inv("e_discharge_year"), "Discharged This Year"),
         row(a.inv("e_solar_diverter"), "Solar Diverter Energy"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
     # an upstream patch that wasn't validated against this integration. Bump both
     # this and manifest.json together.
-    "givenergy-modbus==2.10.0",
+    "givenergy-modbus==2.10.1",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
     # an upstream patch that wasn't validated against this integration. Bump both
     # this and manifest.json together.
-    "givenergy-modbus==2.9.8",
+    "givenergy-modbus==2.10.0",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,11 @@ def mock_inverter() -> MagicMock:
     del inv.e_load_total
     inv.e_pv_generation_today = 11.2
     inv.e_pv_generation_total = 5100.2
+    # 2.10.0 Slice A: e_inverter_out_* are populated ONLY on Model.AC/ALL_IN_ONE
+    # (where e_pv_generation_* honestly read None). None here — a bare MagicMock
+    # attr is truthy and would create the sensors on every hybrid test.
+    inv.e_inverter_out_today = None
+    inv.e_inverter_out_total = None
     inv.t_inverter_heatsink = 45.3
     inv.t_charger = 38.7
     inv.enable_charge = True

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,7 +17,6 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.givenergy_local import (
     _STRATEGY_URL,
     _STRATEGY_VERSION,
-    _reconcile_per_cell_entities,
     async_remove_entry,
     async_setup,
 )
@@ -34,6 +33,7 @@ from custom_components.givenergy_local.const import (
     SERVICE_REDETECT_PLANT,
     SERVICE_SET_SYSTEM_DATETIME,
 )
+from custom_components.givenergy_local.migrations import _reconcile_per_cell_entities
 
 
 async def test_frontend_modules_served_and_autoloaded():

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1618,11 +1618,17 @@ def test_renamed_direct_register_sensors_declare_their_source_field():
         "grid_power_export": "p_grid_out",
         "work_time_total": "work_time_total_hours",
         "e_consumption_today": "e_load_today",
-        # 2.10.0 Slice A: keys deliberately differ from the fields (the
-        # e_inverter_out_* suffixes are claimed by the legacy unique_id
-        # migration map — see migrations.py).
-        "inverter_output_today": "e_inverter_out_today",
-        "inverter_output_total": "e_inverter_out_total",
+        # 2.10.0 Slice A: keys deliberately differ from the fields the value_fn
+        # reads (the e_inverter_out_* suffixes are claimed by the legacy
+        # unique_id migration map — see migrations.py). source_field points at
+        # e_pv_generation_* instead, the name the register LUT actually knows —
+        # e_inverter_out_today/total IS a real (different) field on
+        # ThreePhaseInverter, so pointing source_field at it wouldn't raise
+        # here, but on SinglePhaseInverter (the AC/AIO models this pair is
+        # for) it resolves to no registers and silently disables the
+        # stale-bank gate (Codex review on #267).
+        "inverter_output_today": "e_pv_generation_today",
+        "inverter_output_total": "e_pv_generation_total",
     }
     declared = {d.key: d.source_field for d in INVERTER_SENSORS if d.source_field is not None}
     assert declared == expected
@@ -1633,6 +1639,19 @@ def test_renamed_direct_register_sensors_declare_their_source_field():
         assert _source_ir_registers(SinglePhaseInverter, source) or _source_ir_registers(
             ThreePhaseInverter, source
         ), f"{key}: source_field {source!r} resolves to no IR registers on any model"
+    # inverter_output_*'s target model IS SinglePhaseInverter (AC/AIO) — the
+    # OR-across-models check above isn't enough here, since ThreePhaseInverter
+    # coincidentally has its own real e_inverter_out_* fields that would mask
+    # a SinglePhaseInverter regression.
+    assert _register_shape(_source_ir_registers(SinglePhaseInverter, "e_pv_generation_today")) == [
+        ("IR", 44),
+    ]
+    assert _register_shape(_source_ir_registers(SinglePhaseInverter, "e_pv_generation_total")) == [
+        ("IR", 45),
+        ("IR", 46),
+    ]
+    assert _source_ir_registers(SinglePhaseInverter, "e_inverter_out_today") == ()
+    assert _source_ir_registers(SinglePhaseInverter, "e_inverter_out_total") == ()
     # The consumption source is per-model by construction: on single-phase the
     # value is the derived field (untracked — e_load_today isn't in that LUT),
     # on three-phase it's the native register the value_fn falls back to.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -235,12 +235,14 @@ async def test_expected_sensor_count(hass, setup_integration):
     # (created by default — the test entry has no expose_per_cell key, so it
     # resolves on) + coordinator diagnostics, minus e_load_total which only
     # exists on three-phase models (#154).
+    # -1: e_load_today (3ph-only). -2: the Inverter Output pair reads None on
+    # hybrids (modbus 2.10.0 Slice A — only Model.AC/ALL_IN_ONE populate it).
     expected = (
         len(INVERTER_SENSORS)
         + len(BATTERY_SENSORS)
         + len(BATTERY_CELL_SENSORS)
         + len(COORDINATOR_SENSORS)
-        - 1
+        - 3
     )
     assert len(sensors) == expected
 
@@ -1616,6 +1618,11 @@ def test_renamed_direct_register_sensors_declare_their_source_field():
         "grid_power_export": "p_grid_out",
         "work_time_total": "work_time_total_hours",
         "e_consumption_today": "e_load_today",
+        # 2.10.0 Slice A: keys deliberately differ from the fields (the
+        # e_inverter_out_* suffixes are claimed by the legacy unique_id
+        # migration map — see migrations.py).
+        "inverter_output_today": "e_inverter_out_today",
+        "inverter_output_total": "e_inverter_out_total",
     }
     declared = {d.key: d.source_field for d in INVERTER_SENSORS if d.source_field is not None}
     assert declared == expected
@@ -2601,3 +2608,107 @@ async def test_non_gateway_plant_has_no_gateway_sensors(hass, setup_integration)
     registry = er.async_get(hass)
     for key in ("aio1_soc", "p_load", "e_load_today", "gateway_fault_codes"):
         assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is None, key
+
+
+# ---------------------------------------------------------------------------
+# Model.AC / ALL_IN_ONE PV-generation routing (modbus 2.10.0 Slice A)
+# ---------------------------------------------------------------------------
+
+
+def _setup_ac_plant(mock_client, model=None):
+    """Reshape the mock into an AC-coupled plant with 2.10.0 field routing:
+    e_pv_generation_* honestly None, values in e_inverter_out_*."""
+    from givenergy_modbus.model.inverter import Model
+    from givenergy_modbus.model.plant import PlantCapabilities
+
+    inv = mock_client.plant.inverter
+    inv.e_pv_generation_today = None
+    inv.e_pv_generation_total = None
+    inv.e_inverter_out_today = 6.2
+    inv.e_inverter_out_total = 4321.0
+    # The library None-propagates every PV-derived field on AC/AIO (deliberate:
+    # the corrected formula failed modbus's evidence gate) — mirror it, or the
+    # platform would faithfully re-create the rows the migration removes.
+    inv.e_self_consumption_today = None
+    inv.e_self_consumption_total = None
+    inv.e_pv_direct_today = None
+    inv.e_consumption_today = None
+    mock_client.plant.capabilities = PlantCapabilities(
+        device_type=model or Model.AC,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+
+
+async def test_ac_plant_routes_pv_generation_to_inverter_output(
+    hass, mock_client, mock_config_entry
+):
+    """On Model.AC the Inverter Output pair carries the IR44/45-46 values and
+    the PV Generation pair is not created (fields honestly None)."""
+    _setup_ac_plant(mock_client)
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    expectations = (("inverter_output_today", "6.2"), ("inverter_output_total", "4321.0"))
+    for key, expected in expectations:
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}")
+        assert entity_id is not None, key
+        assert hass.states.get(entity_id).state == expected, key
+    for key in ("e_pv_generation_today", "e_pv_generation_total"):
+        assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is None, key
+
+
+async def test_ac_upgrade_migrates_pv_generation_rows_in_place(
+    hass, mock_client, mock_config_entry
+):
+    """An upgraded AC entry's PV Generation rows are RENAMED to the Inverter
+    Output unique_ids (same registry row — history rides), then adopted by the
+    new sensors; the derived rows that lost their inputs are removed."""
+    _setup_ac_plant(mock_client)
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    old_today = registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_e_pv_generation_today", config_entry=mock_config_entry
+    )
+    row_id_before = old_today.id
+    registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_e_pv_generation_total", config_entry=mock_config_entry
+    )
+    for stale in ("e_self_consumption_today", "e_pv_direct_today", "e_consumption_today"):
+        registry.async_get_or_create(
+            "sensor", DOMAIN, f"SA1234G123_{stale}", config_entry=mock_config_entry
+        )
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Renamed in place: old unique_ids gone, new ones present on the SAME row.
+    old_uid = "SA1234G123_e_pv_generation_today"
+    assert registry.async_get_entity_id("sensor", DOMAIN, old_uid) is None
+    new_entity_id = registry.async_get_entity_id(
+        "sensor", DOMAIN, "SA1234G123_inverter_output_today"
+    )
+    assert new_entity_id is not None
+    assert registry.async_get(new_entity_id).id == row_id_before
+    assert hass.states.get(new_entity_id).state == "6.2"
+    total_uid = "SA1234G123_inverter_output_total"
+    assert registry.async_get_entity_id("sensor", DOMAIN, total_uid) is not None
+    # Derived rows (inputs lost by upstream None-propagation) removed.
+    for stale in ("e_self_consumption_today", "e_pv_direct_today", "e_consumption_today"):
+        assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{stale}") is None, stale
+
+
+async def test_hybrid_keeps_pv_generation_and_no_inverter_output(hass, setup_integration):
+    """The default hybrid fixture keeps its PV Generation pair (genuine PV) and
+    never grows the Inverter Output pair (fields None off AC/AIO)."""
+    registry = er.async_get(hass)
+
+    def uid(key):
+        return registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}")
+
+    assert uid("e_pv_generation_today") is not None
+    assert uid("inverter_output_today") is None
+    assert uid("inverter_output_total") is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2483,8 +2483,8 @@ async def test_gateway_creates_whole_house_and_per_aio_sensors(hass, gateway_set
     expectations = {
         "p_load": "1127",
         "p_pv": "2229",
-        # Raw register values pass through; the sign convention (these read
-        # inverted on live hardware) is being fixed in the library model (#95).
+        # Raw register values pass through (sign is the library's concern —
+        # corrected upstream in modbus 2.10.1, #95).
         "p_aio_total": "155",
         "p_liberty": "185",
         # p_ac1 = grid connection point, signed positive-export; split pair

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = "==2.9.8" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.10.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.9.8"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/88/bb3fede3f37263cc35b702f7bf6e73bde5c95e91339e528a3d90ace7be3a/givenergy_modbus-2.9.8.tar.gz", hash = "sha256:31abc18c2df33db811378ed7890f3be289b7dd9d0975031514755f168788838f", size = 529958, upload-time = "2026-07-07T17:11:34.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/a9/917dd66612c51a5ba135936cbfa4028f907b7259ff3bebb0b1e8cc7c8c4e/givenergy_modbus-2.10.0.tar.gz", hash = "sha256:2b0206ffa149df46fbc399434d3487a97aadebcb0e79225d32b97c26975887cb", size = 541793, upload-time = "2026-07-08T07:59:37.882Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/b9/459c6170cbe1983dcfaf3000d1b46ea723ba946ce4e1fc7a2be5748fce83/givenergy_modbus-2.9.8-py3-none-any.whl", hash = "sha256:31c71db15a1a261b9469048fc3fdd8e6446fe80c96ffee994c6be141d0b52e63", size = 203632, upload-time = "2026-07-07T17:11:32.904Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c1/137c59b465925451951fe9cc096a1e6123a720e31357a9ea529437cdcea2/givenergy_modbus-2.10.0-py3-none-any.whl", hash = "sha256:38ee9186f885503c940585b46ae1734c2d18624c338e93d249459487d0ea37e8", size = 209599, upload-time = "2026-07-08T07:59:35.103Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = "==2.10.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.10.1" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -944,16 +944,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.10.0"
+version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/a9/917dd66612c51a5ba135936cbfa4028f907b7259ff3bebb0b1e8cc7c8c4e/givenergy_modbus-2.10.0.tar.gz", hash = "sha256:2b0206ffa149df46fbc399434d3487a97aadebcb0e79225d32b97c26975887cb", size = 541793, upload-time = "2026-07-08T07:59:37.882Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/65/768cf00cf2d5757aaeed002b5682d9f2a2480ce43b82e345010c91c41a56/givenergy_modbus-2.10.1.tar.gz", hash = "sha256:7eeb0d99724daced44aa2cd5652e50b8e42faa1efbc06a7cf8c5a163e98508fb", size = 545166, upload-time = "2026-07-08T12:34:00.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/c1/137c59b465925451951fe9cc096a1e6123a720e31357a9ea529437cdcea2/givenergy_modbus-2.10.0-py3-none-any.whl", hash = "sha256:38ee9186f885503c940585b46ae1734c2d18624c338e93d249459487d0ea37e8", size = 209599, upload-time = "2026-07-08T07:59:35.103Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/285e4cf76cdec30be8c0f4e197843ee9f7e0ff7a88f09d52998b7033d28a/givenergy_modbus-2.10.1-py3-none-any.whl", hash = "sha256:bf8f1306a8b58f082757904295ee8b6b254da55b67a8077f03ad2def007ae76f", size = 210047, upload-time = "2026-07-08T12:33:59.389Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts 2.10.0 (the #293 manifest series). **Slice A behaviour change handled:** `e_pv_generation_*` honestly return None on Model.AC/ALL_IN_ONE — the values now live in `e_inverter_out_*`, surfaced as **Inverter Output Today/Total** (keys `inverter_output_*` to dodge the legacy unique_id migration map, which claims the field names unconditionally).

- Upgraded AC/AIO entries get an **in-place rename** (PV Generation → Inverter Output, same registry row — genuine same-register history rides); the PV-derived rows (Self Consumption ×2, PV Direct, + House Consumption on Model.AC) are removed, matching upstream None-propagation.
- **New `migrations.py`** concentrates all registry migrations/reconciliations with dated `Introduced:` headers and `Removal candidate:` criteria — the house policy for making this machinery deletable.
- Bundled dashboard totals card shows exactly one of the PV-Generation/Inverter-Output pair per model (strategy v12).
- Slice B/D checked: no deprecated-constant or WRITE_SAFE_REGISTERS usage; `has_extended_slots` unused; managed rollup + 3ph unaffected.
- **Follow-up commit: bumped to 2.10.1**, which corrects the Gateway AIO power sign (`p_liberty`, `p_aio_total`, per-AIO inverter power) to the house convention directly in the model — the sign-inverted-on-live-hardware annotations from #266 are removed since nothing was negated hass-side to begin with.

588 Python + 42 JS green; plan reviewed and approved beforehand.
