### PR TITLE
chore: split direnv config so secrets live outside the repo

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,8 @@
+# Shared direnv entrypoint. Keep this file free of secrets — it is checked in.
+#
+# Put machine-local values (tokens, hostnames, anything you would not paste into
+# a public issue) in .envrc.local, which is gitignored. For example:
+#
+#   export HA_TOKEN=...
+#
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__/
 dist/
 *.egg-info/
 .env
+# direnv: .envrc is checked in and must stay secret-free; local values live here.
+.envrc.local
 .DS_Store
 
 .coverage


### PR DESCRIPTION
`.envrc` held a Home Assistant long-lived access token while being untracked but *not* ignored — one `git add -A` away from being committed, which is precisely what nearly happened during today's work. Caught before pushing; the token was never exposed.

Tracked-but-empty is the safer shape than untracked-and-forgotten:

- `.envrc` is now checked in, carries no secrets, and does nothing but `source_env_if_exists .envrc.local`.
- `.envrc.local` is gitignored and holds the machine-local values.

Anyone with an existing checkout: move your current `.envrc` to `.envrc.local`, pull, then `direnv allow` to re-approve the changed entrypoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)