### PR TITLE
fix: wait briefly for HACS cards to register before the strategy renders (#255)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -89,7 +89,7 @@ _STRATEGY_URL = f"/{DOMAIN}/{_STRATEGY_FILENAME}"
 # served from the same package dir so they resolve offline without a CDN.
 _FONTS_DIRNAME = "fonts"
 _FONTS_URL = f"/{DOMAIN}/{_FONTS_DIRNAME}"
-_STRATEGY_VERSION = "13"
+_STRATEGY_VERSION = "14"
 
 # Per-config-entry topology cache. PlantCapabilities is persisted as
 # `to_dict()` directly (no envelope) following HA Core's Store convention —

--- a/custom_components/givenergy_local/www/ge-strategy.js
+++ b/custom_components/givenergy_local/www/ge-strategy.js
@@ -207,6 +207,35 @@
     }
   }
 
+  // Custom cards the views render as first-class content (otherwise a placeholder).
+  // These are separate HACS frontend modules that load independently of this
+  // strategy, so on a cold load they can still be registering when generate()
+  // runs -- haveCard() would then wrongly report them missing and drop in the
+  // "not installed" placeholder (#255). Give each undefined one a brief, bounded
+  // chance to register before we decide; a genuinely-absent card still times out
+  // to the placeholder. Overlapped with the registry fetch (see generateDashboard)
+  // so it adds no serial latency on the common, warm path.
+  var STRATEGY_CARDS = ["apexcharts-card", "power-flow-card-plus"];
+  var CARD_WAIT_MS = 1500;
+
+  function ensureCards(names, timeoutMs) {
+    if (typeof customElements === "undefined" || !customElements.whenDefined) {
+      return Promise.resolve();
+    }
+    return Promise.all(
+      names.map(function (name) {
+        if (customElements.get(name)) return null; // already registered -- no wait
+        return new Promise(function (resolve) {
+          var timer = setTimeout(resolve, timeoutMs);
+          customElements.whenDefined(name).then(function () {
+            clearTimeout(timer);
+            resolve();
+          }, function () {});
+        });
+      })
+    );
+  }
+
   function pad2(n) {
     return n < 10 ? "0" + n : "" + n;
   }
@@ -1181,7 +1210,13 @@
       serial: config.serial || null,
       mode: config.mode || "classic",
     };
-    var plant = await buildPlant(hass, opts);
+    // Overlap the bounded card-registration wait (#255) with the registry fetch,
+    // so on a warm load (cards already defined) it costs nothing, and on a cold
+    // load the wait hides behind the registry round-trip rather than adding to it.
+    var plant = (await Promise.all([
+      buildPlant(hass, opts),
+      ensureCards(STRATEGY_CARDS, CARD_WAIT_MS),
+    ]))[0];
     if (!plant.target) {
       var notice;
       if (plant.registryError) {

--- a/custom_components/givenergy_local/www/ge-strategy.js
+++ b/custom_components/givenergy_local/www/ge-strategy.js
@@ -224,14 +224,21 @@
     }
     return Promise.all(
       names.map(function (name) {
-        if (customElements.get(name)) return null; // already registered -- no wait
-        return new Promise(function (resolve) {
-          var timer = setTimeout(resolve, timeoutMs);
-          customElements.whenDefined(name).then(function () {
-            clearTimeout(timer);
-            resolve();
-          }, function () {});
-        });
+        try {
+          if (customElements.get(name)) return null; // already registered -- no wait
+          return new Promise(function (resolve) {
+            var timer = setTimeout(resolve, timeoutMs);
+            customElements.whenDefined(name).then(function () {
+              clearTimeout(timer);
+              resolve();
+            }, function () {});
+          });
+        } catch (e) {
+          // Pathological environment (e.g. a browser that throws on the lookup) --
+          // proceed without waiting; the later haveCard() check fails closed to
+          // the placeholder, matching its own defensive try/catch.
+          return null;
+        }
       })
     );
   }

--- a/tests/js/ge-strategy.test.js
+++ b/tests/js/ge-strategy.test.js
@@ -565,3 +565,57 @@ describe("analyst mode", () => {
     expect(view(dash, "Analyst")).toBeUndefined();
   });
 });
