### PR TITLE
feat: gate reconnect on a liveness probe (adopt modbus 2.12.0)

### DIFF
--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -86,6 +86,13 @@ def _summarize_failures(failures: Iterable[ReadFailure]) -> str:
 PROBE_TIMEOUT_SECONDS = 1.0
 PROBE_RETRIES = 3
 
+# On a reconnect we gate the heavy detect sweep behind a cheap HR0 liveness probe
+# (givenergy-modbus 2.12.0 `probe_alive`). retries=1 tolerates a single dropped
+# identity frame on an otherwise-healthy reconnect (fails in ~4s on a genuine
+# hang vs ~2s at 0) — the lossy-dongle case (#280) is exactly where a healthy
+# reconnect can still drop a stray frame, so we don't want to bail on the first.
+RECONNECT_PROBE_RETRIES = 1
+
 # When detect() reports a DEVICE LOSS (a previously-known battery/meter/stack
 # stopped answering), re-probe a few times before believing it — a slow BMS
 # often answers on the next sweep. Kept small: this blocks _connect(), which
@@ -516,6 +523,18 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         self._comms_last_seen.clear()
         try:
             await self._client.connect()
+            # On a reconnect (we've polled before), gate the heavy detect sweep
+            # behind a cheap HR0 liveness probe (#280). A hung dongle accepts the
+            # TCP connect but refuses its identity read; probe_alive fails fast and
+            # closes the socket, so we serve last-known and reprobe next tick rather
+            # than spending the full detect timeout hammering a dead connection.
+            # On success the socket stays open and detect runs robustly on it. The
+            # first-ever setup (no data yet) skips the probe and runs the full
+            # detect to establish topology from scratch.
+            if self.data is not None and not await self._client.probe_alive(
+                retries=RECONNECT_PROBE_RETRIES
+            ):
+                raise TimeoutError("inverter did not answer the reconnect liveness probe")
             topology_confirmed = True
             try:
                 # The library's battery sweep probes each pack slot (0x33-0x37)

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus==2.11.2"
+    "givenergy-modbus==2.12.0"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
     # an upstream patch that wasn't validated against this integration. Bump both
     # this and manifest.json together.
-    "givenergy-modbus==2.11.2",
+    "givenergy-modbus==2.12.0",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,6 +236,7 @@ def mock_client(mock_plant) -> AsyncMock:
             "load_config",
             "connect",
             "detect",
+            "probe_alive",
             "close",
             "one_shot_command",
             "capture_frames",
@@ -247,6 +248,9 @@ def mock_client(mock_plant) -> AsyncMock:
     client.load_config = AsyncMock(return_value=mock_plant)
     client.connect = AsyncMock()
     client.detect = AsyncMock()
