### PR TITLE
feat: back off reconnects on a hung dongle + reconnect diagnostics (#280)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,9 @@ Some energy sensors are model-dependent: on AC-coupled and All-in-One systems th
 | Last Successful Refresh | timestamp | |
 | Consecutive Refresh Failures | — | Resets to 0 on the next good poll |
 | Total Refresh Failures | — | Ever-increasing (resets only on HA restart — long-term stats handle that) |
+| Reconnects | — | Times the connection was re-established after a drop |
+| Dongle Hangs | — | Reconnects where the dongle answered TCP but not its identity read (a Modbus-level hang) |
+| Reconnect Backoffs | — | Sustained hangs where reconnecting was paused to let the dongle recover |
 
 </details>
 
@@ -494,7 +497,7 @@ The daily counters reset at midnight; Home Assistant's recorder detects the rese
 
 ## Troubleshooting
 
-- **Comms health at a glance.** Each device exposes diagnostic counters that surface connection problems without trawling logs: `Consecutive Refresh Failures` (resets to 0 on the next good poll), `Total Refresh Failures`, `Last Successful Refresh`, plus per-cause counters for CRC failures, frame-splice rejections and holds, read retries and cold-start holds. A steady trickle is normal; a sustained climb is worth a look.
+- **Comms health at a glance.** Each device exposes diagnostic counters that surface connection problems without trawling logs: `Consecutive Refresh Failures` (resets to 0 on the next good poll), `Total Refresh Failures`, `Last Successful Refresh`, per-cause counters for CRC failures, frame-splice rejections and holds, read retries and cold-start holds, plus connection-layer counters — `Reconnects`, `Dongle Hangs` (the dongle up on TCP but not answering), and `Reconnect Backoffs`. A steady trickle is normal; a sustained climb is worth a look.
 - **CRC errors are normal — and are how the library knows the bus data is trustworthy.** They're almost always electrical (cable routing near current-carrying conductors, termination, shielding), *not* a symptom of too many clients: the data adapter mediates the downstream Modbus bus no matter how many clients connect. A frame that fails its CRC is simply discarded and re-read on the next tick. The odd one logged at WARNING is the guard doing its job.
 - **Transient connection drops are normal.** TCP-level timeouts and the occasional reset are logged at WARNING and the next scan tick reconnects — the counters above will tell you if something more persistent is going on.
 - **Control values drift back on EMS plants.** With EMS plant mode active, the controller periodically reasserts certain inverter settings (notably *Inverter Max Output Active Power*, HR50) over its own controller-to-inverter link, which this integration cannot observe. Writes succeed and hold briefly, then revert within minutes. That's the EMS doing its job, not a failed write; taking the plant out of EMS plant mode makes manually set values stick ([#52](https://github.com/dewet22/givenergy-hass/issues/52)).

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -93,6 +93,18 @@ PROBE_RETRIES = 3
 # reconnect can still drop a stray frame, so we don't want to bail on the first.
 RECONNECT_PROBE_RETRIES = 1
 
+# After this many CONSECUTIVE failed liveness probes we treat the dongle as hung
+# and step back from reconnecting for a quiet window (#280, Lever 2). Two (not
+# one) so a single missed probe — after retries — doesn't trip it; mirrors the
+# GivTCP "2 missed polls" field result. The window is max(floor, poll interval):
+# the floor guarantees a breather materially longer than the normal cadence even
+# for a 60s-polled Gateway (the case this targets), where the poll interval alone
+# would give no extra quiet. Flat, not exponential — deliberately conservative
+# given the evidence for a specific duration is thin; the Dongle Hangs / Reconnect
+# Backoffs diagnostics let us tune it on real data.
+BACKOFF_AFTER_PROBE_FAILURES = 2
+RECONNECT_BACKOFF_FLOOR = 120.0  # seconds
+
 # When detect() reports a DEVICE LOSS (a previously-known battery/meter/stack
 # stopped answering), re-probe a few times before believing it — a slow BMS
 # often answers on the next sweep. Kept small: this blocks _connect(), which
@@ -196,6 +208,16 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         self.last_successful_refresh: datetime | None = None
         self.consecutive_failures: int = 0
         self.total_failures: int = 0
+        # Reconnect-health counters (#280): reconnects = successful re-establishments
+        # after a drop; dongle_hangs = liveness-probe failures (dongle up on TCP but
+        # refusing its identity read); reconnect_backoffs = distinct hang episodes
+        # that tripped the quiet-window backoff. consecutive_probe_failures and
+        # _reconnect_backoff_until drive that backoff (BACKOFF_AFTER_PROBE_FAILURES).
+        self.reconnect_count: int = 0
+        self.dongle_hangs: int = 0
+        self.reconnect_backoffs: int = 0
+        self.consecutive_probe_failures: int = 0
+        self._reconnect_backoff_until: float = 0.0
         # Cumulative count of polls that returned *some* data but had one or
         # more register reads fail (RefreshPartiallySucceeded). Distinct from
         # total_failures (which counts polls that yielded no usable data) so a
@@ -248,6 +270,16 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                 self._loss_redetect_after = loop.time() + LOSS_REDETECT_INTERVAL
             reconnecting = self._client is None or not self._client.connected
             if reconnecting:
+                if (
+                    self.consecutive_probe_failures >= BACKOFF_AFTER_PROBE_FAILURES
+                    and loop.time() < self._reconnect_backoff_until
+                ):
+                    # Dongle hung (#280): hold off reconnecting for a quiet window
+                    # rather than reprobing every tick. Sensors stay unavailable
+                    # (we're past the tolerance already), but the socket stays
+                    # released so the dongle gets an uninterrupted breather — which
+                    # is what a marginal unit needs to recover.
+                    raise UpdateFailed("holding off reconnect for the dongle to recover")
                 await self._connect()
             if self._client is None:
                 # The entry was unloaded while _connect() was resolving topology
@@ -523,18 +555,37 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         self._comms_last_seen.clear()
         try:
             await self._client.connect()
-            # On a reconnect (we've polled before), gate the heavy detect sweep
-            # behind a cheap HR0 liveness probe (#280). A hung dongle accepts the
-            # TCP connect but refuses its identity read; probe_alive fails fast and
-            # closes the socket, so we serve last-known and reprobe next tick rather
-            # than spending the full detect timeout hammering a dead connection.
-            # On success the socket stays open and detect runs robustly on it. The
-            # first-ever setup (no data yet) skips the probe and runs the full
-            # detect to establish topology from scratch.
-            if self.data is not None and not await self._client.probe_alive(
-                retries=RECONNECT_PROBE_RETRIES
-            ):
-                raise TimeoutError("inverter did not answer the reconnect liveness probe")
+            is_reconnect = self.data is not None
+            # On a reconnect, gate the heavy detect sweep behind a cheap HR0
+            # liveness probe (#280). A hung dongle accepts the TCP connect but
+            # refuses its identity read; probe_alive fails fast and closes the
+            # socket, so we serve last-known and reprobe rather than spending the
+            # full detect timeout on a dead connection. On success the socket stays
+            # open and detect runs robustly on it. First-ever setup (no data yet)
+            # skips the probe and runs the full detect to establish topology.
+            if is_reconnect:
+                if not await self._client.probe_alive(retries=RECONNECT_PROBE_RETRIES):
+                    # Dongle hung. Count it, and after two consecutive hangs arm the
+                    # quiet-window backoff (Lever 2): a breather longer than the poll
+                    # cadence is what lets a marginal dongle recover (GivTCP field
+                    # result). probe_alive has already closed the socket.
+                    self.dongle_hangs += 1
+                    self.consecutive_probe_failures += 1
+                    if self.consecutive_probe_failures == BACKOFF_AFTER_PROBE_FAILURES:
+                        self.reconnect_backoffs += 1
+                    if self.consecutive_probe_failures >= BACKOFF_AFTER_PROBE_FAILURES:
+                        interval = (
+                            self.update_interval.total_seconds() if self.update_interval else 0.0
+                        )
+                        self._reconnect_backoff_until = asyncio.get_running_loop().time() + max(
+                            RECONNECT_BACKOFF_FLOOR, interval
+                        )
+                    raise TimeoutError("inverter did not answer the reconnect liveness probe")
+                # Probe answered: the dongle is alive. Clear the hang state now —
+                # even if the detect below transiently fails — so a later hang
+                # episode counts fresh.
+                self.consecutive_probe_failures = 0
+                self._reconnect_backoff_until = 0.0
             topology_confirmed = True
             try:
                 # The library's battery sweep probes each pack slot (0x33-0x37)
@@ -579,6 +630,8 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                         exc_info=True,
                     )
             self._active_tick = 0
