### PR TITLE
feat: add EMS battery charge/discharge energy sensors (#275)

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,13 +364,14 @@ All-in-One systems expose each removable battery module separately, so on AIO ha
 
 ### EMS controller device
 
-On an EMS plant the controller device carries plant-level aggregates the inverter registers don't: managed-inverter count, calculated/measured load power, grid meter power, total battery power and remaining battery energy. Two derived energy sensors build on the load aggregate:
+On an EMS plant the controller device carries plant-level aggregates the inverter registers don't: managed-inverter count, calculated/measured load power, grid meter power, total battery power and remaining battery energy. Since the EMS rollup carries no energy counters, several energy sensors are derived by integrating those live power signals client-side:
 
 | Entity | Unit | Notes |
 |---|---|---|
 | EMS Calculated Load Energy Today / Total | kWh | Integrated client-side from *EMS Calculated Load Power* — the EMS rollup carries no energy counters, so no register-backed figure exists. An estimate, not a meter reading: it undercounts across restarts and outages (a sampling gap contributes at most one capped slice), though the accumulated value does survive Home Assistant restarts. |
+| EMS Battery Charge / Discharge Today / Total | kWh | Integrated client-side from *EMS Total Battery Power*, split by sign into charging and discharging energy — the pair the Home Assistant Energy dashboard's battery section expects. Same estimate caveats as the load energy above: undercounts across gaps, survives restarts. |
 
-These replace the Integral + Utility Meter helpers a Predbat EMS setup previously had to hand-create ([#248](https://github.com/dewet22/givenergy-hass/issues/248)).
+These replace the Integral + Utility Meter helpers a Predbat EMS setup previously had to hand-create ([#248](https://github.com/dewet22/givenergy-hass/issues/248), [#275](https://github.com/dewet22/givenergy-hass/issues/275)).
 
 ### Gateway device
 

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -1882,6 +1882,42 @@ EMS_LOAD_ENERGY_TODAY = GivEnergyEmsSensorDescription(
     suggested_display_precision=2,
 )
 
+# Battery charge/discharge energy (#275). Sign-split integrals of
+# total_battery_power (IR2090), for the Energy dashboard's battery section. Today
+# resets at midnight; Total is lifetime — HA buckets either into periods.
+EMS_BATTERY_CHARGE_ENERGY_TOTAL = GivEnergyEmsSensorDescription(
+    key="ems_battery_charge_energy_total",
+    name="EMS Battery Charge Total",
+    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    device_class=SensorDeviceClass.ENERGY,
+    state_class=SensorStateClass.TOTAL_INCREASING,
+    suggested_display_precision=2,
+)
+EMS_BATTERY_CHARGE_ENERGY_TODAY = GivEnergyEmsSensorDescription(
+    key="ems_battery_charge_energy_today",
+    name="EMS Battery Charge Today",
+    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    device_class=SensorDeviceClass.ENERGY,
+    state_class=SensorStateClass.TOTAL_INCREASING,
+    suggested_display_precision=2,
+)
+EMS_BATTERY_DISCHARGE_ENERGY_TOTAL = GivEnergyEmsSensorDescription(
+    key="ems_battery_discharge_energy_total",
+    name="EMS Battery Discharge Total",
+    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    device_class=SensorDeviceClass.ENERGY,
+    state_class=SensorStateClass.TOTAL_INCREASING,
+    suggested_display_precision=2,
+)
+EMS_BATTERY_DISCHARGE_ENERGY_TODAY = GivEnergyEmsSensorDescription(
+    key="ems_battery_discharge_energy_today",
+    name="EMS Battery Discharge Today",
+    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    device_class=SensorDeviceClass.ENERGY,
+    state_class=SensorStateClass.TOTAL_INCREASING,
+    suggested_display_precision=2,
+)
+
 
 def _gateway_aio_energy(
     slot: int, direction: str, period: str
@@ -2484,6 +2520,22 @@ async def async_setup_entry(
         entities.append(
             GivEnergyEmsLoadEnergySensor(coordinator, EMS_LOAD_ENERGY_TODAY, daily_reset=True)
         )
+        # Battery charge/discharge energy: sign-split integrals of total_battery_power (#275).
+        for description, direction, daily_reset in (
+            (EMS_BATTERY_CHARGE_ENERGY_TOTAL, _ENERGY_CHARGE, False),
+            (EMS_BATTERY_CHARGE_ENERGY_TODAY, _ENERGY_CHARGE, True),
+            (EMS_BATTERY_DISCHARGE_ENERGY_TOTAL, _ENERGY_DISCHARGE, False),
+            (EMS_BATTERY_DISCHARGE_ENERGY_TODAY, _ENERGY_DISCHARGE, True),
+        ):
+            entities.append(
+                GivEnergyEmsLoadEnergySensor(
+                    coordinator,
+                    description,
+                    daily_reset=daily_reset,
+                    source_field="total_battery_power",
+                    direction=direction,
+                )
+            )
 
     for battery_index, battery in enumerate(coordinator.data.batteries):
         # Skip a capabilities-listed-but-unreachable pack: modbus 2.11.x yields an
@@ -3369,16 +3421,26 @@ _LOAD_ENERGY_GAP_SCANS = 3
 # Fallback cap when the coordinator carries no update interval (never in practice).
 _LOAD_ENERGY_GAP_FLOOR = 300.0
 
+# Sign split for the battery-power integral. total_battery_power (IR2090):
+# positive = discharge, negative = charge — confirmed against modbus's golden EMS
+# capture (the busbar power-balance closes to the watt only under this sign, and
+# IR2090 equals the sum of the managed inverters' battery power, inheriting their
+# house convention). Kept as the single point of truth for the split.
+_ENERGY_CHARGE = "charge"
+_ENERGY_DISCHARGE = "discharge"
+
 
 class GivEnergyEmsLoadEnergySensor(GivEnergyEmsSensor, RestoreEntity):
-    """Client-side integral of EMS calculated load power (#248).
+    """Client-side integral of an EMS power signal (#248, #275).
 
-    The EMS rollup carries no energy counters and the site PV is only visible as
-    meter power samples, so on an EMS plant house-load energy exists solely as a
-    live power signal — there is nothing register-backed to read or balance
-    against (settled empirically against real EMS captures). This integrates
-    calc_load_power (IR2086) at poll cadence; measured_load_power reads a
-    constant zero on real sites and is deliberately not a fallback.
+    The EMS rollup carries no energy counters, so on an EMS plant these energies
+    exist solely as live power signals — nothing register-backed to read or
+    balance against (settled empirically against real EMS captures). Integrates
+    ``source_field`` at poll cadence:
+    - calc_load_power (IR2086) for house-load energy (measured_load_power reads a
+      constant zero on real sites and is deliberately not a fallback);
+    - total_battery_power (IR2090) for battery charge/discharge energy, sign-split
+      by ``direction`` so one accumulator collects only its half of the signal.
 
     An estimate, not a meter: every failure mode undercounts, never overcounts.
     The accumulator restores across HA restarts, and any sampling gap (restart,
@@ -3391,9 +3453,13 @@ class GivEnergyEmsLoadEnergySensor(GivEnergyEmsSensor, RestoreEntity):
         description: GivEnergyEmsSensorDescription,
         *,
         daily_reset: bool,
+        source_field: str = "calc_load_power",
+        direction: str | None = None,
     ) -> None:
         super().__init__(coordinator, description)
         self._daily_reset = daily_reset
+        self._source_field = source_field
+        self._direction = direction
         self._total_kwh = 0.0
         self._day: date | None = None
         self._last_sample_at: datetime | None = None
@@ -3432,16 +3498,17 @@ class GivEnergyEmsLoadEnergySensor(GivEnergyEmsSensor, RestoreEntity):
         if mark is None or mark == self._last_mark:
             return
         ems = self.coordinator.data.ems
-        power = getattr(ems, "calc_load_power", None) if ems is not None else None
+        raw = getattr(ems, self._source_field, None) if ems is not None else None
         now = dt_util.utcnow()
-        if power is None:
-            # A successful refresh without a load sample (rollup bank missing or
+        if raw is None:
+            # A successful refresh without a power sample (rollup bank missing or
             # partial) consumes the sample boundary: advance the clock and mark
             # without adding energy, so a later valid sample can't bridge the
             # unknown interval at its own power — undercount, never overcount.
             self._last_sample_at = now
             self._last_mark = mark
             return
+        power = self._directional_power(raw)
         if self._daily_reset:
             today = dt_util.now().date()
             if self._day != today:
@@ -3455,6 +3522,20 @@ class GivEnergyEmsLoadEnergySensor(GivEnergyEmsSensor, RestoreEntity):
                 self._total_kwh += power * min(elapsed, self._gap_cap) / 3_600_000
         self._last_sample_at = now
         self._last_mark = mark
+
+    def _directional_power(self, raw: float) -> float:
+        """Non-negative power for this sensor's half of the signal.
+
+        Load energy (direction=None) integrates the raw signal as-is. The battery
+        directions clamp to their own sign — positive=discharge, negative=charge —
+        so the off-sign periods contribute a zero slice rather than the other
+        direction's energy.
+        """
+        if self._direction == _ENERGY_CHARGE:
+            return max(-raw, 0.0)
+        if self._direction == _ENERGY_DISCHARGE:
+            return max(raw, 0.0)
+        return raw
 
     @property
     def native_value(self) -> float | None:

--- a/tests/test_ems.py
+++ b/tests/test_ems.py
@@ -672,3 +672,89 @@ async def test_load_energy_entities_created_on_ems(hass, ems_setup):
     assert today.state == "0.0"
     assert total.attributes["unit_of_measurement"] == "kWh"
     assert total.attributes["state_class"] == "total_increasing"
+
+
+# ---------------------------------------------------------------------------
+# EMS battery charge/discharge energy (#275) — sign-split integrals of
+# total_battery_power. The shared integral machinery (gap-cap, restore, midnight
+# reset, missing-sample boundary) is covered by the load-energy tests above; these
+# focus on the new sign split and entity creation.
+# ---------------------------------------------------------------------------
+
+
+def _battery_energy_entity(mock_plant, mock_ems, *, charge: bool, daily: bool = False):
+    """A battery charge- or discharge-energy integrator against a mocked coordinator."""
+    from custom_components.givenergy_local.sensor import (
+        _ENERGY_CHARGE,
+        _ENERGY_DISCHARGE,
+        EMS_BATTERY_CHARGE_ENERGY_TODAY,
+        EMS_BATTERY_CHARGE_ENERGY_TOTAL,
+        EMS_BATTERY_DISCHARGE_ENERGY_TODAY,
+        EMS_BATTERY_DISCHARGE_ENERGY_TOTAL,
+        GivEnergyEmsLoadEnergySensor,
+    )
+
+    mock_plant.ems = mock_ems
+    mock_plant.inverter.model = Model.EMS
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.last_successful_refresh = None
+    coordinator.update_interval = timedelta(seconds=30)
+    coordinator.data = mock_plant
+    if charge:
+        desc = EMS_BATTERY_CHARGE_ENERGY_TODAY if daily else EMS_BATTERY_CHARGE_ENERGY_TOTAL
+        direction = _ENERGY_CHARGE
+    else:
+        desc = EMS_BATTERY_DISCHARGE_ENERGY_TODAY if daily else EMS_BATTERY_DISCHARGE_ENERGY_TOTAL
+        direction = _ENERGY_DISCHARGE
+    entity = GivEnergyEmsLoadEnergySensor(
+        coordinator,
+        desc,
+        daily_reset=daily,
+        source_field="total_battery_power",
+        direction=direction,
+    )
+    return entity, coordinator
+
+
+def test_battery_discharge_integrates_positive_power(mock_plant, mock_ems, freezer):
+    """Positive total_battery_power = discharge: the discharge integral accumulates
+    while the charge integral, seeing the off-sign, stays at zero."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    mock_ems.total_battery_power = 1800  # discharging at 1800 W → 0.015 kWh / 30 s
+    discharge, dcoord = _battery_energy_entity(mock_plant, mock_ems, charge=False)
+    charge, ccoord = _battery_energy_entity(mock_plant, mock_ems, charge=True)
+    assert _refresh(discharge, dcoord) == 0.0  # seed
+    assert _refresh(charge, ccoord) == 0.0  # seed
+    freezer.tick(30)
+    assert _refresh(discharge, dcoord) == pytest.approx(0.015)
+    assert _refresh(charge, ccoord) == 0.0
+
+
+def test_battery_charge_integrates_negative_power(mock_plant, mock_ems, freezer):
+    """Negative total_battery_power = charge: the charge integral accumulates the
+    magnitude while the discharge integral stays at zero."""
+    freezer.move_to("2026-06-12 12:00:00+00:00")
+    mock_ems.total_battery_power = -1800  # charging at 1800 W
+    charge, ccoord = _battery_energy_entity(mock_plant, mock_ems, charge=True)
+    discharge, dcoord = _battery_energy_entity(mock_plant, mock_ems, charge=False)
+    assert _refresh(charge, ccoord) == 0.0  # seed
+    assert _refresh(discharge, dcoord) == 0.0  # seed
+    freezer.tick(30)
+    assert _refresh(charge, ccoord) == pytest.approx(0.015)
+    assert _refresh(discharge, dcoord) == 0.0
+
+
+async def test_battery_energy_entities_created_on_ems(hass, ems_setup):
+    """All four battery charge/discharge integrals surface on the controller device."""
+    for key in (
+        "ems_battery_charge_energy_total",
+        "ems_battery_charge_energy_today",
+        "ems_battery_discharge_energy_total",
+        "ems_battery_discharge_energy_today",
+    ):
+        state = hass.states.get(_entity_id(hass, "sensor", f"SA1234G123_{key}"))
+        assert state is not None, key
+        assert state.state == "0.0"
+        assert state.attributes["unit_of_measurement"] == "kWh"
+        assert state.attributes["state_class"] == "total_increasing"


### PR DESCRIPTION
Adds EMS Battery Charge/Discharge energy sensors — the second half of the v1.4.1 cycle (Nick's [#275](https://github.com/dewet22/givenergy-hass/issues/275) Ask a).

## Why

The HA Energy dashboard's battery section wants two figures: energy *into* the battery and energy *out*. On an EMS plant there's no register-backed battery-energy counter, and the managed-inverter summaries are blinded — so, exactly like the existing EMS Calculated Load Energy, these are derived by integrating a live power signal client-side. Here that's `ems.total_battery_power` (IR2090), sign-split into charge and discharge.

## What

- **Generalises `GivEnergyEmsLoadEnergySensor`** with two optional params, `source_field` (default `calc_load_power`) and `direction` (`None` | charge | discharge). The two existing load-energy sensors pass the defaults and are byte-for-byte unchanged. All the hardened integral behaviour — idempotent-per-refresh, gap-cap, `RestoreEntity` persistence, missing-sample boundary-consume, midnight reset — is inherited verbatim; the only new logic is a directional clamp (`_directional_power`).
- **Four sensors on the EMS controller device:** Battery Charge / Discharge, each Today + Total (`TOTAL_INCREASING` kWh). Nick asked for Today; Total is added to match the existing load-energy pair and give the Energy dashboard the lifetime `TOTAL_INCREASING` primitive it buckets itself.

## Sign convention — confirmed, not assumed

positive = discharge, negative = charge. Confirmed from a golden EMS capture two independent ways: the busbar power-balance closes to the watt only under this sign (battery +2511 W = load 677 W + export 1834 W), and IR2090 equals the exact sum of the managed inverters' battery power (inheriting their house convention). Isolated to a single `_directional_power` method regardless.

## Estimate caveats (inherited, documented on the class)

Client-side integral: undercounts across gaps/restarts, never overcounts; survives HA restarts.

## Tests & docs

Three new tests (`test_ems.py`): discharge accumulates on positive power / charge on negative / each reads zero on the off-sign, plus all four surface on the EMS device. The shared integral machinery is already covered by the load-energy tests. README EMS section updated.

## Soak

v1.4.1rc with Nick validating magnitude on his EMS plant (I have no EMS hardware). The sign is confirmed from a single exact power-balance tick rather than a multi-sample SOC ramp — modbus will re-confirm if a future capture catches the EMS battery moving its SOC measurably, but the balance is unambiguous.

## Verification

`ruff` clean, `mypy` clean, **595** Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
