### PR TITLE
feat: restore passive (listen-only) mode under Advanced features (#280)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To change any of these later, open the integration's **⋮** menu in **Settings 
 
 Both this integration and other local polling solutions (GivTCP, the GivEnergy app, custom scripts) can run in active mode at the same time without issue. The inverter handles concurrent Modbus clients reliably — earlier reports of polling conflicts were largely a consequence of retry and error-recovery behaviour in the older shared library, not an inverter limitation. Running multiple clients in parallel has been solid in practice, even at faster-than-default poll intervals.
 
-> **Note:** earlier versions offered a "passive mode" (listen only, relying on another client's polling to keep values fresh). It was removed in v1.3.37: concurrent active polling is well within what the hardware handles, while passive mode's freshness expectations could never be met by the cloud's ~5-minute polling cadence, producing continuous spurious refresh failures (#253). An entry that still has the old setting stored simply polls actively.
+> **Note:** an optional **passive (listen-only) mode** is available under *Advanced features*. Rather than polling, it reads the register cache that another active client (for example GivTCP) keeps fresh on the same dongle — halving the polling load, which is worth having on a marginal dongle that struggles under two active clients. It was briefly removed in v1.3.37 because, with only the GivEnergy cloud's ~5-minute polling to listen to, its freshness expectations couldn't be met; it's back because that reasoning doesn't apply when a local client is actively polling. It needs another client actively polling the same inverter — on its own, values will go stale.
 
 #### GivTCP long-term stats migration
 

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -34,6 +34,8 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_BATTERY_DATA_ONLY,
+    CONF_EXPERIMENTAL,
+    CONF_PASSIVE,
     CONF_RETRIES,
     CONF_SCAN_INTERVAL,
     CONF_TIMEOUT_TOLERANCE,
@@ -549,14 +551,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Resolve opt-in experimental client flags from options into Client(...) kwargs.
     # Empty for the default-off case, so the construction is unchanged.
     experimental_client_kwargs = resolve_experimental_client_kwargs(entry.options)
+    # Passive (listen-only) mode is an Advanced-features opt-in in the same section,
+    # but a coordinator flag rather than a client kwarg, so read it directly (#280).
+    passive = bool(entry.options.get(CONF_EXPERIMENTAL, {}).get(CONF_PASSIVE, False))
 
     coordinator = GivEnergyUpdateCoordinator(
         hass=hass,
         host=entry.data[CONF_HOST],
         port=entry.data[CONF_PORT],
         scan_interval=entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
-        # NB: a legacy `passive` key may remain in entry.data — deliberately
-        # ignored since passive mode's removal (#253); all entries poll actively.
+        passive=passive,
         experimental_client_kwargs=experimental_client_kwargs,
         prior_capabilities=prior_capabilities,
         on_topology_changed=_on_topology_changed,

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -553,7 +553,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     experimental_client_kwargs = resolve_experimental_client_kwargs(entry.options)
     # Passive (listen-only) mode is an Advanced-features opt-in in the same section,
     # but a coordinator flag rather than a client kwarg, so read it directly (#280).
-    passive = bool(entry.options.get(CONF_EXPERIMENTAL, {}).get(CONF_PASSIVE, False))
+    passive = bool((entry.options.get(CONF_EXPERIMENTAL) or {}).get(CONF_PASSIVE, False))
 
     coordinator = GivEnergyUpdateCoordinator(
         hass=hass,

--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_BATTERY_DATA_ONLY,
     CONF_EXPERIMENTAL,
     CONF_EXPOSE_PER_CELL,
+    CONF_PASSIVE,
     CONF_SCAN_INTERVAL,
     CONF_WARN_CLOCK_DRIFT,
     DEFAULT_BATTERY_DATA_ONLY,
@@ -194,35 +195,34 @@ class GivEnergyLocalOptionsFlow(OptionsFlowWithReload):
             # False from config-flow creation, surfaced via add_suggested_values.
             vol.Required(CONF_EXPOSE_PER_CELL, default=True): bool,
         }
-        # Surface the collapsed "Experimental features" group only once at least one
-        # flag exists, so the header never appears empty (the registry ships empty).
-        if EXPERIMENTAL_FEATURES:
-            # Seed the section default from the currently-saved values so an
-            # omitted (untouched, collapsed) section round-trips its existing
-            # values: when the frontend omits the section key, the vol.Optional
-            # section default plus the inner defaults restore what was saved.
-            existing_exp: dict[str, Any] = self.config_entry.options.get(CONF_EXPERIMENTAL, {})
-            schema_dict[vol.Optional(CONF_EXPERIMENTAL, default=existing_exp)] = section(
-                vol.Schema(
-                    {
-                        # vol.Optional, NOT vol.Required: a required field inside a
-                        # collapsed section is never initialised in the frontend's
-                        # data model (the inner form isn't rendered until the user
-                        # expands it), so HA's submit-time required-fields check
-                        # fails with "Not all required fields are filled in" and
-                        # blocks saving for any entry that has never opened the
-                        # section (#251). The default still applies server-side, and
-                        # resolve_experimental_client_kwargs reads via
-                        # .get(..., feature.default), so an omitted key is unchanged.
-                        vol.Optional(
-                            feature.conf_key,
-                            default=existing_exp.get(feature.conf_key, feature.default),
-                        ): bool
-                        for feature in EXPERIMENTAL_FEATURES
-                    }
-                ),
-                SectionConfig(collapsed=True),
-            )
+        # The collapsed "Experimental features" group always carries the passive
+        # (listen-only) toggle, plus any registered client-kwarg feature flags.
+        # Seed defaults from the currently-saved values so an omitted (untouched,
+        # collapsed) section round-trips its existing values.
+        #
+        # vol.Optional, NOT vol.Required, throughout: a required field inside a
+        # collapsed section is never initialised in the frontend's data model (the
+        # inner form isn't rendered until the user expands it), so HA's submit-time
+        # required-fields check fails with "Not all required fields are filled in"
+        # and blocks saving for any entry that has never opened the section (#251).
+        # The default applies server-side, so an omitted key is unchanged.
+        existing_exp: dict[str, Any] = self.config_entry.options.get(CONF_EXPERIMENTAL, {})
+        section_schema: dict[Any, Any] = {
+            vol.Optional(CONF_PASSIVE, default=existing_exp.get(CONF_PASSIVE, False)): bool,
+        }
+        section_schema.update(
+            {
+                vol.Optional(
+                    feature.conf_key,
+                    default=existing_exp.get(feature.conf_key, feature.default),
+                ): bool
+                for feature in EXPERIMENTAL_FEATURES
+            }
+        )
+        schema_dict[vol.Optional(CONF_EXPERIMENTAL, default=existing_exp)] = section(
+            vol.Schema(section_schema),
+            SectionConfig(collapsed=True),
+        )
         schema = vol.Schema(schema_dict)
         return self.async_show_form(
             step_id="init",

--- a/custom_components/givenergy_local/config_flow.py
+++ b/custom_components/givenergy_local/config_flow.py
@@ -206,7 +206,7 @@ class GivEnergyLocalOptionsFlow(OptionsFlowWithReload):
         # required-fields check fails with "Not all required fields are filled in"
         # and blocks saving for any entry that has never opened the section (#251).
         # The default applies server-side, so an omitted key is unchanged.
-        existing_exp: dict[str, Any] = self.config_entry.options.get(CONF_EXPERIMENTAL, {})
+        existing_exp: dict[str, Any] = self.config_entry.options.get(CONF_EXPERIMENTAL) or {}
         section_schema: dict[Any, Any] = {
             vol.Optional(CONF_PASSIVE, default=existing_exp.get(CONF_PASSIVE, False)): bool,
         }

--- a/custom_components/givenergy_local/const.py
+++ b/custom_components/givenergy_local/const.py
@@ -103,6 +103,10 @@ EXPOSE_RECOMMENDED_ENTITY_KEYS = (
 #       ),
 #   )
 CONF_EXPERIMENTAL = "experimental"
+# Passive (listen-only) mode lives inside the experimental section but is a
+# coordinator flag, not a Client(...) kwarg — so it's read directly, not via
+# resolve_experimental_client_kwargs. Off by default (#280/#256 revival).
+CONF_PASSIVE = "passive"
 
 
 @dataclass(frozen=True)

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -173,6 +173,7 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         host: str,
         port: int,
         scan_interval: int,
+        passive: bool = False,
         experimental_client_kwargs: dict[str, Any] | None = None,
         timeout_tolerance: int = 3,
         retries: int = 1,
@@ -189,6 +190,12 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         )
         self.host = host
         self.port = port
+        # Passive (listen-only) mode: seed the plant on (re)connect, then read the
+        # register cache the library keeps fresh from a PEER client's polling on
+        # the shared dongle, instead of polling ourselves (#280/#256). Off by
+        # default; an Advanced-features opt-in for a side-by-side rig (e.g. GivTCP
+        # actively polling a marginal Gateway dongle while we only listen).
+        self.passive = passive
         # Resolved opt-in givenergy-modbus client kwargs (empty by default, so
         # Client(host, port) is unchanged). Splatted at every (re)connect.
         self._experimental_client_kwargs = experimental_client_kwargs or {}
@@ -289,7 +296,11 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
                 # down, and a routine unload should not log an ERROR.
                 return self.data
 
-            plant = await self._active_update()
+            plant = (
+                await self._passive_update(reconnecting)
+                if self.passive
+                else await self._active_update()
+            )
 
             # A fully clean poll ends the partial run so the next one warns afresh.
             # The last_partial_failures detail and last_partial_at are deliberately
@@ -526,6 +537,24 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         if full_refresh:
             await self._client.load_config(retries=self.retries)
         return await self._client.refresh(retries=self.retries)
+
+    async def _passive_update(self, reconnecting: bool) -> Plant:
+        """Seed the cache on (re)connect; on subsequent ticks read the cached plant.
+
+        The library's register cache is kept fresh by a peer client's polling on
+        the shared dongle — every observed response is folded in, not just our own
+        (network consumer). So we seed once on connect (load_config + refresh),
+        then read the plant without issuing our own requests. Per-sensor staleness
+        (a frozen cache = no peer polling) is caught by the stale-IR gate
+        (register_age), which is topology-agnostic; a coordinator-level freshness
+        check awaits a first-class library freshness indicator — inverter
+        system_time proved too brittle (spurious on a Gateway).
+        """
+        assert self._client is not None  # _async_update_data ensures this
+        if reconnecting:
+            await self._client.load_config(retries=self.retries)
+            return await self._client.refresh(retries=self.retries)
+        return self._client.plant
 
     # ------------------------------------------------------------------
     # Connection helpers

--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -114,6 +114,16 @@ DETECT_LOSS_RETRIES = 2
 DETECT_LOSS_RETRY_DELAY = 5.0  # seconds
 LOSS_REDETECT_INTERVAL = 300.0  # seconds between loss-driven reconnect-and-detect attempts
 
+# Passive mode leans on a peer client keeping the register cache fresh. If the peer
+# goes quiet, the cache freezes: register-backed sensors age out via the stale-IR
+# gate, but the derived EMS energy integrals sample on last_successful_refresh, so a
+# tick that marks success on a frozen cache keeps accumulating from a stale power
+# value (#284). Fail the tick once the newest committed block is older than this —
+# max(floor, multiple x scan interval) — so success (and the integrals) only advance
+# while a peer is actually refreshing.
+PASSIVE_STALE_FLOOR = 180.0  # seconds
+PASSIVE_STALE_INTERVAL_MULTIPLE = 3
+
 
 def missing_devices(prior: PlantCapabilities | None, actual: PlantCapabilities) -> list[str]:
     """Describe devices present in ``prior`` but absent from ``actual``.
@@ -544,17 +554,36 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         The library's register cache is kept fresh by a peer client's polling on
         the shared dongle — every observed response is folded in, not just our own
         (network consumer). So we seed once on connect (load_config + refresh),
-        then read the plant without issuing our own requests. Per-sensor staleness
-        (a frozen cache = no peer polling) is caught by the stale-IR gate
-        (register_age), which is topology-agnostic; a coordinator-level freshness
-        check awaits a first-class library freshness indicator — inverter
-        system_time proved too brittle (spurious on a Gateway).
+        then read the plant without issuing our own requests.
+
+        A frozen cache (the peer stopped polling) must not mark the tick
+        successful: register-backed sensors age out via the topology-agnostic
+        stale-IR gate (register_age), but the derived EMS energy integrals sample
+        on last_successful_refresh, so advancing it over a stale cache inflates
+        Energy Dashboard totals rather than merely showing stale values (#284). So
+        gate on the newest committed register block: if nothing has been ingested
+        recently, fail the tick (UpdateFailed) rather than serve a frozen cache as
+        fresh. This reads register_block_updated_at directly for now; it moves to
+        the first-class Plant.last_updated_at accessor once givenergy-modbus ships
+        it (same newest-commit semantics). The old inverter-system_time inference
+        is gone — brittle, and spurious on a Gateway's synthetic inverter.
         """
         assert self._client is not None  # _async_update_data ensures this
         if reconnecting:
             await self._client.load_config(retries=self.retries)
             return await self._client.refresh(retries=self.retries)
-        return self._client.plant
+        plant = self._client.plant
+        stamps = plant.register_block_updated_at
+        if stamps:  # empty only before the first commit (cold); never fail on that
+            interval = self.update_interval.total_seconds() if self.update_interval else 0.0
+            max_age = max(PASSIVE_STALE_FLOOR, PASSIVE_STALE_INTERVAL_MULTIPLE * interval)
+            newest_age = (dt_util.utcnow() - max(stamps.values())).total_seconds()
+            if newest_age > max_age:
+                raise UpdateFailed(
+                    f"passive cache stale: no peer refresh in {newest_age:.0f}s "
+                    f"(> {max_age:.0f}s) — is another local client still polling?"
+                )
+        return plant
 
     # ------------------------------------------------------------------
     # Connection helpers

--- a/custom_components/givenergy_local/strings.json
+++ b/custom_components/givenergy_local/strings.json
@@ -51,9 +51,11 @@
             "name": "Advanced features",
             "description": "Optional low-risk tuning flags. Safe to leave off; turn one on if it matches a symptom you're seeing.",
             "data": {
+              "passive": "Passive (listen-only) mode",
               "splice_reject_heal": "Enable splice-guard heal window"
             },
             "data_description": {
+              "passive": "Stop polling the inverter and instead read the shared register cache that another client keeps fresh on the same dongle. Useful in a side-by-side setup — for example GivTCP polling actively while Home Assistant only listens — to halve the load on a marginal dongle. Requires another client actively polling the same inverter; on its own the data will go stale.",
               "splice_reject_heal": "Allows the battery splice-guard to recover from legitimate LiFePO4 charge-knee surges (voltage/capacity class, multi-poll streak gate) rather than keeping the battery permanently offline. Worth enabling if you see repeated battery disconnects near full charge."
             }
           }

--- a/custom_components/givenergy_local/translations/en.json
+++ b/custom_components/givenergy_local/translations/en.json
@@ -49,9 +49,11 @@
             "name": "Advanced features",
             "description": "Optional low-risk tuning flags. Safe to leave off; turn one on if it matches a symptom you're seeing.",
             "data": {
+              "passive": "Passive (listen-only) mode",
               "splice_reject_heal": "Enable splice-guard heal window"
             },
             "data_description": {
+              "passive": "Stop polling the inverter and instead read the shared register cache that another client keeps fresh on the same dongle. Useful in a side-by-side setup — for example GivTCP polling actively while Home Assistant only listens — to halve the load on a marginal dongle. Requires another client actively polling the same inverter; on its own the data will go stale.",
               "splice_reject_heal": "Allows the battery splice-guard to recover from legitimate LiFePO4 charge-knee surges (voltage/capacity class, multi-poll streak gate) rather than keeping the battery permanently offline. Worth enabling if you see repeated battery disconnects near full charge."
             }
           }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Shared fixtures for GivEnergy Local tests."""
 
-from datetime import datetime, time
+from datetime import UTC, datetime, time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -220,6 +220,10 @@ def mock_plant(mock_inverter, mock_battery) -> MagicMock:
         lv_battery_addresses=[0x32],
         bcu_stacks=[],
     )
+    # Freshness signal read by passive mode's stale-cache gate (#284): a real dict
+    # (not a MagicMock child) with a just-committed block so passive reads serve by
+    # default; the stale-cache test rewinds this timestamp.
+    plant.register_block_updated_at = {(0x32, "IR", 0, 60): datetime.now(UTC)}
     return plant
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -360,7 +360,7 @@ async def test_options_flow_persists_experimental_toggle(hass, mock_client, setu
         await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
-    assert setup_integration.options[CONF_EXPERIMENTAL] == {"demo": True}
+    assert setup_integration.options[CONF_EXPERIMENTAL] == {"demo": True, "passive": False}
 
 
 async def test_options_flow_preserves_experimental_when_section_omitted(
@@ -391,7 +391,7 @@ async def test_options_flow_preserves_experimental_when_section_omitted(
     assert result["type"] == "create_entry"
     assert setup_integration.options[CONF_BATTERY_DATA_ONLY] is True
     # The experimental flag must survive the second save unmodified.
-    assert setup_integration.options[CONF_EXPERIMENTAL] == {"demo": True}
+    assert setup_integration.options[CONF_EXPERIMENTAL] == {"demo": True, "passive": False}
 
 
 async def test_options_flow_explicit_false_disables_experimental_flag(
@@ -421,18 +421,21 @@ async def test_options_flow_explicit_false_disables_experimental_flag(
         await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
-    assert setup_integration.options[CONF_EXPERIMENTAL] == {"demo": False}
+    assert setup_integration.options[CONF_EXPERIMENTAL] == {"demo": False, "passive": False}
 
 
-async def test_options_flow_omits_section_when_no_features(hass, mock_client, setup_integration):
-    """An empty registry => no experimental section in the form."""
+async def test_options_flow_renders_section_with_only_passive_when_no_features(
+    hass, mock_client, setup_integration
+):
+    """Even with no client-kwarg features registered, the experimental section still
+    renders — it always carries the passive (listen-only) toggle (#280)."""
     with patch(
         "custom_components.givenergy_local.config_flow.EXPERIMENTAL_FEATURES",
         (),
     ):
         result = await hass.config_entries.options.async_init(setup_integration.entry_id)
     top_keys = {marker.schema for marker in result["data_schema"].schema}
-    assert CONF_EXPERIMENTAL not in top_keys
+    assert CONF_EXPERIMENTAL in top_keys
     assert CONF_BATTERY_DATA_ONLY in top_keys
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -455,8 +455,9 @@ async def test_backoff_clears_and_counts_reconnect_on_recovery(hass, mock_plant)
 async def test_passive_mode_seeds_on_reconnect_then_reads_cache(hass, mock_plant):
     """Passive mode seeds actively on (re)connect (load_config + refresh), then on
     every subsequent tick reads the cached plant WITHOUT issuing its own requests —
-    the cache is kept fresh by a peer client on the shared dongle (#280). No
-    clock-based freshness check here; per-sensor staleness is the stale-IR gate's."""
+    the cache is kept fresh by a peer client on the shared dongle (#280). A fresh
+    cache (mock_plant stamps a just-committed block) serves without polling or
+    failing; the stale-cache path is covered separately (#284)."""
     coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True)
 
     with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
@@ -479,6 +480,48 @@ async def test_passive_mode_seeds_on_reconnect_then_reads_cache(hass, mock_plant
             assert await coordinator._async_update_data() is mock_plant
         client.refresh.assert_not_called()
         client.load_config.assert_not_called()
+
+
+async def test_passive_mode_stale_cache_fails_without_marking_success(hass, mock_plant):
+    """When the peer stops polling, the register cache freezes. Passive must NOT
+    mark the tick successful on a stale cache: register-backed sensors age out via
+    the stale-IR gate, but the EMS energy integrals sample on
+    last_successful_refresh, so advancing it over a frozen cache inflates Energy
+    Dashboard totals (#284). Once the newest committed block is older than
+    max(floor, 3x interval), the tick fails and last_successful_refresh is held."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.load_config = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        mock_cls.return_value = client
+
+        # Seed on the first (reconnecting) tick, then a fresh steady-state tick.
+        assert await coordinator._async_update_data() is mock_plant
+        assert await coordinator._async_update_data() is mock_plant
+        seeded_success = coordinator.last_successful_refresh
+        assert seeded_success is not None
+
+        # Rewind the newest committed block well past the staleness ceiling
+        # (floor 180s, interval 30s -> 180s) — the peer has gone quiet.
+        mock_plant.register_block_updated_at = {
+            (0x32, "IR", 0, 60): datetime.now(UTC) - timedelta(seconds=300)
+        }
+
+        client.load_config.reset_mock()
+        client.refresh.reset_mock()
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+        # Never polled (still passive), and success was NOT advanced — so the EMS
+        # integrals don't sample the stale cache.
+        client.refresh.assert_not_called()
+        client.load_config.assert_not_called()
+        assert coordinator.last_successful_refresh == seeded_success
+        assert coordinator.consecutive_failures == 1
 
 
 async def test_cancelled_connect_discards_client(hass, mock_plant):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -452,6 +452,35 @@ async def test_backoff_clears_and_counts_reconnect_on_recovery(hass, mock_plant)
         assert coordinator.reconnect_backoffs == 1  # historical total preserved
 
 
+async def test_passive_mode_seeds_on_reconnect_then_reads_cache(hass, mock_plant):
+    """Passive mode seeds actively on (re)connect (load_config + refresh), then on
+    every subsequent tick reads the cached plant WITHOUT issuing its own requests —
+    the cache is kept fresh by a peer client on the shared dongle (#280). No
+    clock-based freshness check here; per-sensor staleness is the stale-IR gate's."""
+    coordinator = GivEnergyUpdateCoordinator(hass, "192.168.1.1", 8899, 30, passive=True)
+
+    with patch("custom_components.givenergy_local.coordinator.Client") as mock_cls:
+        client = AsyncMock()
+        client.connected = True
+        client.plant = mock_plant
+        client.load_config = AsyncMock(return_value=mock_plant)
+        client.refresh = AsyncMock(return_value=mock_plant)
+        mock_cls.return_value = client
+
+        # First tick (reconnecting): active seed.
+        assert await coordinator._async_update_data() is mock_plant
+        client.load_config.assert_awaited()
+        client.refresh.assert_awaited()
+
+        # Subsequent ticks (connected): read the cache, never poll, never fail.
+        client.load_config.reset_mock()
+        client.refresh.reset_mock()
+        for _ in range(3):
+            assert await coordinator._async_update_data() is mock_plant
+        client.refresh.assert_not_called()
+        client.load_config.assert_not_called()
+
+
 async def test_cancelled_connect_discards_client(hass, mock_plant):
     """A cancellation during _connect() (HA cancelling the attempt) must still
     discard the half-initialised client. CancelledError is a BaseException, not


### PR DESCRIPTION
Backs out the v1.3.37 passive-mode removal (#256), reintroducing **passive (listen-only) mode** as an experimental / Advanced-features opt-in. From #280 / AberDino's Gateway dongle work on #95.

## Why bring it back

Passive listens to the register cache a peer client (e.g. GivTCP) keeps fresh on the shared dongle, instead of polling itself — halving the active load on a marginal dongle that struggles under two active clients. That's exactly AberDino's Gateway case: the v1.4.2/v1.4.3 reconnect work handles *recovery*; passive is the *prevention* lever (his GivTCP-lite precedent showed light polling helps).

The original removal reason — with only the GivEnergy cloud's ~5-minute polling to listen to, the freshness check couldn't be met — simply doesn't apply when a *local* client is actively polling.

## How

- **Coordinator:** on (re)connect, seed actively (`load_config` + `refresh`); on subsequent ticks read `client.plant` without issuing requests. Verified the library still folds *every* observed response into the cache (`plant.update` in the network consumer), so peer/mirrored frames keep it fresh — no deprecated API needed.
- **Config:** a `passive` toggle in the collapsed *Advanced features* section (a coordinator flag, read directly rather than via the client-kwarg feature mechanism). The section now always renders since passive is always available.

## Deliberately no `system_time` freshness check

The old passive inferred "is a peer still refreshing?" from `inverter.system_time` advancing. That's brittle — a data field pressed into a freshness role, and *spurious on a Gateway* (the synthetic all-zeros inverter), the exact target topology. So it's left out:

- Per-sensor staleness is already covered **topology-agnostically** by the stale-IR gate (`register_age`), which works on Gateway too.
- A proper *coordinator-level* freshness signal is raised with givenergy-modbus as a first-class cache-freshness indicator, to replace the brittle clock inference for good.

## Tests & docs

Coordinator test: seeds on reconnect, then reads the cache across ticks without polling or failing. Config-flow tests updated for the always-rendered section (persisted section dict now carries `passive`). README "Running alongside other local polling clients" note updated from "removed" to the revived behaviour; UI strings describe the toggle and its "needs an active peer" caveat.

## Verification

`ruff` clean, `mypy` clean, **601** Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional passive (listen-only) mode that reads cached values maintained by another active client, reducing polling activity.
  - Added a Passive mode toggle under **Advanced features**.
  - In passive mode, the system performs an initial refresh after connecting, then relies on cached data on subsequent updates.

- **Documentation**
  - Updated the README to explain passive mode behaviour, staleness warnings, and that it’s restored because freshness is satisfied when another local active client is running.  

- **Bug Fixes**
  - Prevents passive mode from treating stale cached registers as successful updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->