### PR TITLE
feat: retire the Battery Discharge This Year sensor (#275)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,6 @@ Some energy sensors are model-dependent: on AC-coupled and All-in-One systems th
 | Export Power Rate Limit | % | Three-phase only — installer-set grid export power-rate cap (% of rated power) |
 | Inverter Export Total | kWh | Cumulative inverter export to grid |
 | Charge from Grid Total | kWh | Cumulative grid-sourced battery charging |
-| Battery Discharge This Year | kWh | |
 | Backup Power | W | EPS port output |
 | Combined Generation Power | W | Solar + battery combined |
 | Work Time Total | h | |

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -71,6 +71,7 @@ from .migrations import (
     _reconcile_gateway_entities,
     _reconcile_per_cell_entities,
     _reconcile_readability_gated_controls,
+    _remove_retired_battery_discharge_year,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -86,7 +87,7 @@ _STRATEGY_URL = f"/{DOMAIN}/{_STRATEGY_FILENAME}"
 # served from the same package dir so they resolve offline without a CDN.
 _FONTS_DIRNAME = "fonts"
 _FONTS_URL = f"/{DOMAIN}/{_FONTS_DIRNAME}"
-_STRATEGY_VERSION = "12"
+_STRATEGY_VERSION = "13"
 
 # Per-config-entry topology cache. PlantCapabilities is persisted as
 # `to_dict()` directly (no envelope) following HA Core's Store convention —
@@ -608,6 +609,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Re-point any entities under renamed unique_ids before the platforms create
     # them, so the existing entity (and its history) is reused rather than orphaned.
     _migrate_unique_ids(hass, entry)
+
+    # Battery Discharge This Year was retired entirely (#275) — static on AIO,
+    # 0 on inverters, unavailable on EMS, so no signal on any hardware. Clear the
+    # orphaned row an upgraded entry would otherwise keep as a dead entity.
+    _remove_retired_battery_discharge_year(hass, coordinator.data.inverter_serial_number)
 
     # On an EMS plant the 0x11 device is a controller, not an inverter (#201). An
     # upgraded entry still carries the inverter sensors/controls an earlier version

--- a/custom_components/givenergy_local/migrations.py
+++ b/custom_components/givenergy_local/migrations.py
@@ -246,6 +246,25 @@ def _reconcile_aio_house_consumption(hass: HomeAssistant, serial: str) -> None:
         registry.async_remove(entity_id)
 
 
+def _remove_retired_battery_discharge_year(hass: HomeAssistant, serial: str) -> None:
+    """Remove the retired Battery Discharge This Year sensor (#275).
+
+    Introduced: v1.4.0 (2026-07-09). Removal candidate: when upgrades from
+    pre-v1.4.0 installs are presumed extinct.
+
+    `e_discharge_year` was dropped entirely — it read a static meaningless value
+    on AIO, a flat 0 on inverters, and was unavailable on EMS, so it carried no
+    signal on any hardware. The description is gone; this clears the orphaned
+    registry row an upgraded entry would otherwise keep as a dead, unavailable
+    entity.
+    """
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_e_discharge_year")
+    if entity_id is not None:
+        _LOGGER.info("Removing %s: Battery Discharge This Year retired (#275)", entity_id)
+        registry.async_remove(entity_id)
+
+
 # The PV Generation → Inverter Output rename on Model.AC / ALL_IN_ONE, plus the
 # derived rows that lose their inputs there. Values: (old_key, new_key) pairs
 # share the entity_id slug shapes (pv_generation_x → inverter_output_x).

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1040,19 +1040,6 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda inv: inv.e_inverter_in_total,
     ),
-    GivEnergyInverterSensorDescription(
-        key="e_discharge_year",
-        name="Battery Discharge This Year",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda inv: inv.e_discharge_year,
-        # AIO reports a static, meaningless figure here (not None), so skip_if_none
-        # never caught it — gate on AIO topology instead (#95). skip_if_none still
-        # drops it on any non-AIO model where the register is genuinely absent.
-        skip_if_aio=True,
-        skip_if_none=True,
-    ),
     # --- Lifetime battery energy totals (routed per-model in givenergy-modbus
     # #76; return None on models with no known total register — e.g. AC-coupled
     # — so they're skipped there rather than shown blank). These replace the

--- a/custom_components/givenergy_local/www/ge-strategy.js
+++ b/custom_components/givenergy_local/www/ge-strategy.js
@@ -657,7 +657,6 @@
         row(a.inv("e_pv_generation_total"), "PV Generation Total"),
         row(a.inv("inverter_output_total"), "Inverter Output Total"),
         row(a.inv("e_inverter_in_total"), "Charged from Grid"),
-        row(a.inv("e_discharge_year"), "Discharged This Year"),
         row(a.inv("e_solar_diverter"), "Solar Diverter Energy"),
       ]),
     });

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,6 @@ def mock_inverter() -> MagicMock:
     # Additional energy totals
     inv.e_inverter_export_total = 2105.7
     inv.e_inverter_in_total = 312.4