+
+// The cold-load custom-card race (#255): the apexcharts / power-flow HACS modules
+// can still be registering when the strategy runs, so a synchronous haveCard()
+// check would wrongly emit the "not installed" placeholder. ensureCards() gives an
+// undefined-but-registering card a bounded chance to define first.
+describe("cold-load custom-card race (#255)", () => {
+  afterEach(() => {
+    delete global.customElements;
+  });
+
+  it("waits for a slow-to-register card instead of showing the placeholder", async () => {
+    const defined = new Set();
+    const resolvers = [];
+    global.customElements = {
+      get: (n) => (defined.has(n) ? class {} : undefined),
+      whenDefined: (n) =>
+        new Promise((resolve) => {
+          resolvers.push(() => {
+            defined.add(n);
+            resolve();
+          });
+        }),
+    };
+    const hass = makeHass({ batterySerials: ["BAT1"], acCoupled: true });
+    // ensureCards registers its whenDefined waiters synchronously as generate()
+    // starts; let a microtask pass, then "register" the HACS cards late.
+    const p = GE.generateDashboard({ mode: "classic" }, hass);
+    await Promise.resolve();
+    resolvers.forEach((fn) => fn());
+    const dash = await p;
+    const flat = JSON.stringify(dash);
+    expect(flat).not.toContain("is not installed");
+    expect(flat).toContain("custom:apexcharts-card");
+    expect(flat).toContain("custom:power-flow-card-plus");
+  });
+
+  it("still falls back to the placeholder for a genuinely absent card (bounded wait)", async () => {
+    vi.useFakeTimers();
+    try {
+      // whenDefined never resolves; only the bounded timer lets generate() finish.
+      global.customElements = {
+        get: () => undefined,
+        whenDefined: () => new Promise(() => {}),
+      };
+      const hass = makeHass({ batterySerials: ["BAT1"], acCoupled: true });
+      const p = GE.generateDashboard({ mode: "classic" }, hass);
+      await vi.advanceTimersByTimeAsync(2000);
+      const dash = await p;
+      expect(JSON.stringify(dash)).toContain("is not installed");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Fixes the "*card-name* is not installed" placeholders that appear on a cold dashboard load and clear on refresh (#255).

## Cause
The strategy's `haveCard()` is a synchronous `customElements.get()` check, but `apexcharts-card` and `power-flow-card-plus` are separate HACS frontend modules that load independently of this strategy. On a cold load they can still be registering when `generate()` runs, so `haveCard()` reports them missing and the strategy drops in the placeholder. A refresh works because they're cached and register instantly by then. Same root cause as the intermittent generate-timeout: cold-load frontend-resource timing.

## Fix
`ensureCards()` gives each *undefined* card a bounded chance to register (`customElements.whenDefined`, capped at 1.5s) before deciding it's absent — a genuinely-missing card still times out to the placeholder. The wait is **overlapped with the registry fetch** (`Promise.all([buildPlant, ensureCards])`), so:
- a **warm** load (cards already defined) costs nothing — `ensureCards` returns immediately;
- a **cold** load hides the ≤1.5s wait behind the registry round-trip rather than adding to it, keeping it clear of HA's strategy-generate timeout.

`_STRATEGY_VERSION` bumped so browsers fetch the new module.

## Tests
Two new JS cases: a slow-to-register card renders the real card (no placeholder); a genuinely-absent card still falls back after the bounded wait. Existing tests unaffected — `ensureCards` no-ops when `customElements.whenDefined` isn't present. **44 JS tests + 59 `test_init` pass.**

## Honest limit
This targets the *placeholder* half of #255. The intermittent generate-*timeout* itself is HA frontend-load timing and only reducible, not perfectly curable; the overlap design deliberately avoids making it worse. Real-world confirmation on a reliably-reproducing install (thanks @stripwax) is the final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard loading so custom cards are detected before the strategy renders.
  * Reduced missing-card placeholders during slower or cold page loads.
  * Added a bounded fallback so dashboards continue loading when cards remain unavailable.

* **Chores**
  * Refreshed frontend caching to ensure the latest dashboard strategy is loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->