+            if is_reconnect:
+                self.reconnect_count += 1
             _LOGGER.info("Connected to inverter at %s:%s", self.host, self.port)
         except BaseException:
             # connect()/detect() failed before capabilities were established (a

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -2409,6 +2409,36 @@ COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
         attributes_fn=_comms_counter_attributes("cold_start_held_by_device"),
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # Reconnect health (#280). Distinct from the refresh-failure counters above:
+    # these track the connection layer — how often it re-establishes, how often the
+    # dongle hangs (up on TCP but not answering its identity read), and how often a
+    # sustained hang trips the quiet-window backoff.
+    GivEnergyCoordinatorSensorDescription(
+        key="reconnects",
+        name="Reconnects",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda coord: coord.reconnect_count,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyCoordinatorSensorDescription(
+        key="dongle_hangs",
+        name="Dongle Hangs",
+        # A reconnect where the dongle accepted the TCP connection but failed the
+        # liveness probe — the Modbus-level hang some marginal dongles fall into.
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda coord: coord.dongle_hangs,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    GivEnergyCoordinatorSensorDescription(
+        key="reconnect_backoffs",
+        name="Reconnect Backoffs",
+        # Distinct hang episodes bad enough (2+ consecutive) to trip the quiet-
+        # window backoff, where we stop reconnecting for a while to let the dongle
+        # recover. A climbing rate flags a dongle in real trouble.
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda coord: coord.reconnect_backoffs,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 )
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -385,6 +385,73 @@ async def test_first_connect_skips_liveness_probe(hass, mock_plant):
         client.detect.assert_awaited_once()  # full detect ran
 
 
+async def test_two_probe_failures_arm_backoff_and_skip_reconnect(hass, mock_plant):
+    """Two consecutive hung reconnects arm the quiet-window backoff (#280): the
+    next tick must NOT attempt a reconnect at all — the socket stays released so
+    the dongle gets an uninterrupted breather — and the counters reflect it."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+    coordinator.data = mock_plant  # reconnect path
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.probe_alive = AsyncMock(return_value=False)  # hung dongle
+        mock_cls.return_value = client
+
+        # First hung reconnect: counted, no backoff yet.
+        await coordinator._async_update_data()
+        assert coordinator.consecutive_probe_failures == 1
+        assert coordinator.dongle_hangs == 1
+        assert coordinator.reconnect_backoffs == 0
+
+        # Second hung reconnect: arms the backoff.
+        await coordinator._async_update_data()
+        assert coordinator.consecutive_probe_failures == 2
+        assert coordinator.dongle_hangs == 2
+        assert coordinator.reconnect_backoffs == 1
+
+        # Third tick falls inside the backoff window: no reconnect attempted at all.
+        mock_cls.reset_mock()
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+        mock_cls.assert_not_called()  # never touched the dongle
+        assert coordinator.dongle_hangs == 2  # unchanged: we didn't probe
+
+
+async def test_backoff_clears_and_counts_reconnect_on_recovery(hass, mock_plant):
+    """Once the backoff window passes and the dongle answers again, the full detect
+    runs, the probe-failure state clears, and the successful reconnect is counted;
+    the historical hang/backoff totals are left intact."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30)
+    coordinator.data = mock_plant
+    # Simulate mid-outage state with the backoff window already expired.
+    coordinator.consecutive_probe_failures = 2
+    coordinator.dongle_hangs = 2
+    coordinator.reconnect_backoffs = 1
+    coordinator._reconnect_backoff_until = 0.0
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.probe_alive = AsyncMock(return_value=True)  # dongle answers now
+        client.load_config = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        mock_cls.return_value = client
+
+        result = await coordinator._async_update_data()
+
+        assert result is mock_plant
+        client.probe_alive.assert_awaited_once()
+        client.detect.assert_awaited_once()  # robust detect on recovery
+        assert coordinator.consecutive_probe_failures == 0  # cleared
+        assert coordinator._reconnect_backoff_until == 0.0
+        assert coordinator.reconnect_count == 1  # counted the successful reconnect
+        assert coordinator.dongle_hangs == 2  # historical total preserved
+        assert coordinator.reconnect_backoffs == 1  # historical total preserved
+
+
 async def test_cancelled_connect_discards_client(hass, mock_plant):
     """A cancellation during _connect() (HA cancelling the attempt) must still
     discard the half-initialised client. CancelledError is a BaseException, not


### PR DESCRIPTION
Lever 2 of the marginal-dongle work (#280), building on the v1.4.2 liveness probe.

## What

When the reconnect liveness probe fails on **two consecutive** reconnects, treat the dongle as hung and **stop reconnecting for a quiet window** — `max(120s, poll interval)` — instead of reprobing every tick. The socket stays fully released during the window (client is `None`), giving a marginal dongle an uninterrupted breather to recover.

- **Trigger:** 2 consecutive failed probes (not 1 — the probe already tolerates one dropped frame; two mirrors GivTCP's "2 missed polls").
- **Window:** flat `max(120, POLLING_INTERVAL)`. The 120s floor guarantees a breather *longer* than the normal cadence even for a 60s-polled Gateway — the exact case this targets, where the poll interval alone (`max(60, 60)`) would give no extra quiet. Flat, not exponential, and deliberately conservative on duration: the evidence for a specific figure is thin (see below), so the counters let us tune it on real data rather than guessing.
- Resets to normal cadence the moment the probe answers again.

## Why 120s / why a backoff at all

From AberDino (#95): the GivTCP 'lite' mode author found light polling *alone* didn't prevent the lock-ups — what solved it was an automation to **stop the client for a few minutes after 2 missed polls**. That's real-world evidence that a quiet window materially longer than the poll cadence is the piece that actually helps a hung dongle recover (the v1.4.2 probe is the "light polling" half). We're starting conservative at 120s rather than adopting their 300s from a sample of one.

## Diagnostics

Three new coordinator diagnostic sensors for the **connection layer**, distinct from the existing refresh-failure counters:

- **Reconnects** — successful re-establishments after a drop
- **Dongle Hangs** — reconnects where the dongle answered TCP but failed its identity read (the Modbus-level hang)
- **Reconnect Backoffs** — distinct hang episodes that tripped the quiet window

These give AberDino (and anyone) direct visibility into how often the dongle hangs and whether the backoff is engaging — and are the data that'll tell us whether 120s is enough or we climb toward GivTCP's 300.

## Tests & docs

Two coordinator tests: two probe failures arm the backoff and the next tick attempts no reconnect at all (socket stays released); recovery clears the hang state, runs the robust detect, and counts the reconnect while preserving the historical totals. README diagnostics section updated with the three counters.

## Verification

`ruff` clean, `mypy` clean, **600** Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic counters for reconnects, dongle hangs and reconnect backoffs.
  * Improved connection recovery by pausing repeated reconnect attempts when the dongle appears unresponsive.
  * Reconnect health counters are now visible through diagnostic sensors.

* **Documentation**
  * Updated diagnostic sensor and troubleshooting guidance to explain the new communication metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->