### PR TITLE
fix: keep DC battery-rate controls on directly-polled All-in-One (#281)

### DIFF
--- a/custom_components/givenergy_local/migrations.py
+++ b/custom_components/givenergy_local/migrations.py
@@ -421,7 +421,7 @@ def _reconcile_per_cell_entities(hass: HomeAssistant, entry: ConfigEntry) -> Non
 def _reconcile_ac_coupled_dc_limits(
     hass: HomeAssistant, coordinator: GivEnergyUpdateCoordinator
 ) -> None:
-    """Remove the DC battery-limit rows on AC-coupled / AIO plants (#52).
+    """Remove the DC battery-limit rows on genuinely AC-coupled plants (#52).
 
     Introduced: v1.3.17 (2026-06). Ongoing while the AC-pair suppression exists
     (cheap no-op once rows are gone).
@@ -431,7 +431,10 @@ def _reconcile_ac_coupled_dc_limits(
     entry HA keeps the pre-existing DC rows when the platform stops adding them, so
     the bundled dashboard would still resolve the now-orphaned DC controls from the
     registry. Mirror the other reconcilers and remove exactly those rows pre-platform.
-    DC-coupled hybrids don't enter this branch and keep their DC controls.
+    The gate must match the platform's suppression: is_ac_coupled, not the broader
+    has_ac_config_block — the AIO carries the block but is DC-battery-backed, so HR111/112
+    is its operative control and its rows must survive (hass#281). DC-coupled hybrids
+    don't enter this branch either and keep their DC controls.
     """
     # Local import: the platform imports from this package, so a module-scope import
     # risks a load-order cycle. The key set is the same one the platform suppresses on.
@@ -441,7 +444,7 @@ def _reconcile_ac_coupled_dc_limits(
     # EMS reconciliation — it needs no partial-poll guard: a None/incomplete
     # capabilities simply fails the positive check and removes nothing.
     caps = coordinator.data.capabilities
-    if caps is None or not caps.has_ac_config_block or caps.is_three_phase:
+    if caps is None or not caps.is_ac_coupled or caps.is_three_phase:
         return
     serial = coordinator.data.inverter_serial_number
     registry = er.async_get(hass)

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -114,9 +114,10 @@ NUMBER_DESCRIPTIONS: tuple[GivEnergyNumberEntityDescription, ...] = (
 
 # --- AC-config-block controls (AC-coupled inverters + single-phase All-in-One) ---
 
-# DC battery power-limit controls (HR111/112) suppressed on plants that expose the
-# AC-config block — there the AC pair (HR313/314) is the battery-power control and the
-# DC pair targets a different register (modbus #301/#302).
+# DC battery power-limit controls (HR111/112) suppressed on genuinely AC-coupled plants
+# (is_ac_coupled) — there the AC pair (HR313/314) is the battery-power control and the DC
+# pair targets a different register (modbus #301/#302). The AIO exposes the AC-config
+# block but is DC-battery-backed, so HR111/112 stays its operative control (hass#281).
 _DC_BATTERY_LIMIT_KEYS = frozenset({"battery_charge_limit", "battery_discharge_limit"})
 
 # The AC charge/discharge power limits (HR313/314) are distinct from the DC-side
@@ -269,12 +270,17 @@ async def async_setup_entry(
         )
     else:
         caps = coordinator.data.capabilities
-        ac_battery_control = (
-            caps is not None and caps.has_ac_config_block and not caps.is_three_phase
-        )
+        # Two distinct facts, deliberately not conflated (hass#281):
+        #   has_ac_config_block — register surface: which models answer HR300-359.
+        #   is_ac_coupled       — control routing: the plant has no operative DC battery.
+        # The AC pair (HR313/314) is created wherever the block is readable; the DC pair
+        # (HR111/112) is suppressed only where it isn't the real control. The AIO carries
+        # the block yet is DC-battery-backed, so it gets both.
+        create_ac_pair = caps is not None and caps.has_ac_config_block and not caps.is_three_phase
+        suppress_dc_pair = caps is not None and caps.is_ac_coupled and not caps.is_three_phase
         descriptions: tuple[GivEnergyNumberEntityDescription, ...] = NUMBER_DESCRIPTIONS
-        if ac_battery_control:
-            # On AC-coupled / AIO plants battery power is controlled via the AC pair
+        if suppress_dc_pair:
+            # On genuinely AC-coupled plants battery power is controlled via the AC pair
             # (HR313/314) created below; the DC pair (HR111/112) targets a different
             # register here and would mislead, so suppress it (modbus #301/#302).
             descriptions = tuple(
@@ -283,7 +289,7 @@ async def async_setup_entry(
         entities.extend(
             GivEnergyNumberEntity(coordinator, description) for description in descriptions
         )
-        if ac_battery_control:
+        if create_ac_pair:
             inverter = coordinator.data.inverter
             clean = not coordinator.last_partial_failures
             entities.extend(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1073,6 +1073,40 @@ async def test_dc_limit_rows_retained_on_hybrid(
     assert _present("battery_discharge_limit")
 
 
+async def test_dc_limit_rows_retained_on_all_in_one(
+    hass, mock_client, mock_plant, mock_inverter, mock_config_entry
+):
+    """hass#281: the AIO carries the AC-config block but is not AC-coupled — HR111/112
+    is its operative battery-rate control. The reconciler gates on is_ac_coupled, so it
+    must not delete the DC rows on an AIO upgrade (only the AC pair is additive)."""
+    mock_plant.capabilities = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x32,
+        meter_addresses=[],
+        lv_battery_addresses=[0x32],
+        bcu_stacks=[],
+    )
+    mock_inverter.battery_charge_limit_ac = 50
+    mock_inverter.battery_discharge_limit_ac = 60
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    for unique_id in ("SA1234G123_battery_charge_limit", "SA1234G123_battery_discharge_limit"):
+        registry.async_get_or_create("number", DOMAIN, unique_id, config_entry=mock_config_entry)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    def _present(key: str) -> bool:
+        return registry.async_get_entity_id("number", DOMAIN, f"SA1234G123_{key}") is not None
+
+    # DC pair is the operative control on an AIO — retained...
+    assert _present("battery_charge_limit")
+    assert _present("battery_discharge_limit")
+    # ...and the AC pair is created alongside it, not instead of it.
+    assert _present("battery_charge_limit_ac")
+    assert _present("battery_discharge_limit_ac")
+
+
 # --- Experimental-features registry + resolver (client feature-flagging) ------
 
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -203,10 +203,12 @@ async def test_dc_limits_suppressed_on_ac_coupled_plant(hass, ac_coupled_setup):
     assert _maybe_entity_id(hass, "SA1234G123_battery_discharge_limit") is None
 
 
-async def test_dc_limits_suppressed_on_all_in_one_plant(hass, aio_setup):
-    """AIO exposes the AC-config block, so the DC battery limits are suppressed too."""
-    assert _maybe_entity_id(hass, "SA1234G123_battery_charge_limit") is None
-    assert _maybe_entity_id(hass, "SA1234G123_battery_discharge_limit") is None
+async def test_dc_limits_present_on_all_in_one_plant(hass, aio_setup):
+    """The AIO is not AC-coupled: HR111/112 is its operative battery-rate control, so
+    the DC pair is kept. The AC-config block only adds the AC-side extras alongside it
+    (hass#281) — suppression gates on is_ac_coupled, not has_ac_config_block."""
+    _entity_id(hass, "SA1234G123_battery_charge_limit")
+    _entity_id(hass, "SA1234G123_battery_discharge_limit")
 
 
 async def test_dc_limits_present_on_hybrid_plant(hass, setup_integration):


### PR DESCRIPTION
Closes #281 (the control-surface half of it).

## Background

On a directly-polled Gen-1 All-in-One, @crg-n found that the integration was hiding the battery-rate controls Predbat actually needs. His field evidence on #281: both GivTCP and GivEnergy's own control path write **HR111** when setting the charge rate, leaving HR313 untouched. So on an AIO the DC pair (HR111/112) is the operative battery-rate control, and the AC-config pair (HR313/314) is additional surface — pause/EPS/AC-side extras — not a replacement. The diagnosis here is his; this PR is the implementation.

## The defect

`number.py` gated *both* the AC-pair creation and the DC-pair suppression on `has_ac_config_block`. That capability is a register-surface fact — which models answer HR300-359 — and it's true for `{AC, AC_3PH, ALL_IN_ONE}`. The AIO carries the block but is DC-battery-backed, so gating suppression on it stripped the AIO's real controls and left only the HR313/314 pair.

## The change

Split the one flag along the two capabilities it actually spans:

- **Create the AC pair (HR313/314)** — stays on `has_ac_config_block` (register surface). The AIO keeps its AC-side extras.
- **Suppress the DC pair (HR111/112)** — moves to `is_ac_coupled` (`{AC, AC_3PH}` — control routing, "no operative DC battery"). Only genuinely AC-coupled plants lose it; the AIO keeps both pairs.

`_reconcile_ac_coupled_dc_limits` in `migrations.py` gated on the same broad capability and would have re-deleted the DC rows after the platform fix, so it moves to `is_ac_coupled` to match. A useful side-effect: an AIO that lost its DC rows under a prior version gets them re-created at setup, no manual step.

Net behavioural change across every model is **AIO only** — HYBRID, AC single-phase, AC_3PH, EMS, gateway and battery-data-only paths are unchanged.

## One judgement call worth a look

I kept the `and not is_three_phase` guard on the suppression rather than gating on bare `is_ac_coupled`. `AC_3PH` is AC-coupled but gets no AC pair created (the three-phase read-back remaps to different registers — modbus#75), so suppressing its DC pair would leave it with no battery-rate control at all. With the guard, AC_3PH stays a strict no-op. It's the bit I'm least certain about, so worth a second opinion.

The mapping of what HR313/314 actually *does* on an AIO isn't characterised yet — present, holds a value, seemingly inert during charge-rate changes in crg-n's captures — so that's something I'll return to separately.

## Tests

- `test_number.py`: inverted the AIO suppression assertion — the AIO now keeps HR111/112 alongside the AC pair.
- `test_init.py`: added a migration guard that an AIO upgrade retains its DC rows.
- Full suite (603) green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected battery charge and discharge limit controls for All-in-One systems.
  * All-in-One systems now retain DC battery limit controls while also supporting AC-side controls.
  * Refined control visibility for AC-coupled, DC-coupled and three-phase systems.

* **Tests**
  * Added regression coverage to verify correct control retention during upgrades.
  * Updated All-in-One coverage for the expected battery limit controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->