+    # Reconnect liveness gate (givenergy-modbus 2.12.0): default alive so a
+    # reconnect proceeds to detect; the probe-failure path overrides this.
+    client.probe_alive = AsyncMock(return_value=True)
     client.close = AsyncMock()
     client.one_shot_command = AsyncMock()
     with (

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -316,6 +316,75 @@ async def test_detect_timeout_on_reconnect_discards_client(hass, mock_plant):
         assert coordinator.consecutive_failures == 0
 
 
+async def test_reconnect_probe_alive_false_serves_last_known(hass, mock_plant):
+    """On a reconnect a hung dongle fails the liveness probe: probe_alive closes
+    the socket, so we serve last-known and reprobe next tick WITHOUT running the
+    heavy detect sweep against a dead connection (#280)."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+    coordinator.data = mock_plant  # reconnect path: we've polled before
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.probe_alive = AsyncMock(return_value=False)  # hung dongle
+        mock_cls.return_value = client
+
+        result = await coordinator._async_update_data()
+
+        assert result is mock_plant  # last-known served this tick
+        client.probe_alive.assert_awaited_once()
+        client.detect.assert_not_called()  # never ran the sweep on a dead socket
+        assert coordinator._client is None  # torn down; next tick reprobes
+        assert coordinator.consecutive_failures == 1
+
+
+async def test_reconnect_probe_alive_true_runs_detect(hass, mock_plant):
+    """When the reconnect probe reports alive, the socket stays open and the full
+    (robust) detect runs on it, and the poll proceeds normally."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+    coordinator.data = mock_plant  # reconnect path
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.probe_alive = AsyncMock(return_value=True)
+        client.load_config = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        mock_cls.return_value = client
+
+        result = await coordinator._async_update_data()
+
+        assert result is mock_plant
+        client.probe_alive.assert_awaited_once()
+        client.detect.assert_awaited_once()  # robust detect ran on the live socket
+        assert coordinator._client is client
+        assert coordinator.consecutive_failures == 0
+
+
+async def test_first_connect_skips_liveness_probe(hass, mock_plant):
+    """The first-ever setup has no prior data, so it runs the full detect to
+    establish topology rather than gating behind the reconnect liveness probe."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+    # coordinator.data is None — no successful poll yet.
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.probe_alive = AsyncMock(return_value=False)  # would abort IF consulted
+        client.load_config = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        mock_cls.return_value = client
+
+        result = await coordinator._async_update_data()
+
+        assert result is mock_plant
+        client.probe_alive.assert_not_called()  # first connect: no gate
+        client.detect.assert_awaited_once()  # full detect ran
+
+
 async def test_cancelled_connect_discards_client(hass, mock_plant):
     """A cancellation during _connect() (HA cancelling the attempt) must still
     discard the half-initialised client. CancelledError is a BaseException, not

--- a/uv.lock
+++ b/uv.lock
@@ -937,7 +937,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = "==2.11.2" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.12.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -951,16 +951,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.11.2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/34/f07860074d41959c58bcd3edb83f7b406c6daaa92b9b042360e1f0386982/givenergy_modbus-2.11.2.tar.gz", hash = "sha256:a56540e7992d512f263ca4a9e97ad05c8ea32201975f623c6bc9469f3ad07870", size = 580689, upload-time = "2026-07-10T11:30:20.498Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/61/f8ece64acb3dc2d1014a0005a2d9a56ea11b195833fb424593d67df6fd74/givenergy_modbus-2.12.0.tar.gz", hash = "sha256:921f991f95db3ab55589611b965dbbae18d2e6ce8d30cf3c431b39507de8c733", size = 589443, upload-time = "2026-07-10T20:53:01.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/78/b9a7b2bfc537890f1c0144d723eba7fb786c8be0a9f263e92bd714b595e5/givenergy_modbus-2.11.2-py3-none-any.whl", hash = "sha256:ee86c7a70c421c5471c30ca8a4734e7b4d6267f1c8123b6d76b6d3621e8aba2b", size = 214493, upload-time = "2026-07-10T11:30:18.872Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/48fdadceae81b4632e084a3f7263e848eb668afe659c4ca04c84fece20cb/givenergy_modbus-2.12.0-py3-none-any.whl", hash = "sha256:17e62387fd84ad0f28d5e72685e974b295fb942ac7cbaa796333a748eb89371e", size = 216851, upload-time = "2026-07-10T20:52:59.389Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts givenergy-modbus 2.12.0 and uses its new `probe_alive()` to make reconnection cheap and low-impact on a hung dongle. Closes the build half of #280 (Lever 1).

## The problem

On a marginal dongle (diagnosed from AberDino's Gen-1 Gateway capture in #95), the TCP connection drops (`connection lost (reader at EOF)`) and the dongle then refuses even its identity read for a minute or two — a Modbus-level hang. Previously each reconnect tick ran a **full detect** against the dead socket, spending ~8s (4×2s) hammering it before giving up, then retrying ~40s later.

## The fix

On a *reconnect* (`self.data is not None`), gate the heavy detect sweep behind modbus 2.12.0's `probe_alive(retries=1)` — a single cheap HR0 identity read:

- **Not alive** → `probe_alive` closes the socket and returns `False`; we raise a transient timeout, so the existing teardown + serve-last-known path runs and the next tick reprobes. No detect sweep against a dead connection.
- **Alive** → the socket is left open and the existing (robust, default-retries) `detect` runs on it to re-establish topology.

The first-ever setup (`self.data is None`) skips the probe and runs the full detect to establish topology from scratch. `retries=1` tolerates a single dropped identity frame on an otherwise-healthy reconnect (fails in ~4s on a genuine hang vs ~2s at 0) — apt for exactly the lossy dongles this targets.

This is the split modbus recommended (PR #398): a fused `detect(retries=0)` would have made the *recovery* detect fragile too, since the sweep would inherit the fail-fast retries. `probe_alive` keeps the liveness check cheap and the recovery robust.

## Scope

Pin `2.11.2 → 2.12.0`. This is Lever 1 only; deliberately **not** bundled: the exponential-backoff experiment (Lever 2, still unproven — #280), the #106 `Plant.devices` walk migration (at-my-pace), and the #399 connection-lifecycle review that also ship in 2.12.0.

## Tests

Three coordinator tests: reconnect + probe `False` serves last-known and skips detect (client torn down, one failure counted); reconnect + probe `True` runs the robust detect and polls; first-connect skips the probe entirely. The conftest mock Client gains `probe_alive` (default alive).

## Verification

`ruff` clean, `mypy` clean, **598** Python tests. Clean additive 2.12.0 adoption (no breakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnect handling by checking connection health before performing a full system scan.
  * Failed connections are now discarded promptly, allowing the next update to establish a clean connection.
  * Preserved the most recent data when a reconnect attempt temporarily fails.
  * Initial setup continues to perform the full system discovery process as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->