### PR TITLE
feat: adopt givenergy-modbus 2.13.0 (8102 single-phase, PV string V/I) (#281, #295)

### DIFF
--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -79,6 +79,7 @@ from .migrations import (
     _reconcile_per_cell_entities,
     _reconcile_pv_string_vi_sensors,
     _reconcile_readability_gated_controls,
+    _reconcile_reclassified_single_phase_sensors,
     _remove_retired_battery_discharge_year,
 )
 from .predbat import generate_apps_yaml
@@ -648,6 +649,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # current sensors report a mains-derived figure under a PV name; the library now
     # returns None for them and the platform skips them — remove the stale rows (#281).
     _reconcile_pv_string_vi_sensors(hass, coordinator)
+
+    # An 8102 now decodes single-phase rather than three-phase, so the sensors only the
+    # three-phase decode populated are no longer created — remove those rows too (#295).
+    _reconcile_reclassified_single_phase_sensors(hass, coordinator)
 
     # When per-cell exposure is off, remove any individual per-cell rows a prior
     # version (or a prior opt-in) created, so the toggle cleans up rather than

--- a/custom_components/givenergy_local/__init__.py
+++ b/custom_components/givenergy_local/__init__.py
@@ -77,6 +77,7 @@ from .migrations import (
     _reconcile_ems_entities,
     _reconcile_gateway_entities,
     _reconcile_per_cell_entities,
+    _reconcile_pv_string_vi_sensors,
     _reconcile_readability_gated_controls,
     _remove_retired_battery_discharge_year,
 )
@@ -642,6 +643,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # On AC-coupled / AIO plants the DC battery-limit controls are suppressed in
     # favour of the AC pair; remove the stale DC rows an upgraded entry would keep (#52).
     _reconcile_ac_coupled_dc_limits(hass, coordinator)
+
+    # Where PV is metered AC-side there is no DC string, so the per-string voltage and
+    # current sensors report a mains-derived figure under a PV name; the library now
+    # returns None for them and the platform skips them — remove the stale rows (#281).
+    _reconcile_pv_string_vi_sensors(hass, coordinator)
 
     # When per-cell exposure is off, remove any individual per-cell rows a prior
     # version (or a prior opt-in) created, so the toggle cleans up rather than

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dewet22/givenergy-hass/issues",
   "requirements": [
-    "givenergy-modbus==2.12.2"
+    "givenergy-modbus==2.13.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/givenergy_local/migrations.py
+++ b/custom_components/givenergy_local/migrations.py
@@ -418,6 +418,61 @@ def _reconcile_per_cell_entities(hass: HomeAssistant, entry: ConfigEntry) -> Non
             registry.async_remove(ent.entity_id)
 
 
+def _reconcile_pv_string_vi_sensors(
+    hass: HomeAssistant, coordinator: GivEnergyUpdateCoordinator
+) -> None:
+    """Remove per-string PV voltage/current rows where PV is metered AC-side (#281).
+
+    Introduced: v1.4.10 (2026-08). Ongoing while the suppression exists (cheap
+    no-op once rows are gone).
+
+    givenergy-modbus 2.13.0 returns None for v_pv1/v_pv2/i_pv1/i_pv2 on AC-coupled
+    and All-in-One models, where the registers carry an AC-side measurement rather
+    than a DC string (modbus#414). The sensor platform's skip_if_none gate stops
+    creating them, but on an upgraded entry HA keeps the pre-existing rows — four
+    permanently-unknown orphans reporting a mains voltage under a PV-string name,
+    which is exactly the mislabelling the suppression exists to end.
+
+    Reuses the platform's own gate rather than re-deriving the model logic, so a
+    later upstream widening (AC_3PH is deliberately not covered today) needs no
+    change here.
+    """
+    # Local imports: the platform imports from this package, so a module-scope import
+    # risks a load-order cycle (Model follows the convention used above).
+    from givenergy_modbus.model.inverter import Model
+
+    from .sensor import _PV_STRING_VI_KEYS, INVERTER_SENSORS, _include_inverter_sensor
+
+    # A partial seed poll serves last-good with last_partial_failures set, so a None
+    # read may be a transient bank failure rather than structural absence — removing
+    # rows then would destroy history on a healthy DC hybrid. Reconcile only on a
+    # clean seed, mirroring _reconcile_readability_gated_controls.
+    if coordinator.last_partial_failures:
+        return
+
+    capabilities = coordinator.data.capabilities
+    is_three_phase = bool(capabilities) and capabilities.is_three_phase
+    is_aio = bool(capabilities) and capabilities.device_type is Model.ALL_IN_ONE
+    inverter = coordinator.data.inverter
+    serial = coordinator.data.inverter_serial_number
+    registry = er.async_get(hass)
+    for description in INVERTER_SENSORS:
+        if description.key not in _PV_STRING_VI_KEYS:
+            continue
+        if _include_inverter_sensor(
+            description, inverter, is_three_phase, is_aio, coordinator.data.ems is not None
+        ):
+            continue
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_{description.key}")
+        if entity_id is not None:
+            _LOGGER.info(
+                "Removing %s: this model meters PV on the AC side, so the per-string "
+                "voltage/current is not a string measurement (#281)",
+                entity_id,
+            )
+            registry.async_remove(entity_id)
+
+
 def _reconcile_ac_coupled_dc_limits(
     hass: HomeAssistant, coordinator: GivEnergyUpdateCoordinator
 ) -> None:

--- a/custom_components/givenergy_local/migrations.py
+++ b/custom_components/givenergy_local/migrations.py
@@ -418,6 +418,68 @@ def _reconcile_per_cell_entities(hass: HomeAssistant, entry: ConfigEntry) -> Non
             registry.async_remove(ent.entity_id)
 
 
+def _reconcile_reclassified_single_phase_sensors(
+    hass: HomeAssistant, coordinator: GivEnergyUpdateCoordinator
+) -> None:
+    """Remove three-phase leftovers on a reclassified HYBRID_HV_GEN3 (#295).
+
+    Introduced: v1.4.10 (2026-08, givenergy-modbus 2.13.0). Removal candidate:
+    when upgrades of an 8102 entry from before that pin are presumed extinct.
+
+    givenergy-modbus 2.13.0 reclassified DTC 81 as single-phase, so `plant.inverter`
+    on these units decodes as a `SinglePhaseInverter` where it previously decoded as
+    a `ThreePhaseInverter`. That changes which sensors the platform creates in both
+    directions: six are gained, and seven the three-phase decode populated are no
+    longer included (`battery_maintenance_mode`, `e_battery_charge_total`,
+    `e_battery_discharge_total`, `e_load_total`, `export_power_rate`,
+    `inverter_output_today`, `inverter_output_total` — verified by replaying the
+    reporter's capture through both inclusion paths). Their old values were non-None,
+    so an existing entry registered all seven, and HA keeps the rows when the
+    platform stops adding them — seven permanently-unavailable orphans.
+
+    Scoped to the one reclassified model rather than sweeping every model's
+    no-longer-included sensors: a blanket sweep would delete history wherever a
+    field merely reads None, which is a much larger blast radius than this
+    correction needs. The key set is derived from the platform's own gate rather
+    than hardcoded, so it stays correct if upstream changes which fields decode.
+    """
+    # Local imports: the platform imports from this package, so a module-scope import
+    # risks a load-order cycle (Model follows the convention used above).
+    from givenergy_modbus.model.inverter import Model
+
+    from .sensor import INVERTER_SENSORS, _include_inverter_sensor
+
+    # A partial seed serves last-good, so a None read may be a transient bank failure
+    # rather than the reclassification — removing rows then would destroy history.
+    if coordinator.last_partial_failures:
+        return
+
+    capabilities = coordinator.data.capabilities
+    if capabilities is None or capabilities.device_type is not Model.HYBRID_HV_GEN3:
+        return
+
+    inverter = coordinator.data.inverter
+    serial = coordinator.data.inverter_serial_number
+    registry = er.async_get(hass)
+    for description in INVERTER_SENSORS:
+        if _include_inverter_sensor(
+            description,
+            inverter,
+            capabilities.is_three_phase,
+            False,
+            coordinator.data.ems is not None,
+        ):
+            continue
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, f"{serial}_{description.key}")
+        if entity_id is not None:
+            _LOGGER.info(
+                "Removing %s: this model is single-phase, so the three-phase decode "
+                "that populated it no longer applies (#295)",
+                entity_id,
+            )
+            registry.async_remove(entity_id)
+
+
 def _reconcile_pv_string_vi_sensors(
     hass: HomeAssistant, coordinator: GivEnergyUpdateCoordinator
 ) -> None:

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -504,6 +504,16 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda inv: inv.p_pv2,
     ),
