### PR TITLE
fix: wire PV on AC-coupled installs in the Predbat generator (#281)

### DIFF
--- a/custom_components/givenergy_local/predbat.py
+++ b/custom_components/givenergy_local/predbat.py
@@ -108,7 +108,8 @@ def _build_plant(entities: Iterable[Any], devices: Iterable[Any]) -> _Plant:
 # Single-inverter (hybrid / AC-coupled). Resolved against the inverter's keys, with
 # the battery device's keys merged in for soc. AC-coupled rate maps to the AC pair
 # (HR313/314); on a pure hybrid that key is absent so the line auto-omits (its rate
-# control is the HR111/112 C-rate — a #281 follow-up). PV auto-omits on AC-coupled.
+# control is the HR111/112 C-rate — a #281 follow-up). PV wires on both topologies —
+# an AC-coupled unit meters generation AC-side rather than from a DC string (#281).
 _SINGLE_INVERTER_MAP: tuple[tuple[str, str], ...] = (
     ("soc_percent", "battery_soc"),
     ("soc_kw", "soc_kwh"),
@@ -276,17 +277,21 @@ def generate_apps_yaml(
         pv_note: list[str] = []
         unmappable: dict[str, str] = {}
         if ac:
-            # An AC-coupled unit has no PV of its own; don't wire its ~0 readings.
-            mapping = tuple(
-                (f, k) for (f, k) in _SINGLE_INVERTER_MAP if f not in ("pv_power", "pv_today")
-            )
+            # PV IS wired on AC-coupled, contrary to the original assumption (#281).
+            # These units have no DC string, but they do meter generation on the AC
+            # side and report it through the PV registers: across the fixture corpus
+            # v_pv1 tracks v_ac1 to within a volt on every AC/AIO unit (243.1 vs
+            # 242.7, 245.7 vs 245.7) while a genuine DC hybrid reads an independent
+            # 325-372 V, and their lifetime e_pv_total figures are large and real.
+            # Confirmed live on a GIV-AC3.0 (hass#281): 1355 W at 244.0 V / 5.5 A.
+            # An install with no generation CT fitted reads zero — hence the caveat
+            # rather than an unconditional wiring.
             pv_note = [
-                "  # An AC-coupled inverter has no PV of its own — point these at your SEPARATE",
-                "  # PV inverter's sensors:",
-                "  # pv_today:",
-                "  # - sensor.<your_pv_inverter>_energy_today",
-                "  # pv_power:",
-                "  # - sensor.<your_pv_inverter>_power",
+                "  # NB: this inverter has no DC PV string — the figures above are generation",
+                "  # metered on the AC side, which is why the reported string voltage tracks",
+                "  # your mains voltage. They are real; sanity-check them against your solar",
+                "  # inverter once. If they read zero, no generation CT is fitted on your",
+                "  # install — point pv_today/pv_power at your separate PV inverter instead.",
             ]
         else:
             # Hybrid rate is the HR111/112 C-rate — omit with an explanatory comment

--- a/custom_components/givenergy_local/predbat.py
+++ b/custom_components/givenergy_local/predbat.py
@@ -290,8 +290,10 @@ def generate_apps_yaml(
                 "  # NB: this inverter has no DC PV string — the figures above are generation",
                 "  # metered on the AC side, which is why the reported string voltage tracks",
                 "  # your mains voltage. They are real; sanity-check them against your solar",
-                "  # inverter once. If they read zero, no generation CT is fitted on your",
-                "  # install — point pv_today/pv_power at your separate PV inverter instead.",
+                "  # inverter once. If they stay at zero WHILE your solar inverter is",
+                "  # generating, no generation CT is fitted on your install — point",
+                "  # pv_today/pv_power at your separate PV inverter instead. (Zero overnight",
+                "  # is simply zero generation, not a missing CT.)",
             ]
         else:
             # Hybrid rate is the HR111/112 C-rate — omit with an explanatory comment

--- a/tests/test_predbat.py
+++ b/tests/test_predbat.py
@@ -112,6 +112,11 @@ def test_ac_coupled_wires_rate_to_ac_pair_and_caveats_pv():
     assert "metered on the AC side" in out
     assert "no generation CT is fitted" in out
     assert "separate PV inverter" in out
+    # and the zero reading must stay qualified: zero overnight is just zero
+    # generation, so an unqualified "zero means no CT" would send users to rip out
+    # a perfectly good mapping.
+    assert "WHILE your solar inverter is" in out
+    assert "Zero overnight" in out
 
 
 def test_ac_coupled_detected_even_when_rate_entity_disabled():

--- a/tests/test_predbat.py
+++ b/tests/test_predbat.py
@@ -107,7 +107,11 @@ def test_ac_coupled_wires_rate_to_ac_pair_and_caveats_pv():
     # readings are real — carrying a caveat for installs with no generation CT fitted.
     assert "pv_today:\n  - sensor.giv_ac1_e_pv_day" in out
     assert "pv_power:\n  - sensor.giv_ac1_p_pv" in out
+    # the caveat must carry BOTH halves: what the figures are, and what to do when
+    # they read zero (no generation CT fitted) — either half can regress alone.
     assert "metered on the AC side" in out
+    assert "no generation CT is fitted" in out
+    assert "separate PV inverter" in out
 
 
 def test_ac_coupled_detected_even_when_rate_entity_disabled():
@@ -123,6 +127,7 @@ def test_ac_coupled_detected_even_when_rate_entity_disabled():
     out = generate_apps_yaml(ents, devs)
 
     assert "metered on the AC side" in out  # took the AC path
+    assert "no generation CT is fitted" in out  # with the zero-reading fallback
     assert "HR111/112 C-rate" not in out  # not the hybrid path
     assert "pv_today:\n  - sensor.giv_ac1_e_pv_day" in out  # PV wired
 

--- a/tests/test_predbat.py
+++ b/tests/test_predbat.py
@@ -93,7 +93,7 @@ def test_single_hybrid_maps_controls_and_telemetry():
     assert "# discharge_rate_percent: hybrid rate is the HR111/112 C-rate" in out
 
 
-def test_ac_coupled_wires_rate_to_ac_pair_and_flags_pv():
+def test_ac_coupled_wires_rate_to_ac_pair_and_caveats_pv():
     keys = _HYBRID_INV_KEYS + _AC_EXTRA_KEYS
     ents = _entities("AC1", keys, "dev_inv") + _entities("BAT1", _BAT_KEYS, "dev_bat")
     devs = [_dev("dev_inv", "AC1"), _dev("dev_bat", "BAT1", via="dev_inv")]
@@ -103,15 +103,17 @@ def test_ac_coupled_wires_rate_to_ac_pair_and_flags_pv():
     # rate% maps to the AC pair (HR313/314)
     assert "charge_rate_percent:\n  - sensor.giv_ac1_battery_charge_limit_ac" in out
     assert "discharge_rate_percent:\n  - sensor.giv_ac1_battery_discharge_limit_ac" in out
-    # PV is not wired from the AC unit; the user is pointed at their PV inverter
-    assert "AC-coupled inverter has no PV of its own" in out
-    assert "sensor.giv_ac1_e_pv_day" not in out  # not wired
+    # PV IS wired on AC-coupled (#281): these units meter generation AC-side, so the
+    # readings are real — carrying a caveat for installs with no generation CT fitted.
+    assert "pv_today:\n  - sensor.giv_ac1_e_pv_day" in out
+    assert "pv_power:\n  - sensor.giv_ac1_p_pv" in out
+    assert "metered on the AC side" in out
 
 
 def test_ac_coupled_detected_even_when_rate_entity_disabled():
     # battery_charge_limit_ac present but DISABLED: topology must still read as
-    # AC-coupled from the full key set, so PV isn't wired to the AC unit's ~0 sensors
-    # and the hybrid C-rate path isn't taken.
+    # AC-coupled from the full key set, so the AC PV caveat is emitted and the
+    # hybrid C-rate path isn't taken.
     ents = _entities("AC1", _HYBRID_INV_KEYS, "dev_inv")
     ents.append(_ent("AC1", "battery_charge_limit_ac", "dev_inv", disabled=True))
     ents.append(_ent("AC1", "battery_discharge_limit_ac", "dev_inv", disabled=True))
@@ -120,9 +122,9 @@ def test_ac_coupled_detected_even_when_rate_entity_disabled():
 
     out = generate_apps_yaml(ents, devs)
 
-    assert "AC-coupled inverter has no PV of its own" in out  # took the AC path
+    assert "metered on the AC side" in out  # took the AC path
     assert "HR111/112 C-rate" not in out  # not the hybrid path
-    assert "sensor.giv_ac1_e_pv_day" not in out  # PV not wired
+    assert "pv_today:\n  - sensor.giv_ac1_e_pv_day" in out  # PV wired
 
 
 def test_soc_falls_back_to_battery_device_when_inverter_soc_disabled():


### PR DESCRIPTION
The Predbat generator stripped `pv_today`/`pv_power` on an AC-coupled install and emitted a comment telling the user to point them at a separate PV inverter instead. That rested on an assumption I made without checking: that a unit with no DC string reports no PV.

@stripwax queried it on #281 — his GIV-AC3.0's "PV Energy Today" is live and climbing, which shouldn't happen if the sensor were meaningless. He was right and I was wrong.

## What's actually going on

These units meter generation on the **AC side** and report it through the PV registers. The giveaway is the string voltage. Across the fixture corpus:

| fixture | model | `v_pv1` | `v_ac1` | `p_pv1` |
|---|---|---|---|---|
| `hybrid_2_bat_a` | DC hybrid | 372.2 / 333.0 | 243.5 / 242.7 | 2565 / 138 |
| `aio_a` | All-in-One | 245.7 | 245.7 | 862 |
| `ems_2_inv_3_bat_a` | AC | 243.1 / 242.1 | 242.7 / 241.7 | 583 / 0 |

A genuine DC hybrid reads an independent 325–372 V string voltage. Every AC-coupled and All-in-One unit tracks mains to within a volt — consistent with power being computed from an AC-side current measurement against mains voltage, not from a DC string. Those same units carry large, real lifetime `e_pv_total` figures (5276, 6852, 9778 kWh), so this is genuine accumulated generation rather than noise.

Confirmed against live hardware from @stripwax's capture on #281: 1355 W at 244.0 V / 5.5 A on a GIV-AC3.0, versus his mains at 242.4 V, tracking his generation through the day.

## Change

PV wires on both topologies now. The AC-coupled branch keeps a note, but an honest one: the figures are AC-side metering (which is why the string voltage looks like mains), they're real, sanity-check them once, and fall back to a separate PV inverter only if they read zero — which is what an install with no generation CT fitted would show.

Note this does **not** touch `e_pv_generation_*` (IR44/45-46), which genuinely is inverter output on AC/AIO and was correctly relabelled in v1.4.0. Different sensor, different question; the README's statement about it stands.

The per-string voltage/current entities are arguably mislabelled on these models — "PV String 1 Voltage" reading mains isn't meaningful. That's a decode-identity question for the library rather than something to paper over here, and I've raised it on that side.

Two existing tests updated to assert the new behaviour; 610 pytest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - AC-coupled inverter configurations now retain PV power and daily generation readings.
  - PV telemetry is correctly connected for AC-coupled systems, including configurations with disabled rate entities.
  - Configuration guidance now explains that readings represent AC-side generation, may remain zero without a generation CT, and may need assigning to a separate PV inverter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->