### PR TITLE
feat: expose 3-phase Export Power Rate Limit sensor (#178)

### DIFF
--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -619,8 +619,10 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         value_fn=lambda inv: inv.t_battery,
         # Three-phase units inherit this single-phase register address but their
         # firmware never populates it, so it reads frozen rather than unavailable
-        # (#174). Real 3ph battery temperature comes from the HV cluster
-        # (Bcu.cluster_cell_temperature) once HV-stack support lands (#179).
+        # (#174). No aggregate 3ph battery-temperature register substitutes for it:
+        # the HV cluster field once assumed to be one (Bcu.cluster_cell_temperature)
+        # is actually a count, not a temperature (givenergy-modbus#382). Per-module
+        # HV temperatures are surfaced by the BMU sensors instead (#179).
         single_phase_only=True,
     ),
     GivEnergyInverterSensorDescription(

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1015,6 +1015,22 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
+        # Three-phase only: the installer-set grid export power-rate cap (HR1063),
+        # a percentage of rated power. givenergy-modbus #263 corrected this from a
+        # bogus 0-6500 W "power" to the 0-100 % rate it always was, and renamed it
+        # export_power_rate. Read-only for now; a writable control awaits the write
+        # path being confirmed on real three-phase hardware (#178). getattr +
+        # skip_if_none gates it off the single-phase model, which has no such field.
+        key="export_power_rate",
+        name="Export Power Rate Limit",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=1,
+        value_fn=lambda inv: getattr(inv, "export_power_rate", None),
+        skip_if_none=True,
+    ),
+    GivEnergyInverterSensorDescription(
         key="e_inverter_in_total",
         name="Charge from Grid Total",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,9 @@ def mock_inverter() -> MagicMock:
     # attr is truthy and would create the sensors on every hybrid test.
     inv.e_inverter_out_today = None
     inv.e_inverter_out_total = None
+    # export_power_rate (HR1063) is three-phase only; None on the single-phase
+    # hybrid mock, or a bare MagicMock attr would create the sensor here (#178).
+    inv.export_power_rate = None
     inv.t_inverter_heatsink = 45.3
     inv.t_charger = 38.7
     inv.enable_charge = True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -200,6 +200,26 @@ def test_single_phase_only_sensors_gated_on_three_phase():
         assert _include_inverter_sensor(_inverter_desc(key), inv, False) is True
 
 
+def test_export_power_rate_is_three_phase_only():
+    """Export Power Rate Limit (HR1063) exists only on the three-phase model —
+    givenergy-modbus #263 renamed it from the bogus p_export_limit and re-scaled it
+    to a 0-100 % rate. It is NOT flagged single_phase_only (that flag drops a sensor
+    ON three-phase, the opposite of what's wanted); it's gated the reverse way via
+    getattr + skip_if_none, so it appears on three-phase and drops on single-phase (#178)."""
+    from givenergy_modbus.model.inverter import SinglePhaseInverter
+    from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
+
+    desc = _inverter_desc("export_power_rate")
+    assert desc.single_phase_only is False
+    assert desc.skip_if_none is True
+    # Single-phase model has no such field → value_fn resolves to None → dropped.
+    assert not hasattr(SinglePhaseInverter(), "export_power_rate")
+    assert desc.value_fn(SinglePhaseInverter()) is None
+    # Three-phase model defines it (the field exists; None until a poll populates it).
+    assert hasattr(ThreePhaseInverter(), "export_power_rate")
+    assert desc.value_fn(ThreePhaseInverter()) is None
+
+
 def test_device_kind_buckets_to_inverter_ems_gateway():
     """Device-name noun (which drives the entity_id prefix) buckets correctly —
     every actual inverter stays "Inverter"; EMS/Gateway get their own identity."""
@@ -237,12 +257,13 @@ async def test_expected_sensor_count(hass, setup_integration):
     # exists on three-phase models (#154).
     # -1: e_load_today (3ph-only). -2: the Inverter Output pair reads None on
     # hybrids (modbus 2.10.0 Slice A — only Model.AC/ALL_IN_ONE populate it).
+    # -1: export_power_rate (3ph-only HR1063, absent on the single-phase mock — #178).
     expected = (
         len(INVERTER_SENSORS)
         + len(BATTERY_SENSORS)
         + len(BATTERY_CELL_SENSORS)
         + len(COORDINATOR_SENSORS)
-        - 3
+        - 4
     )
     assert len(sensors) == expected
 


### PR DESCRIPTION
Closes the sensor half of #178, now that the upstream blocker (givenergy-modbus#263) is resolved.

#263 renamed the mis-modelled `p_export_limit` → **`export_power_rate`** and re-scaled HR1063 from a bogus 0–6500 W "power" to the 0–100 % rate cap it always was (plus added a setter). This surfaces it as a read-only diagnostic **Export Power Rate Limit** sensor — the installer-level export-cap sensor #178 requested.

- Three-phase only: gated off the single-phase model via `getattr` + `skip_if_none` (the field doesn't exist on `SinglePhaseInverter`). Regression test pins the gating (present on `ThreePhaseInverter`, absent on `SinglePhaseInverter`); the hybrid mock gets `export_power_rate=None` to dodge the MagicMock-truthy trap.
- **Writable control deliberately deferred:** it's an installer-tier grid-compliance (G99) setting, and modbus flags the write path as unconfirmed on real three-phase hardware. Same "validate on real silicon before exposing writes" line held on the Gateway controls — a natural thing for a 3-phase tester (lamztib) to confirm later.

589 tests green, ruff + mypy clean. No hardware to test the reading on my side; a 3-phase owner can sanity-check the value once it ships.