-    inv.e_discharge_year = 421.8
     # EPS / generation
     inv.p_backup = 0
     inv.p_combined_generation = 2500

--- a/tests/js/mock-hass.js
+++ b/tests/js/mock-hass.js
@@ -13,7 +13,7 @@ const INVERTER_KEYS = [
   // energy totals
   "e_pv_total", "e_battery_throughput", "e_battery_charge_total",
   "e_battery_discharge_total", "e_grid_out_total", "e_grid_in_total",
-  "e_pv_generation_total", "e_inverter_in_total", "e_discharge_year",
+  "e_pv_generation_total", "e_inverter_in_total",
   "e_solar_diverter",
   // controls
   "battery_power_mode", "enable_rtc", "active_power_rate", "battery_calibration_stage",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1032,6 +1032,26 @@ async def test_upgrade_removes_dc_limit_rows_on_ac_coupled(
     assert _present("battery_discharge_limit_ac")
 
 
+async def test_upgrade_removes_retired_battery_discharge_year(
+    hass, mock_client, mock_plant, mock_inverter, mock_config_entry
+):
+    """#275: Battery Discharge This Year was retired entirely (no signal on any
+    hardware — static on AIO, 0 on inverters, unavailable on EMS). The description
+    is gone; an upgraded entry's orphaned row is swept pre-platform rather than
+    left as a dead, unavailable entity."""
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_e_discharge_year", config_entry=mock_config_entry
+    )
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_e_discharge_year") is not None
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_e_discharge_year") is None
+
+
 async def test_dc_limit_rows_retained_on_hybrid(
     hass, mock_client, mock_plant, mock_inverter, mock_config_entry
 ):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -137,7 +137,6 @@ def test_aio_inapplicable_inverter_sensors_skip_if_none():
         "num_mppt",
         "e_inverter_export_total",
         "inverter_errors",
-        "e_discharge_year",
         "e_solar_diverter",  # already had it — guard against regression
     ):
         assert _inverter_desc(key).skip_if_none is True, key
@@ -148,13 +147,13 @@ def test_aio_inapplicable_inverter_sensors_skip_if_none():
 
 
 def test_aio_inapplicable_inverter_sensors_gated_on_aio():
-    """MPPT Count, Solar Diverter and Battery Discharge This Year read a meaningless
-    value (0, 0.0, a static figure) — not None — on an AIO, so skip_if_none never
-    dropped them. They're gated on AIO topology instead (#95). House Consumption
-    Today joins them: its PV/grid inputs are under identity investigation on AIO
-    (modbus#293) and the unit reports no raw consumption figure."""
+    """MPPT Count and Solar Diverter read a meaningless value (0, 0.0) — not None —
+    on an AIO, so skip_if_none never dropped them. They're gated on AIO topology
+    instead (#95). House Consumption Today joins them: its PV/grid inputs are under
+    identity investigation on AIO (modbus#293) and the unit reports no raw
+    consumption figure."""
     inv = MagicMock()  # every attr returns a truthy mock, i.e. "not None"
-    aio_gated = {"num_mppt", "e_solar_diverter", "e_discharge_year", "e_consumption_today"}
+    aio_gated = {"num_mppt", "e_solar_diverter", "e_consumption_today"}
     flagged = {d.key for d in INVERTER_SENSORS if d.skip_if_aio}
     assert flagged == aio_gated
     for key in aio_gated:
@@ -1305,7 +1304,7 @@ async def test_aio_model_suppresses_pv_sensors_even_with_empty_modules(hass, hv_
     House Consumption Today joins the gated set: its PV/grid inputs are under identity
     investigation on AIO (modbus#293) and there is no raw backing figure."""
     registry = er.async_get(hass)
-    for key in ("num_mppt", "e_solar_diverter", "e_discharge_year", "e_consumption_today"):
+    for key in ("num_mppt", "e_solar_diverter", "e_consumption_today"):
         assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is None, key
     # Sanity: the inverter-sensor loop did run (only the PV/solar fields were gated).
     assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_system_mode") is not None


### PR DESCRIPTION
Closes Ask 2 of #275 (Nick / njhcarroll).

**Battery Discharge This Year** (`e_discharge_year`) carried no useful signal on any hardware: a static meaningless figure on AIO, a flat 0 on the inverters, and unavailable on EMS. Removed:

- Drop the sensor description.
- **Reconcile the orphaned rows** on upgrade (`_remove_retired_battery_discharge_year`, runs pre-platform for all models) — so it's genuinely gone rather than left as a dead, unavailable entity, which is what Nick was seeing.
- Drop its row from the bundled dashboard strategy (`_STRATEGY_VERSION` → 13).
- Sweep the test/mock references.

Regression test pins the reconciler; 590 Python + 42 JS green, ruff + mypy clean. Intended to ride into v1.4.0. (Ask 1 — EMS Battery Charge/Discharge Today — is a separate, properly-soaked v1.4.1 feature.)
