### PR TITLE
chore: retire the v1.0 maintenance line

### DIFF
--- a/.github/workflows/bump-givenergy-modbus.yml
+++ b/.github/workflows/bump-givenergy-modbus.yml
@@ -45,13 +45,18 @@ jobs:
             exit 1
           fi
           # Route the PR to the branch whose dependency range that minor
-          # version belongs to. Convention: hass v1.0 tracks modbus v2.0,
-          # hass main tracks every later 2.x minor. A 3.x major fails the
-          # routing on purpose — that bump deserves a deliberate decision.
+          # version belongs to. Every 2.x minor now goes to main: the v1.0
+          # maintenance line (which tracked modbus 2.0.x) was retired in
+          # 2026-08, its last release being v1.0.4 in May. A 2.0.x bump is
+          # therefore no longer routable, and a 3.x major fails the routing on
+          # purpose — that bump deserves a deliberate decision.
           major="${NEW%%.*}"
           minor="${NEW#*.}"; minor="${minor%%.*}"
           case "$major.$minor" in
-            2.0) base=v1.0 ;;
+            2.0)
+              echo "::error::givenergy-modbus 2.0.x targeted the retired hass v1.0 line (last release v1.0.4); no branch tracks it"
+              exit 1
+              ;;
             2.*) base=main ;;
             *)
               echo "::error::no target branch configured for givenergy-modbus ${major}.${minor}.x (version $NEW)"

--- a/.github/workflows/bump-givenergy-modbus.yml
+++ b/.github/workflows/bump-givenergy-modbus.yml
@@ -45,11 +45,11 @@ jobs:
             exit 1
           fi
           # Route the PR to the branch whose dependency range that minor
-          # version belongs to. Every 2.x minor now goes to main: the v1.0
-          # maintenance line (which tracked modbus 2.0.x) was retired in
-          # 2026-08, its last release being v1.0.4 in May. A 2.0.x bump is
-          # therefore no longer routable, and a 3.x major fails the routing on
-          # purpose — that bump deserves a deliberate decision.
+          # version belongs to. Every 2.x minor except 2.0 goes to main. The
+          # v1.0 maintenance line (which tracked modbus 2.0.x) was retired in
+          # 2026-08, its last release being v1.0.4 in May, so a 2.0.x bump is
+          # no longer routable and fails below. A 3.x major fails the routing
+          # on purpose too — that bump deserves a deliberate decision.
           major="${NEW%%.*}"
           minor="${NEW#*.}"; minor="${minor%%.*}"
           case "$major.$minor" in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,15 @@ the hass-side change and wait for the sister repo's pre-release before wiring it
 Public-text rules apply: these issues are public OSS, so draft the body and get sign-off
 before filing, and redact real serial numbers / network details from captures.
 
-## Release tracks
-- **`main`** — 1.1.x line, pinned to givenergy-modbus 2.1.x. Pre-releases use `rcN`/`aN`/`bN` suffixes.
-- **`v1.0`** branch — 1.0.x stable/maintenance line, pinned to givenergy-modbus 2.0.x.
+## Release track
+- **`main`** — the only release line. Each release exact-pins a givenergy-modbus
+  version (`==X.Y.Z`); `pyproject.toml` is the current one. Pre-releases use
+  `rcN`/`aN`/`bN` suffixes.
+
+The **`v1.0`** maintenance line (1.0.x, pinned to givenergy-modbus 2.0.x) was retired
+in August 2026, its last release being v1.0.4 in May. Its tags and releases stay
+published, so existing installs are unaffected — there is simply no branch to cut
+further 1.0.x patches from, and the dependency bumper no longer routes to one.
 
 Releases are **tag-driven**: push an annotated `v*` tag and `release.yml` builds and
 publishes the HACS zip. The tag message becomes the release blurb. A lightweight

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,9 @@ Public-text rules apply: these issues are public OSS, so draft the body and get 
 before filing, and redact real serial numbers / network details from captures.
 
 ## Release track
+
 - **`main`** — the only release line. Each release exact-pins a givenergy-modbus
-  version (`==X.Y.Z`); `pyproject.toml` is the current one. Pre-releases use
+  version (`==X.Y.Z`); the current pin is in `pyproject.toml`. Pre-releases use
   `rcN`/`aN`/`bN` suffixes.
 
 The **`v1.0`** maintenance line (1.0.x, pinned to givenergy-modbus 2.0.x) was retired


### PR DESCRIPTION
The 1.0.x line has had no activity since 29 May (last release `v1.0.4`), and the givenergy-modbus 2.0.x range it pinned is nine minors behind. Retiring it rather than leaving a branch that implies a support commitment nobody intends to honour.

## Changes

**`bump-givenergy-modbus.yml`** routed a modbus 2.0.x release to `base=v1.0`, which would target a non-existent branch once it goes. That case now fails with an explanatory error instead. It was already unreachable in practice — modbus is on 2.13.0 — but it shouldn't point at a ghost.

**`AGENTS.md`** release-track section updated to match. Its `main` entry is also de-staled while I'm there: it claimed "1.1.x line, pinned to givenergy-modbus 2.1.x", which has been wrong for several minors. It now points at `pyproject.toml` for the current pin rather than naming a version that goes stale on every adoption.

## Existing installs are unaffected

Tags and releases are independent of the branch: `v1.0.0a5` through `v1.0.4` stay published, and HACS resolves releases rather than branches. Anyone still on 1.0.x keeps working and upgrades to the 1.4.x line normally. The only thing lost is the ability to cut *further* 1.0.x patches, which is the point.

Once this merges, `origin/v1.0` gets deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version `2.0.x` of `givenergy-modbus` is now rejected because its maintenance line has been retired.
  * Other version-routing behaviour remains unchanged.

* **Documentation**
  * Updated release-track guidance, version pinning, pre-release suffixes, and the retirement details for the `v1.0` maintenance line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->