### PR TITLE
feat: adopt givenergy-modbus 2.11.2

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus==2.10.3"
+    "givenergy-modbus==2.11.2"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1558,10 +1558,11 @@ AIO_MODULE_CELL_SENSORS: tuple[GivEnergyAioModuleSensorDescription, ...] = (
 
 # All-in-One / HV battery stack (BCU) sensors (#95). The library decodes a
 # cluster-level Battery Control Unit per HV stack (device 0x70+offset); these
-# surface its pack-level metrics, which were previously unavailable — including
-# the correct pack voltage (the inverter-level `v_battery` is a sub-100V field
-# that reads Unknown on an HV stack). Power/energy go on the main device page;
-# the rest are DIAGNOSTIC, matching the inverter/battery analogues.
+# surface its pack-level metrics. This BCU-level Battery Voltage sits on the HV
+# stack device, distinct from the inverter-level `v_battery` on the main device:
+# both now read a real HV voltage (givenergy-modbus 2.11.2 / #395 widened the
+# inverter-level IR50 bound, which previously clamped HV to Unknown). Power/energy
+# go on the main device page; the rest are DIAGNOSTIC, matching the analogues.
 HV_STACK_SENSORS: tuple[GivEnergyHvStackSensorDescription, ...] = (
     GivEnergyHvStackSensorDescription(
         key="battery_voltage",
@@ -2485,6 +2486,13 @@ async def async_setup_entry(
         )
 
     for battery_index, battery in enumerate(coordinator.data.batteries):
+        # Skip a capabilities-listed-but-unreachable pack: modbus 2.11.x yields an
+        # all-None placeholder (is_valid()==False, no serial) at its index rather
+        # than dropping it, to keep siblings index-aligned (#213). Creating a
+        # device for it would key on a None serial; the index still maps correctly
+        # into `batteries` for the packs we do surface. Mirrors the AIO/BMU loops.
+        if not battery.is_valid():
+            continue
         entities.extend(
             GivEnergyBatterySensor(coordinator, description, battery_index)
             for description in BATTERY_SENSORS
@@ -2967,6 +2975,13 @@ class GivEnergyBatterySensor(
         """
         if not super().available:
             return False
+        # A pack that dropped after setup surfaces as an all-None placeholder at
+        # its index (#213, modbus 2.11.x) — go unavailable rather than show its
+        # last-good/None values frozen. Only an in-range placeholder; an
+        # out-of-range index keeps default availability via the bounds check below.
+        batteries = self.coordinator.data.batteries
+        if self._battery_index < len(batteries) and not batteries[self._battery_index].is_valid():
+            return False
         if not self._source_ir_registers:
             return True
         capabilities = self.coordinator.data.capabilities
@@ -2977,7 +2992,7 @@ class GivEnergyBatterySensor(
     @property
     def native_value(self) -> Any:
         batteries = self.coordinator.data.batteries
-        if self._battery_index >= len(batteries):
+        if self._battery_index >= len(batteries) or not batteries[self._battery_index].is_valid():
             return None
         return self.entity_description.value_fn(batteries[self._battery_index])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
     # an upstream patch that wasn't validated against this integration. Bump both
     # this and manifest.json together.
-    "givenergy-modbus==2.10.3",
+    "givenergy-modbus==2.11.2",
 ]
 
 [dependency-groups]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1823,6 +1823,49 @@ def test_battery_sensor_available_when_index_out_of_range(mock_plant):
     mock_plant.register_age.assert_not_called()
 
 
+def test_battery_sensor_unavailable_when_pack_becomes_placeholder(mock_plant):
+    """A pack that drops after setup surfaces as an all-None placeholder at its
+    index (#213, modbus 2.11.x). The sensor goes unavailable and reads None rather
+    than presenting the placeholder's blank values as if live."""
+    from datetime import timedelta
+
+    from custom_components.givenergy_local.sensor import GivEnergyBatterySensor
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.update_interval = timedelta(seconds=30)
+    coordinator.data = mock_plant
+    entity = GivEnergyBatterySensor(coordinator, _battery_desc("soc"), 0)
+
+    # Pack 0 drops: the library now serves an all-None placeholder at its index.
+    placeholder = MagicMock()
+    placeholder.is_valid.return_value = False
+    mock_plant.batteries = [placeholder]
+
+    assert entity.available is False
+    assert entity.native_value is None
+
+
+async def test_battery_setup_skips_placeholder_pack(hass, mock_client, mock_config_entry):
+    """A capabilities-listed-but-unreachable pack (#213, modbus 2.11.x) arrives as an
+    all-None placeholder (is_valid()==False, no serial). Setup must skip it rather
+    than build a phantom device keyed on a None serial; the real pack is unaffected."""
+    placeholder = MagicMock()
+    placeholder.is_valid.return_value = False
+    placeholder.serial_number = None
+    plant = mock_client.plant
+    plant.batteries = [*plant.batteries, placeholder]
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    # Real pack surfaced; no phantom entity created under a None serial.
+    assert registry.async_get_entity_id("sensor", DOMAIN, "BT1234A001_soc") is not None
+    assert registry.async_get_entity_id("sensor", DOMAIN, "None_soc") is None
+
+
 def _aio_desc(key: str):
     return next(d for d in AIO_MODULE_CELL_SENSORS if d.key == key)
 

--- a/uv.lock
+++ b/uv.lock
@@ -937,7 +937,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = "==2.10.3" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.11.2" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -951,16 +951,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.10.3"
+version = "2.11.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/de/3d1edd240b90269cf635c17daec3f00a477ae25b25c3c51ba8b7b42a0228/givenergy_modbus-2.10.3.tar.gz", hash = "sha256:ac8f589e32a49741dc821c97d671eb19b73634750c31237bf91bc04e844b87d5", size = 558751, upload-time = "2026-07-09T08:42:30.686Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/34/f07860074d41959c58bcd3edb83f7b406c6daaa92b9b042360e1f0386982/givenergy_modbus-2.11.2.tar.gz", hash = "sha256:a56540e7992d512f263ca4a9e97ad05c8ea32201975f623c6bc9469f3ad07870", size = 580689, upload-time = "2026-07-10T11:30:20.498Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/e5/ad0de9031f088e1e187004cf92a030522589de641250dd9f881e04a4c00b/givenergy_modbus-2.10.3-py3-none-any.whl", hash = "sha256:baca99656982450cb7f5d1cb7f713be3ad57aaa0a1a7e4d4e1e758ada83f51c8", size = 210782, upload-time = "2026-07-09T08:42:29.421Z" },
+    { url = "https://files.pythonhosted.org/packages/10/78/b9a7b2bfc537890f1c0144d723eba7fb786c8be0a9f263e92bd714b595e5/givenergy_modbus-2.11.2-py3-none-any.whl", hash = "sha256:ee86c7a70c421c5471c30ca8a4734e7b4d6267f1c8123b6d76b6d3621e8aba2b", size = 214493, upload-time = "2026-07-10T11:30:18.872Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts givenergy-modbus 2.11.2 — the foundation of the v1.4.1 cycle.

## What's in it

**AIO Battery Voltage now reads a real value.** #395 (upstream) widened the inverter-level `v_battery` (IR50) HV bound, so it decodes ~300–500 V instead of clamping to `Unknown` on AIO/HV-stack units — closing the "coming through as Unknown" report from June. The sensor is ungated, so it surfaces automatically on the pin bump; the stale sub-100V comment on the BCU Battery Voltage is corrected to reflect the new reality (both the inverter-level and BCU-level Battery Voltage now read real HV, on their respective devices).

**Guards the LV battery path against #213 placeholders.** This is the substantive code change. In 2.11.x, `Plant.batteries` iterates every capabilities-listed address and yields an **all-None placeholder** (`is_valid()==False`, no serial) for any without a register cache, rather than dropping it — keeping siblings index-aligned. Verified against the installed library (`plant.py`), this path is *live*, not dormant: a pack that's detected-but-not-yet-read produces a placeholder. Unguarded, our LV setup loop would build a device keyed on a `None` serial (`unique_id="None_…"`). So:

- The setup loop skips invalid packs (mirroring the existing AIO/BMU loops).
- A pack that drops *after* setup goes **unavailable** rather than presenting the placeholder's blank values as if live (in-range only; the out-of-range bounds behaviour is unchanged).

The other `.batteries` consumers were checked and are already placeholder-safe (`_live_device_identifiers` guards on serial; the binary-sensor readings absorb all-None via their `None`-guards).

## Tests

Two regression tests: the setup-skip (no phantom `None`-serial device) and the runtime gate (a pack becoming a placeholder → unavailable + `None`).

## Scope

Pin bump in all three places (manifest.json, pyproject.toml, uv.lock). The other 2.11.x deltas are additive or test-only and we don't touch the deprecated BCU fields (only a code comment references the old name, as historical context). Nick's EMS Charge/Discharge Today feature is a separate PR sharing the same v1.4.1rc soak.

## Verification

`ruff` clean, `mypy` clean, **592** Python tests, **42** JS tests, no 2.11.x deprecation warnings from our code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented sensors from appearing for unreachable or invalid battery packs.
  - Invalid battery sensors are now correctly marked unavailable and no longer display misleading readings.
  - Avoided creating phantom devices and entities for battery packs without valid identifiers.
  - Improved handling of missing battery packs while preserving correct sensor alignment for reachable packs.

- **Improvements**
  - Updated battery integration compatibility for newer Modbus behaviour.
  - Clarified the distinction between HV-stack battery voltage and inverter-level battery voltage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->