### PR TITLE
feat: adopt givenergy-modbus 2.12.1 (Plant.last_updated_at + EOF log coalescing)

### DIFF
--- a/custom_components/givenergy_local/coordinator.py
+++ b/custom_components/givenergy_local/coordinator.py
@@ -561,23 +561,23 @@ class GivEnergyUpdateCoordinator(DataUpdateCoordinator[Plant]):
         stale-IR gate (register_age), but the derived EMS energy integrals sample
         on last_successful_refresh, so advancing it over a stale cache inflates
         Energy Dashboard totals rather than merely showing stale values (#284). So
-        gate on the newest committed register block: if nothing has been ingested
-        recently, fail the tick (UpdateFailed) rather than serve a frozen cache as
-        fresh. This reads register_block_updated_at directly for now; it moves to
-        the first-class Plant.last_updated_at accessor once givenergy-modbus ships
-        it (same newest-commit semantics). The old inverter-system_time inference
-        is gone — brittle, and spurious on a Gateway's synthetic inverter.
+        gate on Plant.last_updated_at (the newest register-block ingestion time,
+        advancing whenever any bank commits — solicited or fanned-out from a peer):
+        if nothing has been ingested recently, fail the tick (UpdateFailed) rather
+        than serve a frozen cache as fresh. It's None before the first commit
+        (cold), and topology-agnostic — meaningful even on a Gateway, where the old
+        inverter-system_time inference was spurious (synthetic all-zeros inverter).
         """
         assert self._client is not None  # _async_update_data ensures this
         if reconnecting:
             await self._client.load_config(retries=self.retries)
             return await self._client.refresh(retries=self.retries)
         plant = self._client.plant
-        stamps = plant.register_block_updated_at
-        if stamps:  # empty only before the first commit (cold); never fail on that
+        newest = plant.last_updated_at  # None before the first commit (cold); never fail on that
+        if newest is not None:
             interval = self.update_interval.total_seconds() if self.update_interval else 0.0
             max_age = max(PASSIVE_STALE_FLOOR, PASSIVE_STALE_INTERVAL_MULTIPLE * interval)
-            newest_age = (dt_util.utcnow() - max(stamps.values())).total_seconds()
+            newest_age = (dt_util.utcnow() - newest).total_seconds()
             if newest_age > max_age:
                 raise UpdateFailed(
                     f"passive cache stale: no peer refresh in {newest_age:.0f}s "

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus==2.12.0"
+    "givenergy-modbus==2.12.1"
   ],
   "version": "1.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
     # an upstream patch that wasn't validated against this integration. Bump both
     # this and manifest.json together.
-    "givenergy-modbus==2.12.0",
+    "givenergy-modbus==2.12.1",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,10 +220,11 @@ def mock_plant(mock_inverter, mock_battery) -> MagicMock:
         lv_battery_addresses=[0x32],
         bcu_stacks=[],
     )
-    # Freshness signal read by passive mode's stale-cache gate (#284): a real dict
-    # (not a MagicMock child) with a just-committed block so passive reads serve by
-    # default; the stale-cache test rewinds this timestamp.
-    plant.register_block_updated_at = {(0x32, "IR", 0, 60): datetime.now(UTC)}
+    # Freshness signal read by passive mode's stale-cache gate (#284): a real
+    # datetime (not a MagicMock child) so passive reads serve by default; the
+    # stale-cache test rewinds it. Real Plant derives this from the newest
+    # register-block commit; the mock sets it directly.
+    plant.last_updated_at = datetime.now(UTC)
     return plant
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -505,11 +505,9 @@ async def test_passive_mode_stale_cache_fails_without_marking_success(hass, mock
         seeded_success = coordinator.last_successful_refresh
         assert seeded_success is not None
 
-        # Rewind the newest committed block well past the staleness ceiling
+        # Rewind the freshness signal well past the staleness ceiling
         # (floor 180s, interval 30s -> 180s) — the peer has gone quiet.
-        mock_plant.register_block_updated_at = {
-            (0x32, "IR", 0, 60): datetime.now(UTC) - timedelta(seconds=300)
-        }
+        mock_plant.last_updated_at = datetime.now(UTC) - timedelta(seconds=300)
 
         client.load_config.reset_mock()
         client.refresh.reset_mock()

--- a/uv.lock
+++ b/uv.lock
@@ -937,7 +937,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = "==2.12.0" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.12.1" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -951,16 +951,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.12.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/61/f8ece64acb3dc2d1014a0005a2d9a56ea11b195833fb424593d67df6fd74/givenergy_modbus-2.12.0.tar.gz", hash = "sha256:921f991f95db3ab55589611b965dbbae18d2e6ce8d30cf3c431b39507de8c733", size = 589443, upload-time = "2026-07-10T20:53:01.053Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/71/af657d2b26904257a10a80f74a01907308daa18bcbe0e050b94c38b54196/givenergy_modbus-2.12.1.tar.gz", hash = "sha256:56a76ecaa2415cbd3576f49d046b6c89482a553b4559b3e8e68e02a10f70e3bb", size = 592765, upload-time = "2026-07-12T15:33:03.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/f8/48fdadceae81b4632e084a3f7263e848eb668afe659c4ca04c84fece20cb/givenergy_modbus-2.12.0-py3-none-any.whl", hash = "sha256:17e62387fd84ad0f28d5e72685e974b295fb942ac7cbaa796333a748eb89371e", size = 216851, upload-time = "2026-07-10T20:52:59.389Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cf/4aa83eb4221cbe51864a6b6954d69b5c992d863729211ad3b08ab323980d/givenergy_modbus-2.12.1-py3-none-any.whl", hash = "sha256:3e27a56cdf48b167ff2e00ad8e3de4ce5ded64cb8536dd0ef7f8e929c4eee565", size = 218590, upload-time = "2026-07-12T15:33:01.868Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts givenergy-modbus **2.12.1** and swaps the passive stale-cache gate onto the freshness primitive it ships.

## What changed
- **Pin 2.12.0 → 2.12.1** (pyproject, manifest, lock).
- **`_passive_update` freshness gate → `Plant.last_updated_at`** (#401). The v1.4.4 gate reached into `register_block_updated_at` directly as an interim; 2.12.1 exposes the same newest-commit signal (`max` of the block timestamps, `None` before first commit) behind a supported accessor. Semantically identical — the swap is mechanical.
- **Library reader-EOF log coalescing** comes along for free: a dongle that reaps its idle TCP connection on a short timer (AberDino's newer-chipset AIO, ~every 10s — confirmed a benign dongle-side idle reaper) no longer logs a WARNING per drop. First warns, repeats drop to debug with a periodic tally.

## Notes
- 2.12.1 also carries a docs-only clarification that `has_ac_config_block` is a register-surface fact, not battery-rate routing — no runtime change; our usage already gates AC-config *entities* on it, which is the intended semantic.

## Verification
`ruff` clean, `mypy` clean, **602** tests green (including under `-W error::DeprecationWarning` — no new deprecations from 2.12.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved passive-mode freshness monitoring by using the latest committed plant update time.
  - Stale cached data is now detected more reliably, while plants without a recorded update remain handled safely.
  - Prevented stale refresh attempts from being marked as successful.

- **Compatibility**
  - Updated integration support for the latest compatible GivEnergy communication version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->