+    # The four per-string voltage/current sensors are skip_if_none because
+    # givenergy-modbus 2.13.0 returns None for them on AC-coupled and All-in-One
+    # models: those units have no DC string, and the registers carry an AC-side
+    # measurement instead (the "string" voltage is mains — bit-identical to v_ac1
+    # across an entire AIO capture, while i_pv1 sits pinned as power swings, so
+    # p_pv1 != v_pv1 x i_pv1 there). See hass#281 / modbus#414. The power and
+    # energy members stay live on those models — the generation they report is
+    # real, just metered AC-side. NB the library's suppression does not cover
+    # AC_3PH (its routing lives on SinglePhaseInverter), so a three-phase
+    # AC-coupled install would still surface a mains-derived voltage here.
     GivEnergyInverterSensorDescription(
         key="v_pv1",
         name="PV String 1 Voltage",
@@ -512,6 +522,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda inv: inv.v_pv1,
         entity_category=EntityCategory.DIAGNOSTIC,
+        skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
         key="v_pv2",
@@ -521,6 +532,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda inv: inv.v_pv2,
         entity_category=EntityCategory.DIAGNOSTIC,
+        skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
         key="i_pv1",
@@ -530,6 +542,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda inv: inv.i_pv1,
         entity_category=EntityCategory.DIAGNOSTIC,
+        skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
         key="i_pv2",
@@ -539,6 +552,7 @@ INVERTER_SENSORS: tuple[GivEnergyInverterSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda inv: inv.i_pv2,
         entity_category=EntityCategory.DIAGNOSTIC,
+        skip_if_none=True,
     ),
     GivEnergyInverterSensorDescription(
         key="e_pv_day",
@@ -2440,6 +2454,12 @@ COORDINATOR_SENSORS: tuple[GivEnergyCoordinatorSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
+
+
+# Per-string voltage/current sensors, suppressed where the library reports None
+# because PV is metered AC-side rather than from a DC string (hass#281). Shared
+# with _reconcile_pv_string_vi_sensors so the key set is declared once.
+_PV_STRING_VI_KEYS = frozenset({"v_pv1", "v_pv2", "i_pv1", "i_pv2"})
 
 
 def _include_inverter_sensor(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # identical to the HA-runtime pin in manifest.json) beats auto-floating onto
     # an upstream patch that wasn't validated against this integration. Bump both
     # this and manifest.json together.
-    "givenergy-modbus==2.12.2",
+    "givenergy-modbus==2.13.0",
 ]
 
 [dependency-groups]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1227,3 +1227,65 @@ async def test_reconcile_per_cell_entities_keeps_cells_when_enabled(hass):
     _reconcile_per_cell_entities(hass, entry)
 
     assert registry.async_get_entity_id("sensor", DOMAIN, "BT1234A001_v_cell_01") is not None
+
+
+async def test_upgrade_removes_pv_string_vi_rows_when_pv_is_ac_metered(
+    hass, mock_client, mock_plant, mock_inverter, mock_config_entry
+):
+    """#281: on AC-coupled/AIO models givenergy-modbus 2.13.0 reports the per-string
+    voltage/current as None, because those registers carry an AC-side measurement
+    rather than a DC string. Suppressing creation alone leaves four orphans on an
+    upgraded entry, each reporting a mains-derived figure under a PV-string name."""
+    mock_inverter.v_pv1 = None
+    mock_inverter.v_pv2 = None
+    mock_inverter.i_pv1 = None
+    mock_inverter.i_pv2 = None
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    seeded = ("v_pv1", "v_pv2", "i_pv1", "i_pv2", "p_pv1", "e_pv_day")
+    for key in seeded:
+        registry.async_get_or_create(
+            "sensor", DOMAIN, f"SA1234G123_{key}", config_entry=mock_config_entry
+        )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    def _present(key: str) -> bool:
+        return registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is not None
+
+    for key in ("v_pv1", "v_pv2", "i_pv1", "i_pv2"):
+        assert not _present(key), f"{key} should be removed where PV is metered AC-side"
+    # The power and energy members are untouched upstream by design: the generation
+    # they report is real, just measured on the AC side. They must survive.
+    assert _present("p_pv1")
+    assert _present("e_pv_day")
+
+
+async def test_pv_string_vi_rows_survive_a_partial_seed(hass, setup_integration):
+    """A partial poll serves last-good, so a None read may be a transient bank failure
+    rather than an AC-metered model — removing rows then would destroy a healthy DC
+    hybrid's history. Mirrors the readability-gated guard."""
+    from custom_components.givenergy_local import _reconcile_pv_string_vi_sensors
+
+    coordinator = hass.data[DOMAIN][setup_integration.entry_id]
+    coordinator.last_partial_failures = [object()]  # partial seed
+    coordinator.data.inverter.v_pv1 = None  # reads None (transient)
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_v_pv1", config_entry=setup_integration
+    )
+
+    _reconcile_pv_string_vi_sensors(hass, coordinator)
+
+    assert registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_v_pv1") is not None
+
+
+async def test_pv_string_vi_sensors_kept_on_a_dc_hybrid(hass, setup_integration):
+    """The default (DC hybrid) fixture reports real string voltages and currents, so
+    all four must survive — the suppression is model-scoped, not blanket."""
+    registry = er.async_get(hass)
+    for key in ("v_pv1", "v_pv2", "i_pv1", "i_pv2"):
+        assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is not None, (
+            f"{key} should survive on a DC hybrid with real strings"
+        )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1289,3 +1289,64 @@ async def test_pv_string_vi_sensors_kept_on_a_dc_hybrid(hass, setup_integration)
         assert registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is not None, (
             f"{key} should survive on a DC hybrid with real strings"
         )
+
+
+async def test_upgrade_removes_three_phase_rows_on_a_reclassified_8102(
+    hass, mock_client, mock_plant, mock_inverter, mock_config_entry
+):
+    """#295: givenergy-modbus 2.13.0 reclassified DTC 81 as single-phase, so the
+    sensors only the three-phase decode populated are no longer created. Suppressing
+    creation alone leaves them as permanently-unavailable orphans on an upgraded entry.
+    """
+    from givenergy_modbus.model.inverter import Model
+    from givenergy_modbus.model.plant import PlantCapabilities
+
+    mock_client.plant.capabilities = PlantCapabilities(
+        device_type=Model.HYBRID_HV_GEN3,
+        inverter_address=0x11,
+        meter_addresses=[],
+        lv_battery_addresses=[],
+        bcu_stacks=[],
+    )
+    # Fields the three-phase decode populated but the single-phase one does not.
+    mock_inverter.export_power_rate = None
+    mock_inverter.e_load_total = None
+
+    mock_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    seeded = ("export_power_rate", "e_load_total", "battery_soc")
+    for key in seeded:
+        registry.async_get_or_create(
+            "sensor", DOMAIN, f"SA1234G123_{key}", config_entry=mock_config_entry
+        )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    def _present(key: str) -> bool:
+        return registry.async_get_entity_id("sensor", DOMAIN, f"SA1234G123_{key}") is not None
+
+    assert not _present("export_power_rate"), "three-phase-only row should be removed"
+    assert not _present("e_load_total"), "three-phase-only row should be removed"
+    # A sensor the single-phase decode still populates must survive.
+    assert _present("battery_soc")
+
+
+async def test_reclassified_rows_survive_a_partial_seed(hass, setup_integration):
+    """Same clean-seed guard as the sibling reconcilers: a partial poll's None read is
+    a transient bank failure, not a reclassification."""
+    from custom_components.givenergy_local import _reconcile_reclassified_single_phase_sensors
+
+    coordinator = hass.data[DOMAIN][setup_integration.entry_id]
+    coordinator.last_partial_failures = [object()]
+    coordinator.data.inverter.export_power_rate = None
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "sensor", DOMAIN, "SA1234G123_export_power_rate", config_entry=setup_integration
+    )
+
+    _reconcile_reclassified_single_phase_sensors(hass, coordinator)
+
+    assert (
+        registry.async_get_entity_id("sensor", DOMAIN, "SA1234G123_export_power_rate") is not None
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -937,7 +937,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "givenergy-modbus", specifier = "==2.12.2" }]
+requires-dist = [{ name = "givenergy-modbus", specifier = "==2.13.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -951,16 +951,16 @@ dev = [
 
 [[package]]
 name = "givenergy-modbus"
-version = "2.12.2"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crccheck" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/71/66230507b7aa7af682a180dc9e77ceaa6e04294924c27fce32bb003a2cde/givenergy_modbus-2.12.2.tar.gz", hash = "sha256:86517e474b79ebd9407307001c7d5c8b2c3c88e44241612554527a07c304db2a", size = 597988, upload-time = "2026-07-14T06:28:10.54Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/5b/ea97d904e6eedfff9a1cb0612c6028802788edf69ce4fa485e9fcfbf232c/givenergy_modbus-2.13.0.tar.gz", hash = "sha256:f39939aaf5becd1d0a6e7b603993f0064f4528e2890e6f2632ba104c6f60b467", size = 610738, upload-time = "2026-08-03T12:31:45.719Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/ab/eecd27fa96ebcf6e673c44d8b92709ecc5ea970bd05220827b4fe18a5328/givenergy_modbus-2.12.2-py3-none-any.whl", hash = "sha256:28456bb16681e8a81343699aba4c2989df6210473242d380f327e087388f090e", size = 219545, upload-time = "2026-07-14T06:28:08.698Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/fb/a057f0dbe535139c5848bf0d4f43f4aa2acb7f7f63cdd30895686ec5ab55/givenergy_modbus-2.13.0-py3-none-any.whl", hash = "sha256:48109fac7ccb2affca0169f82ebc7615f332940ebf5e737ff87d679d71cf392d", size = 220918, upload-time = "2026-08-03T12:31:43.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts givenergy-modbus 2.13.0. Two upstream fixes land, one of which is a contract change that needs handling on our side.

## `HYBRID_HV_GEN3` is single-phase (#295, modbus#412)

@KevC1978's GIV-HY-8.0-G3-HV (device type 8102) was classified three-phase, so it read the IR(1000–1413) bank — which on that unit answers every read and returns zero in all 414 registers, while the single-phase bank alongside carried real data the whole time. That's why his SOC, House Consumption and PV strings all sat at zero.

Reclassified upstream, so his install decodes properly on this pin: SOC 100%, PV strings 674 W and 4531 W, 21.1 kWh PV today. His entity set will change as the three-phase entities give way to the single-phase ones that actually carry his data.

## `v_pv*` / `i_pv*` return `None` on AC-coupled and All-in-One (#281, modbus#414)

These models have no DC string; the registers carry an AC-side measurement instead. The evidence is the string voltage — on an All-in-One it is *bit-identical* to `v_ac1` across an entire capture, while `i_pv1` sits pinned as power swings (so `p_pv1 != v_pv1 × i_pv1` there, where that product reconciles on every DC hybrid).

Consumer handling here:

- The four sensors become `skip_if_none`, so they stop being created on those models.
- A new `_reconcile_pv_string_vi_sensors` removes the rows an upgraded entry would otherwise keep. Suppressing creation alone leaves four permanently-unknown orphans reporting a mains voltage under a PV-string name — exactly the mislabelling the suppression exists to end.

The reconciler reuses the sensor platform's own gate rather than re-deriving the model logic, so a later upstream widening needs no change here. It guards on a clean seed poll, mirroring `_reconcile_readability_gated_controls`: a partial poll serves last-good, so a `None` read could be a transient bank failure, and removing rows then would destroy a healthy DC hybrid's history.

**The power and energy members are deliberately untouched upstream** — the generation those report is real, just metered AC-side — so the `pv_today`/`pv_power` wiring from #301 is unaffected.

## Known gap, deliberately not papered over

`AC_3PH` keeps a mains-derived `v_pv1`: the upstream routing lives on `SinglePhaseInverter`, and `ThreePhaseInverter` doesn't carry it, so listing that model would look handled while doing nothing. There's no known AC_3PH install today, so it's currently hypothetical. Recorded in a comment so the gap stays visible; upstream want a generating three-phase AC capture before extending it blind.

## Verification

613 pytest, 45 JS. Three new tests: orphan removal on an AC-metered model (verified failing without the reconciler), retention on a partial seed, and retention on a DC hybrid so the suppression is provably model-scoped rather than blanket.

Pin updated in all three places (`pyproject.toml`, `manifest.json`, `uv.lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete PV-string voltage and current sensors when those readings are no longer available.
  * Preserved PV power and energy sensors during this clean-up.
  * Improved handling for partial data updates, preventing valid sensors from being removed prematurely.
  * Ensured PV-string sensors remain available for DC-coupled hybrid systems where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->